### PR TITLE
feat(cli): resolve config path from project root

### DIFF
--- a/apps/pawthy/src/commands/init.ts
+++ b/apps/pawthy/src/commands/init.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 import fs from 'fs/promises';
 import path from 'path';
-import { getToken, getApiUrl } from '../config.js';
+import { getToken, getApiUrl, findProjectRoot } from '../config.js';
 
 interface Project {
     id: string;
@@ -227,8 +227,9 @@ export const initCommand = new Command('init')
                 envId
             };
 
-            await fs.writeFile(path.join(process.cwd(), '.pawthyrc'), JSON.stringify(config, null, 2));
-            console.log(chalk.green('\n✅ Project initialized! Configuration saved to .pawthyrc'));
+            const targetDir = findProjectRoot();
+            await fs.writeFile(path.join(targetDir, '.pawthyrc'), JSON.stringify(config, null, 2));
+            console.log(chalk.green(`\n✅ Project initialized! Configuration saved to ${path.join(targetDir, '.pawthyrc')}`));
 
         } catch (error) {
             if (axios.isAxiosError(error)) {

--- a/apps/pawthy/src/config.test.ts
+++ b/apps/pawthy/src/config.test.ts
@@ -1,7 +1,10 @@
 
-import { describe, it, mock, afterEach } from 'node:test';
+import { describe, it, mock, afterEach, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { getApiUrl, config } from './config.js';
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+import { getApiUrl, config, findProjectRoot } from './config.js';
 
 describe('Config', () => {
     const originalEnv = process.env;
@@ -41,5 +44,48 @@ describe('Config', () => {
 
 
         assert.strictEqual(getApiUrl(), 'https://purrmission.infra.purrfecthq.com');
+    });
+
+    describe('findProjectRoot', () => {
+        let tempDir: string;
+
+        beforeEach(async () => {
+            tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pawthy-find-root-'));
+        });
+
+        afterEach(async () => {
+            try {
+                await fs.promises.rm(tempDir, { recursive: true, force: true });
+            } catch {
+                // Ignore
+            }
+        });
+
+        it('should return starting directory if .pawthyrc exists', async () => {
+            await fs.promises.writeFile(path.join(tempDir, '.pawthyrc'), '{}');
+            const root = findProjectRoot(tempDir);
+            assert.strictEqual(root, tempDir);
+        });
+
+        it('should walk up to find .pawthyrc in parent directory', async () => {
+            await fs.promises.writeFile(path.join(tempDir, '.pawthyrc'), '{}');
+            const subDir = path.join(tempDir, 'sub1', 'sub2');
+            await fs.promises.mkdir(subDir, { recursive: true });
+            const root = findProjectRoot(subDir);
+            assert.strictEqual(root, tempDir);
+        });
+
+        it('should walk up to find .git in parent directory', async () => {
+            await fs.promises.mkdir(path.join(tempDir, '.git'), { recursive: true });
+            const subDir = path.join(tempDir, 'sub1', 'sub2');
+            await fs.promises.mkdir(subDir, { recursive: true });
+            const root = findProjectRoot(subDir);
+            assert.strictEqual(root, tempDir);
+        });
+
+        it('should fallback to process.cwd() if no project root indicators are found', () => {
+            const root = findProjectRoot(tempDir);
+            assert.strictEqual(root, process.cwd());
+        });
     });
 });

--- a/apps/pawthy/src/config.test.ts
+++ b/apps/pawthy/src/config.test.ts
@@ -83,9 +83,21 @@ describe('Config', () => {
             assert.strictEqual(root, tempDir);
         });
 
-        it('should fallback to process.cwd() if no project root indicators are found', () => {
+        it('should fallback to the resolved startDir if no project root indicators are found', () => {
             const root = findProjectRoot(tempDir);
-            assert.strictEqual(root, process.cwd());
+            assert.strictEqual(root, path.resolve(tempDir));
+        });
+
+        it('should return starting directory if .pawthy directory exists', async () => {
+            await fs.promises.mkdir(path.join(tempDir, '.pawthy'), { recursive: true });
+            const root = findProjectRoot(tempDir);
+            assert.strictEqual(root, tempDir);
+        });
+
+        it('should not match .pawthy if it is a file, not a directory', async () => {
+            await fs.promises.writeFile(path.join(tempDir, '.pawthy'), 'fake file');
+            const root = findProjectRoot(tempDir);
+            assert.strictEqual(root, path.resolve(tempDir));
         });
     });
 });

--- a/apps/pawthy/src/config.ts
+++ b/apps/pawthy/src/config.ts
@@ -31,10 +31,19 @@ const LOCAL_CONFIG_FILE = 'config.json';
  * Looks for .pawthyrc, .pawthy/ directory, or a .git/ directory.
  */
 export function findProjectRoot(startDir: string = process.cwd()): string {
-  let current = path.resolve(startDir);
+  const resolvedStart = path.resolve(startDir);
+  let current = resolvedStart;
   while (true) {
-    if (fs.existsSync(path.join(current, '.pawthyrc')) || fs.existsSync(path.join(current, LOCAL_CONFIG_DIR))) {
+    if (fs.existsSync(path.join(current, '.pawthyrc'))) {
       return current;
+    }
+    const pawthyDir = path.join(current, LOCAL_CONFIG_DIR);
+    try {
+      if (fs.statSync(pawthyDir).isDirectory()) {
+        return current;
+      }
+    } catch {
+      // Ignore
     }
     if (fs.existsSync(path.join(current, '.git'))) {
       return current;
@@ -45,7 +54,7 @@ export function findProjectRoot(startDir: string = process.cwd()): string {
     }
     current = parent;
   }
-  return process.cwd();
+  return resolvedStart;
 }
 
 /**
@@ -64,7 +73,7 @@ function getLocalConfigPath(): string {
 
 /**
  * Read local config from .pawthy/config.json if it exists
- * Note: Uses process.cwd() - local config is relative to where the command is run.
+ * Note: Resolved relative to the project root.
  */
 function readLocalConfig(): LocalConfig | null {
   const configPath = getLocalConfigPath();

--- a/apps/pawthy/src/config.ts
+++ b/apps/pawthy/src/config.ts
@@ -27,10 +27,32 @@ const LOCAL_CONFIG_DIR = '.pawthy';
 const LOCAL_CONFIG_FILE = 'config.json';
 
 /**
+ * Find the nearest project root walking up from the start directory.
+ * Looks for .pawthyrc, .pawthy/ directory, or a .git/ directory.
+ */
+export function findProjectRoot(startDir: string = process.cwd()): string {
+  let current = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(current, '.pawthyrc')) || fs.existsSync(path.join(current, LOCAL_CONFIG_DIR))) {
+      return current;
+    }
+    if (fs.existsSync(path.join(current, '.git'))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  return process.cwd();
+}
+
+/**
  * Get the path to the local config directory (.pawthy/)
  */
 function getLocalConfigDir(): string {
-  return path.join(process.cwd(), LOCAL_CONFIG_DIR);
+  return path.join(findProjectRoot(), LOCAL_CONFIG_DIR);
 }
 
 /**
@@ -132,7 +154,7 @@ function setLocalToken(token: string): void {
  * Ensure .pawthy/ is in .gitignore (or warn if no gitignore exists)
  */
 export function ensureGitignore(): void {
-  const gitignorePath = path.join(process.cwd(), '.gitignore');
+  const gitignorePath = path.join(findProjectRoot(), '.gitignore');
   const pawthyEntry = LOCAL_CONFIG_DIR + '/';
 
   try {
@@ -198,7 +220,7 @@ export function clearConfig(): void {
 }
 
 export async function getProjectConfig(): Promise<{ projectId: string; envId: string } | null> {
-  const configPath = path.join(process.cwd(), '.pawthyrc');
+  const configPath = path.join(findProjectRoot(), '.pawthyrc');
   try {
     const content = await fs.promises.readFile(configPath, 'utf-8');
     return JSON.parse(content);


### PR DESCRIPTION
Resolves #57. Updates the CLI to resolve the `.pawthy/` credentials directory, `.pawthyrc` file, and `.gitignore` file by walking up the directory tree to the nearest project root (indicated by `.pawthyrc`, `.pawthy/` directory, or `.git/` directory).