### PR TITLE
feat: allow spaces in TOTP secrets

### DIFF
--- a/apps/purrmission-bot/src/domain/totp.test.ts
+++ b/apps/purrmission-bot/src/domain/totp.test.ts
@@ -58,6 +58,19 @@ describe('Bypassing spaces in TOTP secrets', () => {
                 accountBase.issuer,
                 accountBase.shared
             );
-        }, /Invalid TOTP secret/);
+        }, /Invalid TOTP secret format \(Base32 expected\)/);
+    });
+
+    test('should accept mixed whitespace characters', () => {
+        const secretWithMixedWhitespace = 'JBSWY\n3DPEH\tPK3PX\r\n P';
+        const expectedSecret = 'JBSWY3DPEHPK3PXP';
+        const account = createTOTPAccountFromSecret(
+            accountBase.ownerDiscordUserId,
+            accountBase.accountName,
+            secretWithMixedWhitespace,
+            accountBase.issuer,
+            accountBase.shared
+        );
+        assert.strictEqual(account.secret, expectedSecret);
     });
 });

--- a/apps/purrmission-bot/src/domain/totp.ts
+++ b/apps/purrmission-bot/src/domain/totp.ts
@@ -93,11 +93,11 @@ export function createTOTPAccountFromSecret(
 
   // Sanitize secret: remove all whitespace (including internal spaces)
   // Google Authenticator often displays secrets with spaces for readability.
-  secret = secret.replace(/\s+/g, '');
+  const sanitizedSecret = secret.replace(/\s+/g, '');
 
   // Stricter Base32 check: A-Z, 2-7, with optional padding only at the end (per RFC 4648)
   const base32Regex = /^[A-Z2-7]+=*$/i;
-  if (!base32Regex.test(secret)) {
+  if (!base32Regex.test(sanitizedSecret)) {
     throw new Error('Invalid TOTP secret format (Base32 expected)');
   }
 
@@ -105,7 +105,7 @@ export function createTOTPAccountFromSecret(
     ownerDiscordUserId,
     accountName,
     issuer,
-    secret,
+    secret: sanitizedSecret,
     shared,
   };
 }


### PR DESCRIPTION
This PR modifies the TOTP secret validation to explicitly strip spaces from the input string. This improves the user experience for users copy-pasting secrets from apps like Google Authenticator that format secrets with spaces.