### PR TITLE
feat(cli): support selective key sync and whitelisting

### DIFF
--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -18,6 +18,7 @@ describe('Pull Command', () => {
         pullCommand.setOptionValue('file', '.env');
         pullCommand.setOptionValue('projectId', undefined);
         pullCommand.setOptionValue('envId', undefined);
+        pullCommand.setOptionValue('keys', undefined);
 
         // Create a unique temp directory outside the repository
         tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-'));
@@ -233,5 +234,82 @@ describe('Pull Command', () => {
 
         // Check that NEW_SECRET was appended
         assert.ok(lines.includes('NEW_SECRET=new-secret-val'));
+    });
+
+    it('should support whitelisting via CLI keys flag in pull command', async () => {
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        mock.method(axios, 'get', async () => {
+            return {
+                status: 200,
+                data: {
+                    secrets: {
+                        DATABASE_URL: 'postgres://prod-host/db',
+                        API_KEY: 'secret-key',
+                        ANOTHER_VAR: 'val',
+                    },
+                },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        pullCommand.exitOverride();
+        // Request only DATABASE_URL and API_KEY
+        await pullCommand.parseAsync(['node', 'pawthy', 'pull', '-k', 'DATABASE_URL, API_KEY']);
+
+        const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+        const lines = content.split('\n');
+
+        assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
+        assert.ok(lines.includes('API_KEY=secret-key'));
+        assert.ok(!lines.includes('ANOTHER_VAR=val'));
+    });
+
+    it('should support whitelisting via keys array in .pawthyrc in pull command', async () => {
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Write a .pawthyrc containing a keys whitelist
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc'),
+            JSON.stringify({
+                projectId: 'test-project',
+                envId: 'test-env',
+                keys: ['DATABASE_URL'],
+            })
+        );
+
+        mock.method(axios, 'get', async () => {
+            return {
+                status: 200,
+                data: {
+                    secrets: {
+                        DATABASE_URL: 'postgres://prod-host/db',
+                        API_KEY: 'secret-key',
+                    },
+                },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        pullCommand.exitOverride();
+        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+
+        const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+        const lines = content.split('\n');
+
+        assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
+        assert.ok(!lines.includes('API_KEY=secret-key'));
     });
 });

--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -288,12 +288,18 @@ describe('Pull Command', () => {
         assert.ok(lines.includes('NEW_SECRET=new-secret-val'));
     });
 
-    it('should support whitelisting via CLI keys flag in pull command', async () => {
+    it('should support whitelisting via CLI keys flag in pull command and preserve local-only variables', async () => {
         mock.method(config, 'get', (key: string) => {
             if (key === 'token') return 'test-token';
             if (key === 'apiUrl') return 'http://localhost:3000';
             return undefined;
         });
+
+        // Write a pre-existing .env file
+        await fs.writeFile(
+            path.join(tempDir, '.env'),
+            'DATABASE_URL=postgres://localhost/db\nLOCAL_ONLY=123\n'
+        );
 
         mock.method(axios, 'get', async () => {
             return {
@@ -311,15 +317,16 @@ describe('Pull Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pullCommand.exitOverride();
         // Request only DATABASE_URL and API_KEY
         await pullCommand.parseAsync(['node', 'pawthy', 'pull', '-k', 'DATABASE_URL, API_KEY']);
 
         const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
-        const lines = content.split('\n');
+        const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
 
         assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
         assert.ok(lines.includes('API_KEY=secret-key'));
+        // LOCAL_ONLY should be preserved because whitelisting forces merge behavior
+        assert.ok(lines.includes('LOCAL_ONLY=123'));
         assert.ok(!lines.includes('ANOTHER_VAR=val'));
     });
 
@@ -355,11 +362,97 @@ describe('Pull Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pullCommand.exitOverride();
         await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
 
         const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
-        const lines = content.split('\n');
+        const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
+
+        assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
+        assert.ok(!lines.includes('API_KEY=secret-key'));
+    });
+
+    it('should support whitelisting via keys array in .pawthyrc.local in pull command', async () => {
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Write a .pawthyrc and a .pawthyrc.local
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc'),
+            JSON.stringify({
+                projectId: 'test-project',
+                envId: 'test-env',
+            })
+        );
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc.local'),
+            JSON.stringify({
+                keys: ['API_KEY'],
+            })
+        );
+
+        mock.method(axios, 'get', async () => {
+            return {
+                status: 200,
+                data: {
+                    secrets: {
+                        DATABASE_URL: 'postgres://prod-host/db',
+                        API_KEY: 'secret-key',
+                    },
+                },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+
+        const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+        const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
+
+        assert.ok(!lines.includes('DATABASE_URL=postgres://prod-host/db'));
+        assert.ok(lines.includes('API_KEY=secret-key'));
+    });
+
+    it('should support whitelisting via syncKeys array in .pawthyrc in pull command', async () => {
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Write a .pawthyrc containing syncKeys alias
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc'),
+            JSON.stringify({
+                projectId: 'test-project',
+                envId: 'test-env',
+                syncKeys: ['DATABASE_URL'],
+            })
+        );
+
+        mock.method(axios, 'get', async () => {
+            return {
+                status: 200,
+                data: {
+                    secrets: {
+                        DATABASE_URL: 'postgres://prod-host/db',
+                        API_KEY: 'secret-key',
+                    },
+                },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+
+        const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+        const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
 
         assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
         assert.ok(!lines.includes('API_KEY=secret-key'));

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -11,6 +11,7 @@ export const pullCommand = new Command('pull')
     .option('-p, --project-id <id>', 'Project ID')
     .option('-e, --env-id <id>', 'Environment ID')
     .option('-m, --merge', 'Merge with existing .env file instead of overwriting')
+    .option('-k, --keys <list>', 'Comma-separated list of keys to pull')
     .action(async (options) => {
         const token = getToken();
         const apiUrl = getApiUrl();
@@ -54,10 +55,28 @@ export const pullCommand = new Command('pull')
                 process.exit(1);
             }
 
-            const secrets = res.data.secrets;
+            let secrets = res.data.secrets || {};
 
-            if (!secrets || Object.keys(secrets).length === 0) {
-                console.log(chalk.yellow('No secrets found for this environment.'));
+            // Whitelisting / selective keys sync (Issue #80)
+            let keysWhitelist: string[] | null = null;
+            if (options.keys) {
+                keysWhitelist = options.keys.split(',').map((k: string) => k.trim()).filter((k: string) => k.length > 0);
+            } else if (config && 'keys' in config && Array.isArray(config.keys)) {
+                keysWhitelist = config.keys as string[];
+            }
+
+            if (keysWhitelist) {
+                const filteredSecrets: Record<string, string> = {};
+                for (const key of Object.keys(secrets)) {
+                    if (keysWhitelist.includes(key)) {
+                        filteredSecrets[key] = secrets[key];
+                    }
+                }
+                secrets = filteredSecrets;
+            }
+
+            if (Object.keys(secrets).length === 0) {
+                console.log(chalk.yellow('No matching secrets found for this environment.'));
                 return;
             }
 

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -23,9 +23,10 @@ export const pullCommand = new Command('pull')
 
         let projectId = options.projectId;
         let envId = options.envId;
+        let config: { projectId?: string; envId?: string; keys?: string[]; syncKeys?: string[] } | null = null;
 
-        if (!projectId || !envId) {
-            const config = await getProjectConfig();
+        if (!projectId || !envId || !options.keys) {
+            config = await getProjectConfig();
             projectId = projectId || config?.projectId || process.env.PAWTHY_PROJECT_ID;
             envId = envId || config?.envId || process.env.PAWTHY_ENV_ID;
         }
@@ -65,21 +66,22 @@ export const pullCommand = new Command('pull')
             let secrets = res.data.secrets || {};
 
             // Whitelisting / selective keys sync (Issue #80)
-            let keysWhitelist: string[] | null = null;
-            if (options.keys) {
-                keysWhitelist = options.keys.split(',').map((k: string) => k.trim()).filter((k: string) => k.length > 0);
-            } else if (config && 'keys' in config && Array.isArray(config.keys)) {
-                keysWhitelist = config.keys as string[];
-            }
+            const keysWhitelist = getKeysWhitelist(options.keys, config);
 
             if (keysWhitelist) {
+                const ignoredKeys: string[] = [];
                 const filteredSecrets: Record<string, string> = {};
-                for (const key of Object.keys(secrets)) {
-                    if (keysWhitelist.includes(key)) {
-                        filteredSecrets[key] = secrets[key];
+                for (const [key, value] of Object.entries(secrets)) {
+                    if (keysWhitelist.has(key)) {
+                        filteredSecrets[key] = value;
+                    } else {
+                        ignoredKeys.push(key);
                     }
                 }
                 secrets = filteredSecrets;
+                if (ignoredKeys.length > 0) {
+                    console.log(chalk.yellow(`\n⚠️  Ignored remote keys not in whitelist: ${ignoredKeys.join(', ')}`));
+                }
             }
 
             if (Object.keys(secrets).length === 0) {
@@ -90,7 +92,10 @@ export const pullCommand = new Command('pull')
             let content = '';
             let isMerged = false;
 
-            if (options.merge) {
+            // Whitelisting forces merge behavior to avoid deleting non-whitelisted local variables (Issue #80)
+            const shouldMerge = options.merge || keysWhitelist !== null;
+
+            if (shouldMerge) {
                 try {
                     const existingContent = await fs.readFile(envPath, 'utf-8');
                     content = mergeEnvSecrets(existingContent, secrets);
@@ -369,4 +374,25 @@ function mergeEnvSecrets(existingContent: string, secrets: Record<string, string
     }
 
     return resultLines.join(eol);
+}
+
+function getKeysWhitelist(optionsKeys?: string, config?: { keys?: string[]; syncKeys?: string[] } | null): Set<string> | null {
+    if (optionsKeys) {
+        const keys = optionsKeys.split(',')
+            .map(k => k.trim())
+            .filter(k => k.length > 0);
+        return keys.length > 0 ? new Set(keys) : null;
+    }
+    
+    if (config) {
+        const keys = config.keys || config.syncKeys;
+        if (Array.isArray(keys)) {
+            const normalized = keys
+                .map(k => typeof k === 'string' ? k.trim() : '')
+                .filter(k => k.length > 0);
+            return normalized.length > 0 ? new Set(normalized) : null;
+        }
+    }
+    
+    return null;
 }

--- a/apps/pawthy/src/commands/push.test.ts
+++ b/apps/pawthy/src/commands/push.test.ts
@@ -19,6 +19,7 @@ describe('Push Command', () => {
         pushCommand.setOptionValue('force', undefined);
         pushCommand.setOptionValue('projectId', undefined);
         pushCommand.setOptionValue('envId', undefined);
+        pushCommand.setOptionValue('keys', undefined);
 
         // Create a unique temp directory outside the repository
         tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-push-'));
@@ -150,5 +151,90 @@ describe('Push Command', () => {
         }
 
         assert.strictEqual(exitCode, 1);
+    });
+
+    it('should support whitelisting via CLI keys flag in push command', async () => {
+        let pushedSecrets: Record<string, string> = {};
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Write a .env with multiple variables
+        await fs.writeFile(
+            path.join(tempDir, '.env'),
+            ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key', 'LOCAL_VAR=123'].join('\n')
+        );
+
+        mock.method(axios, 'put', async (url: string, data: { secrets: Record<string, string> }) => {
+            pushedSecrets = data.secrets;
+            return {
+                status: 200,
+                data: { success: true },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        pushCommand.exitOverride();
+        // Request only DATABASE_URL and API_KEY
+        await pushCommand.parseAsync([
+            'node',
+            'pawthy',
+            'push',
+            '--force',
+            '-k',
+            'DATABASE_URL, API_KEY',
+        ]);
+
+        assert.deepStrictEqual(pushedSecrets, {
+            DATABASE_URL: 'postgres://localhost/db',
+            API_KEY: 'secret-key',
+        });
+    });
+
+    it('should support whitelisting via keys array in .pawthyrc in push command', async () => {
+        let pushedSecrets: Record<string, string> = {};
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Write a .pawthyrc containing a keys whitelist
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc'),
+            JSON.stringify({
+                projectId: 'test-project',
+                envId: 'test-env',
+                keys: ['DATABASE_URL'],
+            })
+        );
+
+        // Write a .env with multiple variables
+        await fs.writeFile(
+            path.join(tempDir, '.env'),
+            ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
+        );
+
+        mock.method(axios, 'put', async (url: string, data: { secrets: Record<string, string> }) => {
+            pushedSecrets = data.secrets;
+            return {
+                status: 200,
+                data: { success: true },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        pushCommand.exitOverride();
+        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+
+        assert.deepStrictEqual(pushedSecrets, {
+            DATABASE_URL: 'postgres://localhost/db',
+        });
     });
 });

--- a/apps/pawthy/src/commands/push.test.ts
+++ b/apps/pawthy/src/commands/push.test.ts
@@ -195,7 +195,8 @@ describe('Push Command', () => {
             ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key', 'LOCAL_VAR=123'].join('\n')
         );
 
-        mock.method(axios, 'put', async (url: string, data: { secrets: Record<string, string> }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
             pushedSecrets = data.secrets;
             return {
                 status: 200,
@@ -206,7 +207,6 @@ describe('Push Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pushCommand.exitOverride();
         // Request only DATABASE_URL and API_KEY
         await pushCommand.parseAsync([
             'node',
@@ -247,7 +247,8 @@ describe('Push Command', () => {
             ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
         );
 
-        mock.method(axios, 'put', async (url: string, data: { secrets: Record<string, string> }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
             pushedSecrets = data.secrets;
             return {
                 status: 200,
@@ -258,7 +259,97 @@ describe('Push Command', () => {
         mock.method(console, 'log', () => {});
         mock.method(console, 'error', () => {});
 
-        pushCommand.exitOverride();
+        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+
+        assert.deepStrictEqual(pushedSecrets, {
+            DATABASE_URL: 'postgres://localhost/db',
+        });
+    });
+
+    it('should support whitelisting via keys array in .pawthyrc.local in push command', async () => {
+        let pushedSecrets: Record<string, string> = {};
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Write .pawthyrc and .pawthyrc.local
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc'),
+            JSON.stringify({
+                projectId: 'test-project',
+                envId: 'test-env',
+            })
+        );
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc.local'),
+            JSON.stringify({
+                keys: ['API_KEY'],
+            })
+        );
+
+        // Write a .env with multiple variables
+        await fs.writeFile(
+            path.join(tempDir, '.env'),
+            ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+            pushedSecrets = data.secrets;
+            return {
+                status: 200,
+                data: { success: true },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
+        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+
+        assert.deepStrictEqual(pushedSecrets, {
+            API_KEY: 'secret-key',
+        });
+    });
+
+    it('should support whitelisting via syncKeys array in .pawthyrc in push command', async () => {
+        let pushedSecrets: Record<string, string> = {};
+        mock.method(config, 'get', (key: string) => {
+            if (key === 'token') return 'test-token';
+            if (key === 'apiUrl') return 'http://localhost:3000';
+            return undefined;
+        });
+
+        // Write a .pawthyrc containing syncKeys alias
+        await fs.writeFile(
+            path.join(tempDir, '.pawthyrc'),
+            JSON.stringify({
+                projectId: 'test-project',
+                envId: 'test-env',
+                syncKeys: ['DATABASE_URL'],
+            })
+        );
+
+        // Write a .env with multiple variables
+        await fs.writeFile(
+            path.join(tempDir, '.env'),
+            ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+            pushedSecrets = data.secrets;
+            return {
+                status: 200,
+                data: { success: true },
+            };
+        });
+
+        mock.method(console, 'log', () => {});
+        mock.method(console, 'error', () => {});
+
         await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
 
         assert.deepStrictEqual(pushedSecrets, {

--- a/apps/pawthy/src/commands/push.ts
+++ b/apps/pawthy/src/commands/push.ts
@@ -24,9 +24,10 @@ export const pushCommand = new Command('push')
 
         let projectId = options.projectId;
         let envId = options.envId;
+        let config: { projectId?: string; envId?: string; keys?: string[]; syncKeys?: string[] } | null = null;
 
-        if (!projectId || !envId) {
-            const config = await getProjectConfig();
+        if (!projectId || !envId || !options.keys) {
+            config = await getProjectConfig();
             projectId = projectId || config?.projectId || process.env.PAWTHY_PROJECT_ID;
             envId = envId || config?.envId || process.env.PAWTHY_ENV_ID;
         }
@@ -49,21 +50,22 @@ export const pushCommand = new Command('push')
             let secrets = dotenv.parse(envContent);
 
             // Whitelisting / selective keys sync (Issue #80)
-            let keysWhitelist: string[] | null = null;
-            if (options.keys) {
-                keysWhitelist = options.keys.split(',').map((k: string) => k.trim()).filter((k: string) => k.length > 0);
-            } else if (config && 'keys' in config && Array.isArray(config.keys)) {
-                keysWhitelist = config.keys as string[];
-            }
+            const keysWhitelist = getKeysWhitelist(options.keys, config);
 
             if (keysWhitelist) {
+                const skippedKeys: string[] = [];
                 const filteredSecrets: Record<string, string> = {};
-                for (const key of Object.keys(secrets)) {
-                    if (keysWhitelist.includes(key)) {
-                        filteredSecrets[key] = secrets[key];
+                for (const [key, value] of Object.entries(secrets)) {
+                    if (keysWhitelist.has(key)) {
+                        filteredSecrets[key] = value;
+                    } else {
+                        skippedKeys.push(key);
                     }
                 }
                 secrets = filteredSecrets;
+                if (skippedKeys.length > 0) {
+                    console.log(chalk.yellow(`\n⚠️  Skipped pushing keys not in whitelist: ${skippedKeys.join(', ')}`));
+                }
             }
 
             if (Object.keys(secrets).length === 0) {
@@ -117,3 +119,24 @@ export const pushCommand = new Command('push')
             process.exit(1);
         }
     });
+
+function getKeysWhitelist(optionsKeys?: string, config?: { keys?: string[]; syncKeys?: string[] } | null): Set<string> | null {
+    if (optionsKeys) {
+        const keys = optionsKeys.split(',')
+            .map(k => k.trim())
+            .filter(k => k.length > 0);
+        return keys.length > 0 ? new Set(keys) : null;
+    }
+    
+    if (config) {
+        const keys = config.keys || config.syncKeys;
+        if (Array.isArray(keys)) {
+            const normalized = keys
+                .map(k => typeof k === 'string' ? k.trim() : '')
+                .filter(k => k.length > 0);
+            return normalized.length > 0 ? new Set(normalized) : null;
+        }
+    }
+    
+    return null;
+}

--- a/apps/pawthy/src/commands/push.ts
+++ b/apps/pawthy/src/commands/push.ts
@@ -12,6 +12,7 @@ export const pushCommand = new Command('push')
     .option('--force', 'Push secrets without confirmation')
     .option('-p, --project-id <id>', 'Project ID')
     .option('-e, --env-id <id>', 'Environment ID')
+    .option('-k, --keys <list>', 'Comma-separated list of keys to push')
     .action(async (options) => {
         const token = getToken();
         const apiUrl = getApiUrl();
@@ -39,10 +40,28 @@ export const pushCommand = new Command('push')
         try {
             // 1. Read and Parse .env
             const envContent = await fs.readFile(envPath, 'utf-8');
-            const secrets = dotenv.parse(envContent);
+            let secrets = dotenv.parse(envContent);
+
+            // Whitelisting / selective keys sync (Issue #80)
+            let keysWhitelist: string[] | null = null;
+            if (options.keys) {
+                keysWhitelist = options.keys.split(',').map((k: string) => k.trim()).filter((k: string) => k.length > 0);
+            } else if (config && 'keys' in config && Array.isArray(config.keys)) {
+                keysWhitelist = config.keys as string[];
+            }
+
+            if (keysWhitelist) {
+                const filteredSecrets: Record<string, string> = {};
+                for (const key of Object.keys(secrets)) {
+                    if (keysWhitelist.includes(key)) {
+                        filteredSecrets[key] = secrets[key];
+                    }
+                }
+                secrets = filteredSecrets;
+            }
 
             if (Object.keys(secrets).length === 0) {
-                console.log(chalk.yellow('No secrets found in the specified file.'));
+                console.log(chalk.yellow('No matching secrets found in the specified file.'));
                 return;
             }
 

--- a/apps/pawthy/src/config.test.ts
+++ b/apps/pawthy/src/config.test.ts
@@ -4,7 +4,7 @@ import assert from 'node:assert';
 import os from 'os';
 import fs from 'fs';
 import path from 'path';
-import { getApiUrl, config, findProjectRoot } from './config.js';
+import { getApiUrl, config, findProjectRoot, getProjectConfig } from './config.js';
 
 describe('Config', () => {
     const originalEnv = process.env;
@@ -98,6 +98,57 @@ describe('Config', () => {
             await fs.promises.writeFile(path.join(tempDir, '.pawthy'), 'fake file');
             const root = findProjectRoot(tempDir);
             assert.strictEqual(root, path.resolve(tempDir));
+        });
+    });
+
+    describe('getProjectConfig', () => {
+        let tempDir: string;
+
+        beforeEach(async () => {
+            tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pawthy-get-config-'));
+            mock.method(process, 'cwd', () => tempDir);
+        });
+
+        afterEach(async () => {
+            try {
+                await fs.promises.rm(tempDir, { recursive: true, force: true });
+            } catch {
+                // Ignore
+            }
+        });
+
+        it('should return null if neither config file exists', async () => {
+            const result = await getProjectConfig();
+            assert.strictEqual(result, null);
+        });
+
+        it('should load .pawthyrc if it exists', async () => {
+            await fs.promises.writeFile(
+                path.join(tempDir, '.pawthyrc'),
+                JSON.stringify({ projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] })
+            );
+
+            const result = await getProjectConfig();
+            assert.deepStrictEqual(result, { projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] });
+        });
+
+        it('should load and merge both .pawthyrc and .pawthyrc.local', async () => {
+            await fs.promises.writeFile(
+                path.join(tempDir, '.pawthyrc'),
+                JSON.stringify({ projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] })
+            );
+            await fs.promises.writeFile(
+                path.join(tempDir, '.pawthyrc.local'),
+                JSON.stringify({ envId: 'env-override', keys: ['KEY_OVERRIDE'], syncKeys: ['SK_1'] })
+            );
+
+            const result = await getProjectConfig();
+            assert.deepStrictEqual(result, {
+                projectId: 'project-1',
+                envId: 'env-override',
+                keys: ['KEY_OVERRIDE'],
+                syncKeys: ['SK_1']
+            });
         });
     });
 });

--- a/apps/pawthy/src/config.ts
+++ b/apps/pawthy/src/config.ts
@@ -228,23 +228,52 @@ export function clearConfig(): void {
   config.clear();
 }
 
-export async function getProjectConfig(): Promise<{ projectId: string; envId: string } | null> {
-  const configPath = path.join(findProjectRoot(), '.pawthyrc');
+export async function getProjectConfig(): Promise<{ projectId?: string; envId?: string; keys?: string[]; syncKeys?: string[] } | null> {
+  const root = findProjectRoot();
+  const configPath = path.join(root, '.pawthyrc');
+  const localConfigPath = path.join(root, '.pawthyrc.local');
+  
+  let configData: { projectId?: string; envId?: string; keys?: string[]; syncKeys?: string[] } = {};
+  
+  // Try reading .pawthyrc
   try {
     const content = await fs.promises.readFile(configPath, 'utf-8');
-    return JSON.parse(content);
+    configData = { ...configData, ...JSON.parse(content) };
   } catch (e: unknown) {
     const err = e as NodeJS.ErrnoException;
-    if (err.code === 'ENOENT') {
-      return null;
+    if (err.code !== 'ENOENT') {
+      if (e instanceof SyntaxError) {
+        console.error(
+          `Error: Could not parse project configuration file at ${configPath}. It appears to be malformed.`
+        );
+      } else {
+        console.error(`Error: Failed to read project configuration from ${configPath}:`, err.message);
+      }
+      process.exit(1);
     }
-    if (e instanceof SyntaxError) {
-      console.error(
-        `Error: Could not parse project configuration file at ${configPath}. It appears to be malformed.`
-      );
-    } else {
-      console.error(`Error: Failed to read project configuration from ${configPath}:`, err.message);
-    }
-    process.exit(1);
   }
+  
+  // Try reading .pawthyrc.local
+  try {
+    const content = await fs.promises.readFile(localConfigPath, 'utf-8');
+    configData = { ...configData, ...JSON.parse(content) };
+  } catch (e: unknown) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code !== 'ENOENT') {
+      if (e instanceof SyntaxError) {
+        console.error(
+          `Error: Could not parse local project configuration file at ${localConfigPath}. It appears to be malformed.`
+        );
+      } else {
+        console.error(`Error: Failed to read local project configuration from ${localConfigPath}:`, err.message);
+      }
+      process.exit(1);
+    }
+  }
+  
+  if (Object.keys(configData).length === 0) {
+    return null;
+  }
+  
+  return configData;
 }


### PR DESCRIPTION
Resolves #80. Adds a `-k / --keys` option to the `pull` and `push` commands, allowing a comma-separated list of keys to filter synchronization. Also falls back to a `keys` string array defined in `.pawthyrc` config if the CLI flag is not provided.