### PR TITLE
feat(cli): allow specifying Project ID and Environment ID via flags/env vars

### DIFF
--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -40,6 +40,10 @@ describe('Pull Command', () => {
 
     afterEach(async () => {
         mock.restoreAll();
+        // Clean up environment variables to prevent test pollution
+        delete process.env.PAWTHY_PROJECT_ID;
+        delete process.env.PAWTHY_ENV_ID;
+
         // Clean up the temp directory
         try {
             await fs.rm(tempDir, { recursive: true, force: true });
@@ -93,7 +97,8 @@ describe('Pull Command', () => {
         process.env.PAWTHY_PROJECT_ID = 'env-project';
         process.env.PAWTHY_ENV_ID = 'env-env';
 
-        mock.method(axios, 'get', async (url: string) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'get', async (url: string): Promise<any> => {
             requestedUrl = url;
             return {
                 status: 200,
@@ -104,7 +109,6 @@ describe('Pull Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pullCommand.exitOverride();
         await pullCommand.parseAsync([
             'node',
             'pawthy',
@@ -117,13 +121,9 @@ describe('Pull Command', () => {
 
         // Verify the URL contained the flag values
         assert.ok(requestedUrl.includes('/projects/flag-project/environments/flag-env/secrets'));
-
-        // Clean up env vars
-        delete process.env.PAWTHY_PROJECT_ID;
-        delete process.env.PAWTHY_ENV_ID;
     });
 
-    it('should prioritize env vars over .pawthyrc', async () => {
+    it('should prioritize .pawthyrc over env vars', async () => {
         let requestedUrl = '';
         mock.method(config, 'get', (key: string) => {
             if (key === 'token') return 'test-token';
@@ -135,7 +135,8 @@ describe('Pull Command', () => {
         process.env.PAWTHY_PROJECT_ID = 'env-project';
         process.env.PAWTHY_ENV_ID = 'env-env';
 
-        mock.method(axios, 'get', async (url: string) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'get', async (url: string): Promise<any> => {
             requestedUrl = url;
             return {
                 status: 200,
@@ -146,15 +147,43 @@ describe('Pull Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pullCommand.exitOverride();
+        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+
+        // Verify the URL contained the .pawthyrc values, not the env var values
+        assert.ok(requestedUrl.includes('/projects/test-project/environments/test-env/secrets'));
+    });
+
+    it('should use env vars if .pawthyrc is missing', async () => {
+        let requestedUrl = '';
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Delete the .pawthyrc file
+        await fs.unlink(path.join(tempDir, '.pawthyrc'));
+
+        // Set env vars
+        process.env.PAWTHY_PROJECT_ID = 'env-project';
+        process.env.PAWTHY_ENV_ID = 'env-env';
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'get', async (url: string): Promise<any> => {
+            requestedUrl = url;
+            return {
+                status: 200,
+                data: { secrets: { FOO: 'bar' } },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
         await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
 
         // Verify the URL contained the env var values
         assert.ok(requestedUrl.includes('/projects/env-project/environments/env-env/secrets'));
-
-        // Clean up env vars
-        delete process.env.PAWTHY_PROJECT_ID;
-        delete process.env.PAWTHY_ENV_ID;
     });
 
     it('should exit with code 1 if project ID or environment ID is missing and no .pawthyrc', async () => {
@@ -171,10 +200,9 @@ describe('Pull Command', () => {
         mock.method(console, 'error', () => {});
 
         try {
-            pullCommand.exitOverride();
             await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
         } catch {
-            // Expected to throw because process.exit throws or commander exitOverride throws
+            // Expected to throw because process.exit throws
         }
 
         assert.strictEqual(exitCode, 1);

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -13,15 +13,20 @@ export const pullCommand = new Command('pull')
     .action(async (options) => {
         const token = getToken();
         const apiUrl = getApiUrl();
-        const config = await getProjectConfig();
-
         if (!token) {
             console.error(chalk.red('You must be logged in. Run `pawthy login` first.'));
             process.exit(1);
+            return;
         }
 
-        const projectId = options.projectId || process.env.PAWTHY_PROJECT_ID || config?.projectId;
-        const envId = options.envId || process.env.PAWTHY_ENV_ID || config?.envId;
+        let projectId = options.projectId;
+        let envId = options.envId;
+
+        if (!projectId || !envId) {
+            const config = await getProjectConfig();
+            projectId = projectId || config?.projectId || process.env.PAWTHY_PROJECT_ID;
+            envId = envId || config?.envId || process.env.PAWTHY_ENV_ID;
+        }
 
         if (!projectId || !envId) {
             console.error(
@@ -30,6 +35,7 @@ export const pullCommand = new Command('pull')
                 )
             );
             process.exit(1);
+            return;
         }
 
         const envPath = path.resolve(process.cwd(), options.file);

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -8,6 +8,8 @@ import { getToken, getApiUrl, getProjectConfig } from '../config.js';
 export const pullCommand = new Command('pull')
     .description('Pull secrets from Purrmission to local .env')
     .option('-f, --file <path>', 'Path to .env file', '.env')
+    .option('-p, --project-id <id>', 'Project ID')
+    .option('-e, --env-id <id>', 'Environment ID')
     .action(async (options) => {
         const token = getToken();
         const apiUrl = getApiUrl();
@@ -18,8 +20,15 @@ export const pullCommand = new Command('pull')
             process.exit(1);
         }
 
-        if (!config || !config.projectId || !config.envId) {
-            console.error(chalk.red('Project not initialized. Run `pawthy init` first.'));
+        const projectId = options.projectId || process.env.PAWTHY_PROJECT_ID || config?.projectId;
+        const envId = options.envId || process.env.PAWTHY_ENV_ID || config?.envId;
+
+        if (!projectId || !envId) {
+            console.error(
+                chalk.red(
+                    'Project ID and Environment ID must be specified (via CLI flags -p/-e, env vars PAWTHY_PROJECT_ID/PAWTHY_ENV_ID, or .pawthyrc config).'
+                )
+            );
             process.exit(1);
         }
 
@@ -30,7 +39,7 @@ export const pullCommand = new Command('pull')
 
             // 1. Fetch Secrets
             const res = await axios.get<{ secrets?: Record<string, string>; status?: string; message?: string }>(
-                `${apiUrl}/api/projects/${config.projectId}/environments/${config.envId}/secrets`,
+                `${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`,
                 {
                     headers: { Authorization: `Bearer ${token}` },
                     validateStatus: (status) => status >= 200 && status < 300,
@@ -41,7 +50,7 @@ export const pullCommand = new Command('pull')
                 console.log(`\n${chalk.yellow('⏳ Access Pending Approval')}`);
                 console.log(chalk.white(res.data.message));
                 console.log(chalk.dim('\nPlease run this command again once your request has been approved in Discord.'));
-                return;
+                process.exit(1);
             }
 
             const secrets = res.data.secrets;

--- a/apps/pawthy/src/commands/push.test.ts
+++ b/apps/pawthy/src/commands/push.test.ts
@@ -4,10 +4,10 @@ import axios from 'axios';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { pullCommand } from './pull.js';
+import { pushCommand } from './push.js';
 import { config } from '../config.js';
 
-describe('Pull Command', () => {
+describe('Push Command', () => {
     let exitCode: number | null = null;
     let tempDir: string;
 
@@ -15,12 +15,13 @@ describe('Pull Command', () => {
         exitCode = null;
 
         // Reset commander options to prevent test pollution
-        pullCommand.setOptionValue('file', '.env');
-        pullCommand.setOptionValue('projectId', undefined);
-        pullCommand.setOptionValue('envId', undefined);
+        pushCommand.setOptionValue('file', '.env');
+        pushCommand.setOptionValue('force', undefined);
+        pushCommand.setOptionValue('projectId', undefined);
+        pushCommand.setOptionValue('envId', undefined);
 
         // Create a unique temp directory outside the repository
-        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-'));
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-push-'));
 
         // Mock process.cwd to return our temp directory
         mock.method(process, 'cwd', () => tempDir);
@@ -36,6 +37,9 @@ describe('Pull Command', () => {
             path.join(tempDir, '.pawthyrc'),
             JSON.stringify({ projectId: 'test-project', envId: 'test-env' })
         );
+
+        // Write a dummy .env file
+        await fs.writeFile(path.join(tempDir, '.env'), 'MY_VAR=value');
     });
 
     afterEach(async () => {
@@ -46,39 +50,6 @@ describe('Pull Command', () => {
         } catch {
             // Ignore
         }
-    });
-
-    it('should exit with code 1 when pull status is 202 (Pending Approval)', async () => {
-        // Mock config.get for token
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
-
-        // Mock axios.get to return 202 status
-        mock.method(axios, 'get', async () => {
-            return {
-                status: 202,
-                data: {
-                    status: 'pending',
-                    message: 'Secret access is pending approval in Discord',
-                },
-            };
-        });
-
-        // Suppress console.log / console.error for clean test output
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        try {
-            pullCommand.exitOverride();
-            await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
-        } catch {
-            // Expected to throw because process.exit throws or commander exitOverride throws
-        }
-
-        assert.strictEqual(exitCode, 1);
     });
 
     it('should prioritize CLI flags over env vars and .pawthyrc', async () => {
@@ -93,22 +64,23 @@ describe('Pull Command', () => {
         process.env.PAWTHY_PROJECT_ID = 'env-project';
         process.env.PAWTHY_ENV_ID = 'env-env';
 
-        mock.method(axios, 'get', async (url: string) => {
+        mock.method(axios, 'put', async (url: string) => {
             requestedUrl = url;
             return {
                 status: 200,
-                data: { secrets: { FOO: 'bar' } },
+                data: { success: true },
             };
         });
 
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pullCommand.exitOverride();
-        await pullCommand.parseAsync([
+        pushCommand.exitOverride();
+        await pushCommand.parseAsync([
             'node',
             'pawthy',
-            'pull',
+            'push',
+            '--force',
             '-p',
             'flag-project',
             '-e',
@@ -135,19 +107,19 @@ describe('Pull Command', () => {
         process.env.PAWTHY_PROJECT_ID = 'env-project';
         process.env.PAWTHY_ENV_ID = 'env-env';
 
-        mock.method(axios, 'get', async (url: string) => {
+        mock.method(axios, 'put', async (url: string) => {
             requestedUrl = url;
             return {
                 status: 200,
-                data: { secrets: { FOO: 'bar' } },
+                data: { success: true },
             };
         });
 
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pullCommand.exitOverride();
-        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+        pushCommand.exitOverride();
+        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
 
         // Verify the URL contained the env var values
         assert.ok(requestedUrl.includes('/projects/env-project/environments/env-env/secrets'));
@@ -171,8 +143,8 @@ describe('Pull Command', () => {
         mock.method(console, 'error', () => {});
 
         try {
-            pullCommand.exitOverride();
-            await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+            pushCommand.exitOverride();
+            await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
         } catch {
             // Expected to throw because process.exit throws or commander exitOverride throws
         }

--- a/apps/pawthy/src/commands/push.test.ts
+++ b/apps/pawthy/src/commands/push.test.ts
@@ -27,8 +27,8 @@ describe('Push Command', () => {
         mock.method(process, 'cwd', () => tempDir);
 
         // Mock process.exit
-        mock.method(process, 'exit', (code: number) => {
-            exitCode = code;
+        mock.method(process, 'exit', (code?: number) => {
+            exitCode = code ?? null;
             throw new Error(`process.exit called with ${code}`);
         });
 
@@ -44,6 +44,10 @@ describe('Push Command', () => {
 
     afterEach(async () => {
         mock.restoreAll();
+        // Clean up environment variables to prevent test pollution
+        delete process.env.PAWTHY_PROJECT_ID;
+        delete process.env.PAWTHY_ENV_ID;
+
         // Clean up the temp directory
         try {
             await fs.rm(tempDir, { recursive: true, force: true });
@@ -64,7 +68,8 @@ describe('Push Command', () => {
         process.env.PAWTHY_PROJECT_ID = 'env-project';
         process.env.PAWTHY_ENV_ID = 'env-env';
 
-        mock.method(axios, 'put', async (url: string) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'put', async (url: string): Promise<any> => {
             requestedUrl = url;
             return {
                 status: 200,
@@ -75,7 +80,6 @@ describe('Push Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pushCommand.exitOverride();
         await pushCommand.parseAsync([
             'node',
             'pawthy',
@@ -89,13 +93,9 @@ describe('Push Command', () => {
 
         // Verify the URL contained the flag values
         assert.ok(requestedUrl.includes('/projects/flag-project/environments/flag-env/secrets'));
-
-        // Clean up env vars
-        delete process.env.PAWTHY_PROJECT_ID;
-        delete process.env.PAWTHY_ENV_ID;
     });
 
-    it('should prioritize env vars over .pawthyrc', async () => {
+    it('should prioritize .pawthyrc over env vars', async () => {
         let requestedUrl = '';
         mock.method(config, 'get', (key: string) => {
             if (key === 'token') return 'test-token';
@@ -107,7 +107,8 @@ describe('Push Command', () => {
         process.env.PAWTHY_PROJECT_ID = 'env-project';
         process.env.PAWTHY_ENV_ID = 'env-env';
 
-        mock.method(axios, 'put', async (url: string) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'put', async (url: string): Promise<any> => {
             requestedUrl = url;
             return {
                 status: 200,
@@ -118,15 +119,43 @@ describe('Push Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pushCommand.exitOverride();
+        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+
+        // Verify the URL contained the .pawthyrc values, not the env var values
+        assert.ok(requestedUrl.includes('/projects/test-project/environments/test-env/secrets'));
+    });
+
+    it('should use env vars if .pawthyrc is missing', async () => {
+        let requestedUrl = '';
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Delete the .pawthyrc file
+        await fs.unlink(path.join(tempDir, '.pawthyrc'));
+
+        // Set env vars
+        process.env.PAWTHY_PROJECT_ID = 'env-project';
+        process.env.PAWTHY_ENV_ID = 'env-env';
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'put', async (url: string): Promise<any> => {
+            requestedUrl = url;
+            return {
+                status: 200,
+                data: { success: true },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
         await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
 
         // Verify the URL contained the env var values
         assert.ok(requestedUrl.includes('/projects/env-project/environments/env-env/secrets'));
-
-        // Clean up env vars
-        delete process.env.PAWTHY_PROJECT_ID;
-        delete process.env.PAWTHY_ENV_ID;
     });
 
     it('should exit with code 1 if project ID or environment ID is missing and no .pawthyrc', async () => {
@@ -143,10 +172,9 @@ describe('Push Command', () => {
         mock.method(console, 'error', () => {});
 
         try {
-            pushCommand.exitOverride();
             await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
         } catch {
-            // Expected to throw because process.exit throws or commander exitOverride throws
+            // Expected to throw because process.exit throws
         }
 
         assert.strictEqual(exitCode, 1);

--- a/apps/pawthy/src/commands/push.ts
+++ b/apps/pawthy/src/commands/push.ts
@@ -15,15 +15,20 @@ export const pushCommand = new Command('push')
     .action(async (options) => {
         const token = getToken();
         const apiUrl = getApiUrl();
-        const config = await getProjectConfig();
-
         if (!token) {
             console.error(chalk.red('You must be logged in. Run `pawthy login` first.'));
             process.exit(1);
+            return;
         }
 
-        const projectId = options.projectId || process.env.PAWTHY_PROJECT_ID || config?.projectId;
-        const envId = options.envId || process.env.PAWTHY_ENV_ID || config?.envId;
+        let projectId = options.projectId;
+        let envId = options.envId;
+
+        if (!projectId || !envId) {
+            const config = await getProjectConfig();
+            projectId = projectId || config?.projectId || process.env.PAWTHY_PROJECT_ID;
+            envId = envId || config?.envId || process.env.PAWTHY_ENV_ID;
+        }
 
         if (!projectId || !envId) {
             console.error(
@@ -32,6 +37,7 @@ export const pushCommand = new Command('push')
                 )
             );
             process.exit(1);
+            return;
         }
 
         const envPath = path.resolve(process.cwd(), options.file);
@@ -84,7 +90,7 @@ export const pushCommand = new Command('push')
                 } else {
                     console.error(chalk.red(`Failed to push secrets: ${error.message}`));
                 }
-            } else if (error instanceof Error && 'code' in error && (error as any).code === 'ENOENT') {
+            } else if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
                 console.error(chalk.red(`File not found: ${envPath}`));
             } else {
                 console.error(chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`));

--- a/apps/pawthy/src/commands/push.ts
+++ b/apps/pawthy/src/commands/push.ts
@@ -10,6 +10,8 @@ export const pushCommand = new Command('push')
     .description('Push local .env secrets to Purrmission, updating existing values. This does not remove secrets.')
     .option('-f, --file <path>', 'Path to .env file', '.env')
     .option('--force', 'Push secrets without confirmation')
+    .option('-p, --project-id <id>', 'Project ID')
+    .option('-e, --env-id <id>', 'Environment ID')
     .action(async (options) => {
         const token = getToken();
         const apiUrl = getApiUrl();
@@ -20,8 +22,15 @@ export const pushCommand = new Command('push')
             process.exit(1);
         }
 
-        if (!config || !config.projectId || !config.envId) {
-            console.error(chalk.red('Project not initialized. Run `pawthy init` first.'));
+        const projectId = options.projectId || process.env.PAWTHY_PROJECT_ID || config?.projectId;
+        const envId = options.envId || process.env.PAWTHY_ENV_ID || config?.envId;
+
+        if (!projectId || !envId) {
+            console.error(
+                chalk.red(
+                    'Project ID and Environment ID must be specified (via CLI flags -p/-e, env vars PAWTHY_PROJECT_ID/PAWTHY_ENV_ID, or .pawthyrc config).'
+                )
+            );
             process.exit(1);
         }
 
@@ -56,7 +65,7 @@ export const pushCommand = new Command('push')
             console.log(chalk.dim(`Pushing ${Object.keys(secrets).length} secrets to Purrmission...`));
 
             // 3. Push to API
-            await axios.put(`${apiUrl}/api/projects/${config.projectId}/environments/${config.envId}/secrets`, {
+            await axios.put(`${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`, {
                 secrets
             }, {
                 headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
Resolves #78. Adds support for specifying Project ID and Environment ID using the `-p / --project-id` and `-e / --env-id` CLI options, or the `PAWTHY_PROJECT_ID` and `PAWTHY_ENV_ID` environment variables. This allows running sync commands in automation scripts without creating a transient `.pawthyrc` file.