### PR TITLE
fix(cli): exit with non-zero code on pending approval

### DIFF
--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -14,6 +14,11 @@ describe('Pull Command', () => {
     beforeEach(async () => {
         exitCode = null;
 
+        // Reset commander options to prevent test pollution
+        pullCommand.setOptionValue('file', '.env');
+        pullCommand.setOptionValue('projectId', undefined);
+        pullCommand.setOptionValue('envId', undefined);
+
         // Create a unique temp directory outside the repository
         tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-'));
 
@@ -21,8 +26,8 @@ describe('Pull Command', () => {
         mock.method(process, 'cwd', () => tempDir);
 
         // Mock process.exit
-        mock.method(process, 'exit', (code: number) => {
-            exitCode = code;
+        mock.method(process, 'exit', (code?: number) => {
+            exitCode = code ?? null;
             throw new Error(`process.exit called with ${code}`);
         });
 
@@ -52,7 +57,8 @@ describe('Pull Command', () => {
         });
 
         // Mock axios.get to return 202 status
-        mock.method(axios, 'get', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'get', async (): Promise<any> => {
             return {
                 status: 202,
                 data: {
@@ -67,10 +73,9 @@ describe('Pull Command', () => {
         mock.method(console, 'error', () => {});
 
         try {
-            pullCommand.exitOverride();
             await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
         } catch {
-            // Expected to throw because process.exit throws or commander exitOverride throws
+            // Expected to throw because process.exit throws
         }
 
         assert.strictEqual(exitCode, 1);

--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, mock, afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import axios from 'axios';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { pullCommand } from './pull.js';
+import { config } from '../config.js';
+
+describe('Pull Command', () => {
+    let exitCode: number | null = null;
+    let tempDir: string;
+
+    beforeEach(async () => {
+        exitCode = null;
+
+        // Create a unique temp directory outside the repository
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-'));
+
+        // Mock process.cwd to return our temp directory
+        mock.method(process, 'cwd', () => tempDir);
+
+        // Mock process.exit
+        mock.method(process, 'exit', (code: number) => {
+            exitCode = code;
+            throw new Error(`process.exit called with ${code}`);
+        });
+
+        // Write a dummy .pawthyrc file in the temp directory
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc'),
+            JSON.stringify({ projectId: 'test-project', envId: 'test-env' })
+        );
+    });
+
+    afterEach(async () => {
+        mock.restoreAll();
+        // Clean up the temp directory
+        try {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        } catch {
+            // Ignore
+        }
+    });
+
+    it('should exit with code 1 when pull status is 202 (Pending Approval)', async () => {
+        // Mock config.get for token
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Mock axios.get to return 202 status
+        mock.method(axios, 'get', async () => {
+            return {
+                status: 202,
+                data: {
+                    status: 'pending',
+                    message: 'Secret access is pending approval in Discord',
+                },
+            };
+        });
+
+        // Suppress console.log / console.error for clean test output
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        try {
+            pullCommand.exitOverride();
+            await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+        } catch {
+            // Expected to throw because process.exit throws or commander exitOverride throws
+        }
+
+        assert.strictEqual(exitCode, 1);
+    });
+});

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -42,6 +42,7 @@ export const pullCommand = new Command('pull')
                 console.log(chalk.white(res.data.message));
                 console.log(chalk.dim('\nPlease run this command again once your request has been approved in Discord.'));
                 process.exit(1);
+                return;
             }
 
             const secrets = res.data.secrets;

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -41,7 +41,7 @@ export const pullCommand = new Command('pull')
                 console.log(`\n${chalk.yellow('⏳ Access Pending Approval')}`);
                 console.log(chalk.white(res.data.message));
                 console.log(chalk.dim('\nPlease run this command again once your request has been approved in Discord.'));
-                return;
+                process.exit(1);
             }
 
             const secrets = res.data.secrets;


### PR DESCRIPTION
Resolves #71. Updates the pawthy pull command to exit with status code 1 when secret access is pending approval.