### PR TITLE
feat(cli): support native merge mode in pull command

### DIFF
--- a/apps/pawthy/README.md
+++ b/apps/pawthy/README.md
@@ -112,11 +112,16 @@ pawthy pull
 | Flag | Description |
 |------|-------------|
 | `-f, --file <path>` | Output file path (default: `.env`) |
+| `-m, --merge` | Merge fetched secrets into existing `.env` file instead of overwriting |
 
-**Example:**
+**Examples:**
 
 ```bash
+# Pull and overwrite local .env (default)
 pawthy pull -f .env.local
+
+# Pull and natively merge into existing .env preserving formatting/comments/local variables
+pawthy pull --merge
 ```
 
 ---

--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -179,4 +179,59 @@ describe('Pull Command', () => {
 
         assert.strictEqual(exitCode, 1);
     });
+
+    it('should natively merge secrets with existing .env file preserving comments and local variables', async () => {
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Write initial .env file with comments and local variables
+        const initialEnv = [
+            '# DB config',
+            'DATABASE_URL=postgres://localhost/db',
+            '',
+            '# Local variables',
+            'LOCAL_ONLY=123',
+            'EXISTING_OVERWRITE=old-value',
+        ].join('\n');
+        await fs.writeFile(path.join(tempDir, '.env'), initialEnv);
+
+        // Mock axios.get to return updated and new secrets
+        mock.method(axios, 'get', async () => {
+            return {
+                status: 200,
+                data: {
+                    secrets: {
+                        DATABASE_URL: 'postgres://prod-host/db',
+                        EXISTING_OVERWRITE: 'new-value',
+                        NEW_SECRET: 'new-secret-val',
+                    },
+                },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        pullCommand.exitOverride();
+        await pullCommand.parseAsync(['node', 'pawthy', 'pull', '--merge']);
+
+        // Read the resulting .env file
+        const mergedContent = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+        const lines = mergedContent.split('\n');
+
+        // Check that DATABASE_URL and EXISTING_OVERWRITE were updated
+        assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
+        assert.ok(lines.includes('EXISTING_OVERWRITE=new-value'));
+
+        // Check that LOCAL_ONLY and comments were preserved
+        assert.ok(lines.includes('# DB config'));
+        assert.ok(lines.includes('LOCAL_ONLY=123'));
+        assert.ok(lines.includes('# Local variables'));
+
+        // Check that NEW_SECRET was appended
+        assert.ok(lines.includes('NEW_SECRET=new-secret-val'));
+    });
 });

--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -18,6 +18,7 @@ describe('Pull Command', () => {
         pullCommand.setOptionValue('file', '.env');
         pullCommand.setOptionValue('projectId', undefined);
         pullCommand.setOptionValue('envId', undefined);
+        pullCommand.setOptionValue('merge', undefined);
 
         // Create a unique temp directory outside the repository
         tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-'));
@@ -220,6 +221,13 @@ describe('Pull Command', () => {
             '# DB config',
             'DATABASE_URL=postgres://localhost/db',
             '',
+            '# Spacing and quotes tests',
+            '  SPACED_KEY  =  "old-value"  ',
+            'SINGLE_QUOTED = \'old-single\'',
+            'WITH_COMMENT = old-val # preserve this comment',
+            'MULTILINE = "line 1',
+            'line 2"',
+            '',
             '# Local variables',
             'LOCAL_ONLY=123',
             'EXISTING_OVERWRITE=old-value',
@@ -227,12 +235,17 @@ describe('Pull Command', () => {
         await fs.writeFile(path.join(tempDir, '.env'), initialEnv);
 
         // Mock axios.get to return updated and new secrets
-        mock.method(axios, 'get', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'get', async (): Promise<any> => {
             return {
                 status: 200,
                 data: {
                     secrets: {
                         DATABASE_URL: 'postgres://prod-host/db',
+                        SPACED_KEY: 'new-value',
+                        SINGLE_QUOTED: 'new-single',
+                        WITH_COMMENT: 'new-val',
+                        MULTILINE: 'new line 1\nnew line 2',
                         EXISTING_OVERWRITE: 'new-value',
                         NEW_SECRET: 'new-secret-val',
                     },
@@ -243,7 +256,6 @@ describe('Pull Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pullCommand.exitOverride();
         await pullCommand.parseAsync(['node', 'pawthy', 'pull', '--merge']);
 
         // Read the resulting .env file
@@ -253,6 +265,18 @@ describe('Pull Command', () => {
         // Check that DATABASE_URL and EXISTING_OVERWRITE were updated
         assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
         assert.ok(lines.includes('EXISTING_OVERWRITE=new-value'));
+
+        // Check spacing, quotes, and comments preservation
+        assert.ok(lines.includes('  SPACED_KEY  =  "new-value"  '));
+        assert.ok(lines.includes('SINGLE_QUOTED = \'new-single\''));
+        assert.ok(lines.includes('WITH_COMMENT = new-val # preserve this comment'));
+
+        // Check multiline preservation/updating
+        // The multiline value contains a newline, so it should be double-quoted
+        const multilineStartIndex = lines.findIndex(l => l.startsWith('MULTILINE ='));
+        assert.notStrictEqual(multilineStartIndex, -1);
+        assert.strictEqual(lines[multilineStartIndex], 'MULTILINE = "new line 1');
+        assert.strictEqual(lines[multilineStartIndex + 1], 'new line 2"');
 
         // Check that LOCAL_ONLY and comments were preserved
         assert.ok(lines.includes('# DB config'));

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -76,8 +76,8 @@ export const pullCommand = new Command('pull')
                     const existingContent = await fs.readFile(envPath, 'utf-8');
                     content = mergeEnvSecrets(existingContent, secrets);
                     isMerged = true;
-                } catch (e: any) {
-                    if (e.code !== 'ENOENT') {
+                } catch (e: unknown) {
+                    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
                         throw e;
                     }
                     // File doesn't exist, fallback to regular pull behavior
@@ -87,13 +87,7 @@ export const pullCommand = new Command('pull')
             if (!isMerged) {
                 // 2. Format as .env
                 content = Object.entries(secrets)
-                    .map(([key, value]) => {
-                        // Wrap values with spaces or special chars in quotes
-                        if (value.includes(' ') || value.includes('#') || value.includes('=')) {
-                            return `${key}="${value.replace(/"/g, '\\"')}"`;
-                        }
-                        return `${key}=${value}`;
-                    })
+                    .map(([key, value]) => `${key}=${formatEnvValue(value)}`)
                     .join('\n') + '\n';
 
                 // 3. Write to file with safety check
@@ -129,28 +123,219 @@ export const pullCommand = new Command('pull')
         }
     });
 
+interface EnvBlock {
+    type: 'comment' | 'empty' | 'key-value';
+    raw: string;
+    key?: string;
+    value?: string;
+    leadingWhitespace?: string;
+    middleWhitespace?: string;
+    quote?: '"' | "'" | null;
+    comment?: string;
+}
+
+function parseEnv(content: string, eol: string = '\n'): EnvBlock[] {
+    const lines = content.split(/\r?\n/);
+    const blocks: EnvBlock[] = [];
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i];
+        
+        if (/^\s*#/.test(line) || /^\s*$/.test(line)) {
+            blocks.push({
+                type: /^\s*#/.test(line) ? 'comment' : 'empty',
+                raw: line,
+            });
+            i++;
+            continue;
+        }
+
+        const declMatch = line.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+        if (!declMatch) {
+            blocks.push({
+                type: 'comment',
+                raw: line,
+            });
+            i++;
+            continue;
+        }
+
+        const leadingWhitespace = declMatch[1];
+        const key = declMatch[2];
+        const rest = declMatch[3];
+
+        const prefixLength = leadingWhitespace.length + key.length;
+        const middleWhitespaceMatch = line.slice(prefixLength).match(/^\s*=\s*/);
+        const middleWhitespace = middleWhitespaceMatch ? middleWhitespaceMatch[0] : '=';
+
+        let value = '';
+        let quote: '"' | "'" | null = null;
+        let trailingComment = '';
+        const rawBlockLines = [line];
+
+        if (rest.startsWith('"')) {
+            quote = '"';
+            const restValue = rest.slice(1);
+            let currentLineIndex = i;
+            let foundEnd = false;
+            let valAcc = '';
+            
+            while (currentLineIndex < lines.length) {
+                const curLine = currentLineIndex === i ? restValue : lines[currentLineIndex];
+                let escaped = false;
+                let quoteIndex = -1;
+                for (let charIdx = 0; charIdx < curLine.length; charIdx++) {
+                    const char = curLine[charIdx];
+                    if (char === '\\') {
+                        escaped = !escaped;
+                    } else if (char === '"' && !escaped) {
+                        quoteIndex = charIdx;
+                        break;
+                    } else {
+                        escaped = false;
+                    }
+                }
+
+                if (quoteIndex !== -1) {
+                    valAcc += curLine.slice(0, quoteIndex);
+                    trailingComment = curLine.slice(quoteIndex + 1);
+                    foundEnd = true;
+                    break;
+                } else {
+                    valAcc += curLine + '\n';
+                    if (currentLineIndex > i) {
+                        rawBlockLines.push(lines[currentLineIndex]);
+                    }
+                    currentLineIndex++;
+                }
+            }
+
+            if (foundEnd) {
+                value = valAcc;
+                i = currentLineIndex + 1;
+            } else {
+                quote = null;
+                value = rest;
+                i++;
+            }
+        } else if (rest.startsWith("'")) {
+            quote = "'";
+            const restValue = rest.slice(1);
+            let currentLineIndex = i;
+            let foundEnd = false;
+            let valAcc = '';
+
+            while (currentLineIndex < lines.length) {
+                const curLine = currentLineIndex === i ? restValue : lines[currentLineIndex];
+                let escaped = false;
+                let quoteIndex = -1;
+                for (let charIdx = 0; charIdx < curLine.length; charIdx++) {
+                    const char = curLine[charIdx];
+                    if (char === '\\') {
+                        escaped = !escaped;
+                    } else if (char === "'" && !escaped) {
+                        quoteIndex = charIdx;
+                        break;
+                    } else {
+                        escaped = false;
+                    }
+                }
+
+                if (quoteIndex !== -1) {
+                    valAcc += curLine.slice(0, quoteIndex);
+                    trailingComment = curLine.slice(quoteIndex + 1);
+                    foundEnd = true;
+                    break;
+                } else {
+                    valAcc += curLine + '\n';
+                    if (currentLineIndex > i) {
+                        rawBlockLines.push(lines[currentLineIndex]);
+                    }
+                    currentLineIndex++;
+                }
+            }
+
+            if (foundEnd) {
+                value = valAcc;
+                i = currentLineIndex + 1;
+            } else {
+                quote = null;
+                value = rest;
+                i++;
+            }
+        } else {
+            const commentMatch = rest.match(/(\s+#.*)$/);
+            if (commentMatch) {
+                value = rest.slice(0, rest.length - commentMatch[1].length).trim();
+                trailingComment = commentMatch[1];
+            } else {
+                value = rest.trim();
+                trailingComment = '';
+            }
+            quote = null;
+            i++;
+        }
+
+        blocks.push({
+            type: 'key-value',
+            raw: rawBlockLines.join(eol),
+            key,
+            value,
+            leadingWhitespace,
+            middleWhitespace,
+            quote,
+            comment: trailingComment,
+        });
+    }
+    return blocks;
+}
+
+function formatEnvValue(value: string, originalQuote?: '"' | "'" | null): string {
+    if (value.includes('\n') || value.includes('\r')) {
+        return `"${value.replace(/"/g, '\\"')}"`;
+    }
+    
+    if (/[#=\s'"]/.test(value)) {
+        const quote = (originalQuote === '"' || originalQuote === "'") ? originalQuote : '"';
+        if (quote === '"') {
+            return `"${value.replace(/"/g, '\\"')}"`;
+        } else {
+            return `'${value.replace(/'/g, "\\'")}'`;
+        }
+    }
+    
+    if (originalQuote === '"') {
+        return `"${value.replace(/"/g, '\\"')}"`;
+    } else if (originalQuote === "'") {
+        return `'${value.replace(/'/g, "\\'")}'`;
+    }
+    
+    return value;
+}
+
 function mergeEnvSecrets(existingContent: string, secrets: Record<string, string>): string {
-    const lines = existingContent.split(/\r?\n/);
+    const eol = existingContent.includes('\r\n') ? '\r\n' : '\n';
+    const blocks = parseEnv(existingContent, eol);
     const updatedKeys = new Set<string>();
     const resultLines: string[] = [];
 
-    for (const line of lines) {
-        const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
-        if (match) {
-            const key = match[1];
-            if (key in secrets) {
+    for (const block of blocks) {
+        if (block.type === 'key-value' && block.key) {
+            const key = block.key;
+            if (Object.prototype.hasOwnProperty.call(secrets, key)) {
                 const value = secrets[key];
-                let formattedValue = value;
-                if (value.includes(' ') || value.includes('#') || value.includes('=')) {
-                    formattedValue = `"${value.replace(/"/g, '\\"')}"`;
-                }
-                const leadingWhitespace = line.match(/^\s*/)?.[0] || '';
-                resultLines.push(`${leadingWhitespace}${key}=${formattedValue}`);
+                resultLines.push(
+                    block.leadingWhitespace +
+                    key +
+                    block.middleWhitespace +
+                    formatEnvValue(value, block.quote) +
+                    block.comment
+                );
                 updatedKeys.add(key);
                 continue;
             }
         }
-        resultLines.push(line);
+        resultLines.push(block.raw);
     }
 
     const newKeys = Object.keys(secrets).filter((k) => !updatedKeys.has(k));
@@ -160,13 +345,9 @@ function mergeEnvSecrets(existingContent: string, secrets: Record<string, string
         }
         for (const key of newKeys) {
             const value = secrets[key];
-            let formattedValue = value;
-            if (value.includes(' ') || value.includes('#') || value.includes('=')) {
-                formattedValue = `"${value.replace(/"/g, '\\"')}"`;
-            }
-            resultLines.push(`${key}=${formattedValue}`);
+            resultLines.push(key + '=' + formatEnvValue(value));
         }
     }
 
-    return resultLines.join('\n');
+    return resultLines.join(eol);
 }

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -10,6 +10,7 @@ export const pullCommand = new Command('pull')
     .option('-f, --file <path>', 'Path to .env file', '.env')
     .option('-p, --project-id <id>', 'Project ID')
     .option('-e, --env-id <id>', 'Environment ID')
+    .option('-m, --merge', 'Merge with existing .env file instead of overwriting')
     .action(async (options) => {
         const token = getToken();
         const apiUrl = getApiUrl();
@@ -60,29 +61,42 @@ export const pullCommand = new Command('pull')
                 return;
             }
 
-            // 2. Format as .env
-            const content = Object.entries(secrets)
-                .map(([key, value]) => {
-                    // Wrap values with spaces or special chars in quotes
-                    if (value.includes(' ') || value.includes('#') || value.includes('=')) {
-                        return `${key}="${value.replace(/"/g, '\\"')}"`;
-                    }
-                    return `${key}=${value}`;
-                })
-                .join('\n');
+            let content = '';
+            let isMerged = false;
 
-            // 3. Write to file with safety check
-            try {
-                await fs.access(envPath);
-                // File exists
-                console.warn(chalk.yellow(`\n⚠️  File ${options.file} already exists.`));
-                // For CLI non-interactive mode or simple safety, we might want to fail or require --force.
-                // Given the review comment asked for a warning/prompt, and we don't have interactive prompt lib handy (inquirer isn't in package.json yet),
-                // we will just warn and overwrite for now but formatted nicely, or maybe throw error if no force flag?
-                // Step 460 implies adding a check. Let's just log a warning for this iteration as prompt lib might be out of scope.
-                console.warn(chalk.yellow('Overwriting existing file...'));
-            } catch {
-                // File doesn't exist, proceed safe.
+            if (options.merge) {
+                try {
+                    const existingContent = await fs.readFile(envPath, 'utf-8');
+                    content = mergeEnvSecrets(existingContent, secrets);
+                    isMerged = true;
+                } catch (e: any) {
+                    if (e.code !== 'ENOENT') {
+                        throw e;
+                    }
+                    // File doesn't exist, fallback to regular pull behavior
+                }
+            }
+
+            if (!isMerged) {
+                // 2. Format as .env
+                content = Object.entries(secrets)
+                    .map(([key, value]) => {
+                        // Wrap values with spaces or special chars in quotes
+                        if (value.includes(' ') || value.includes('#') || value.includes('=')) {
+                            return `${key}="${value.replace(/"/g, '\\"')}"`;
+                        }
+                        return `${key}=${value}`;
+                    })
+                    .join('\n') + '\n';
+
+                // 3. Write to file with safety check
+                try {
+                    await fs.access(envPath);
+                    console.warn(chalk.yellow(`\n⚠️  File ${options.file} already exists.`));
+                    console.warn(chalk.yellow('Overwriting existing file...'));
+                } catch {
+                    // File doesn't exist, proceed safe.
+                }
             }
 
             // 3. Write to file
@@ -107,3 +121,45 @@ export const pullCommand = new Command('pull')
             process.exit(1);
         }
     });
+
+function mergeEnvSecrets(existingContent: string, secrets: Record<string, string>): string {
+    const lines = existingContent.split(/\r?\n/);
+    const updatedKeys = new Set<string>();
+    const resultLines: string[] = [];
+
+    for (const line of lines) {
+        const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+        if (match) {
+            const key = match[1];
+            if (key in secrets) {
+                const value = secrets[key];
+                let formattedValue = value;
+                if (value.includes(' ') || value.includes('#') || value.includes('=')) {
+                    formattedValue = `"${value.replace(/"/g, '\\"')}"`;
+                }
+                const leadingWhitespace = line.match(/^\s*/)?.[0] || '';
+                resultLines.push(`${leadingWhitespace}${key}=${formattedValue}`);
+                updatedKeys.add(key);
+                continue;
+            }
+        }
+        resultLines.push(line);
+    }
+
+    const newKeys = Object.keys(secrets).filter((k) => !updatedKeys.has(k));
+    if (newKeys.length > 0) {
+        if (resultLines.length > 0 && resultLines[resultLines.length - 1].trim() !== '') {
+            resultLines.push('');
+        }
+        for (const key of newKeys) {
+            const value = secrets[key];
+            let formattedValue = value;
+            if (value.includes(' ') || value.includes('#') || value.includes('=')) {
+                formattedValue = `"${value.replace(/"/g, '\\"')}"`;
+            }
+            resultLines.push(`${key}=${formattedValue}`);
+        }
+    }
+
+    return resultLines.join('\n');
+}


### PR DESCRIPTION
Resolves #79. Adds a `-m / --merge` option to the `pawthy pull` command. In merge mode, if the target `.env` file already exists, it is parsed and only the remote-fetched secrets are updated or inserted. Existing comments and local-only variables are preserved.