### PR TITLE
docs: Comprehensive README overhaul for Pawthy CLI and main project

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [Pawthy CLI Documentation](apps/pawthy/README.md) for full usage.
 
 | Action | Command |
 |--------|---------|
-| Add Account | `/purrmission 2fa add account:"..." mode:uri uri:...` |
+| Add Account | `/purrmission 2fa add account:"..." mode:uri` (then enter URI in modal) |
 | List Accounts | `/purrmission 2fa list [shared:True]` |
 | Get Code | `/purrmission 2fa get account:"..."` |
 | Update Key | `/purrmission 2fa update account:"..." backup_key:"..."` |
@@ -88,9 +88,9 @@ See [Pawthy CLI Documentation](apps/pawthy/README.md) for full usage.
 
 | Action | Command |
 |--------|---------|
-| Add Guardian | `/purrmission guardian add resource:<id> user:@someone` |
-| Remove Guardian | `/purrmission guardian remove resource:<id> user:@someone` |
-| List Guardians | `/purrmission guardian list resource:<id>` |
+| Add Guardian | `/purrmission guardian add resource-id:<id> user:@someone` |
+| Remove Guardian | `/purrmission guardian remove resource-id:<id> user:@someone` |
+| List Guardians | `/purrmission guardian list resource-id:<id>` |
 
 ### CLI Login
 
@@ -132,7 +132,7 @@ pnpm prisma:deploy
 pnpm discord:deploy-commands
 
 # 7. Start the bot
-pnpm dev
+pnpm dev:purrmission
 ```
 
 ### Environment Variables
@@ -200,7 +200,7 @@ purrmission/
 │   │   │   └── http/        # Fastify API server
 │   │   └── package.json
 │   └── pawthy/              # CLI tool
-│       ├── src/
+│       ├── src/             # Command implementations
 │       └── package.json
 ├── prisma/                  # Database schema & migrations
 ├── package.json             # Workspace root
@@ -211,7 +211,7 @@ purrmission/
 
 | Command | Description |
 |---------|-------------|
-| `pnpm dev` | Start bot in development mode |
+| `pnpm dev:purrmission` | Start bot in development mode |
 | `pnpm build` | Build all packages |
 | `pnpm test` | Run tests |
 | `pnpm lint` | Run ESLint |

--- a/apps/pawthy/README.md
+++ b/apps/pawthy/README.md
@@ -136,7 +136,7 @@ Purrmission uses a **Guardian-based approval system** for secure secret access.
 1. **Project Owner** creates the project and pushes initial secrets
 2. **Owner** adds team members as Guardians via Discord:
    ```
-   /purrmission guardian add resource:<resource-id> user:@teammate
+   /purrmission guardian add resource-id:<resource-id> user:@teammate
    ```
 3. **Guardians** can now:
    - Pull secrets directly (no approval needed)
@@ -219,7 +219,7 @@ Default session storage location:
 
 | Variable | Description |
 |----------|-------------|
-| `PAWTHY_API_URL` | Override the Purrmission server URL (default: production server) |
+| `PAWTHY_API_URL` | Override the Purrmission server URL (default: `http://localhost:3000` for local dev) |
 
 ---
 
@@ -263,10 +263,15 @@ pawthy init
 
 ### Cached Server URL
 
-If switching between local dev and production, clear config:
+If switching between local dev and production, you may need to clear the global configuration file.
+
+Refer to the "Global Configuration" section above for the file path on your OS:
+- **Linux/macOS:** `~/.config/configstore/pawthy.json`
+- **Windows:** `%APPDATA%\configstore\pawthy.json`
+
+After deleting the file, log in again:
 
 ```bash
-rm ~/.config/configstore/pawthy.json
 pawthy login
 ```
 

--- a/apps/purrmission-bot/README.md
+++ b/apps/purrmission-bot/README.md
@@ -56,16 +56,18 @@ Manage shared and personal 2FA accounts directly from Discord.
 
 ### Quickstart
 
+All commands below should be run from the **workspace root** (`/purrmission`):
+
 ```bash
 # 1. Configure environment
 cp .env.example .env
 # Edit .env with your Discord credentials
 
-# 2. Generate Prisma Client
+# 2. Generate Prisma Client (from workspace root)
 pnpm prisma:generate
 
-# 3. Run development server
-pnpm dev
+# 3. Run development server (from workspace root)
+pnpm dev:purrmission
 
 # 4. Deploy commands (if changed)
 pnpm discord:deploy-commands


### PR DESCRIPTION
## Summary
Complete documentation refresh for both the main project README and the Pawthy CLI README.

## Changes

### `README.md` (Main Project)
- Added **Pawthy CLI quick start** section for developers
- Updated architecture diagram for credential sync flow
- Fixed Discord command format and added guardian commands
- **Removed outdated MVP limitations** (now implemented: Prisma storage, owner auth, etc.)
- Fixed duplicate scripts table headers
- Added link to Pawthy CLI documentation

### `apps/pawthy/README.md` (CLI)
- Complete **Getting Started guide** (4 steps with all options)
- **Multi-user & team workflows** (Owner/Guardian/Requester roles explained)
- Approval flow explanation with example CLI output
- Configuration details (`.pawthyrc` should be committed)
- `.pawthyrc.local` override note (see #61)
- Command reference table
- Security best practices

## Related Issues
- Closes #36 (QA Verification completed separately)
- References #61 (`.pawthyrc.local` follow-up)