### PR TITLE
feat(bot): implement auto-expiration of pending approval requests after 24 hours

### DIFF
--- a/apps/purrmission-bot/src/domain/repositories.mock.ts
+++ b/apps/purrmission-bot/src/domain/repositories.mock.ts
@@ -188,14 +188,28 @@ export class InMemoryApprovalRequestRepository implements ApprovalRequestReposit
     resourceId: string,
     requesterId: string
   ): Promise<ApprovalRequest | null> {
+    const now = new Date();
     return (
       Array.from(this.requests.values()).find(
         (request) =>
           request.resourceId === resourceId &&
           ['PENDING', 'APPROVED'].includes(request.status) &&
+          (!request.expiresAt || request.expiresAt > now) &&
           (request.context as Record<string, unknown>)['requesterId'] === requesterId
       ) || null
     );
+  }
+
+  async expireRequests(): Promise<number> {
+    const now = new Date();
+    let count = 0;
+    for (const request of this.requests.values()) {
+      if (request.status === 'PENDING' && request.expiresAt && request.expiresAt < now) {
+        request.status = 'EXPIRED';
+        count++;
+      }
+    }
+    return count;
   }
 }
 

--- a/apps/purrmission-bot/src/domain/repositories.ts
+++ b/apps/purrmission-bot/src/domain/repositories.ts
@@ -115,6 +115,12 @@ export interface ApprovalRequestRepository {
    * Find an active approval request by resource and requester.
    */
   findActiveByRequester(resourceId: string, requesterId: string): Promise<ApprovalRequest | null>;
+
+  /**
+   * Mark all pending requests that have passed their expiresAt time as EXPIRED.
+   * @returns The number of requests updated.
+   */
+  expireRequests(): Promise<number>;
 }
 
 /**
@@ -751,10 +757,12 @@ export class PrismaApprovalRequestRepository implements ApprovalRequestRepositor
     resourceId: string,
     requesterId: string
   ): Promise<ApprovalRequest | null> {
+    const now = new Date();
     const rows = await this.prisma.approvalRequest.findMany({
       where: {
         resourceId,
         status: { in: ['PENDING', 'APPROVED'] },
+        OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
       },
       orderBy: {
         createdAt: 'desc',
@@ -773,6 +781,20 @@ export class PrismaApprovalRequestRepository implements ApprovalRequestRepositor
     });
 
     return match ? this.mapPrismaToDomain(match) : null;
+  }
+
+  async expireRequests(): Promise<number> {
+    const now = new Date();
+    const result = await this.prisma.approvalRequest.updateMany({
+      where: {
+        status: 'PENDING',
+        expiresAt: { lt: now },
+      },
+      data: {
+        status: 'EXPIRED',
+      },
+    });
+    return result.count;
   }
 
   private mapPrismaToDomain(row: {

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -92,6 +92,13 @@ export class ApprovalService {
       };
     }
 
+    if (input.expiresInMs !== undefined && input.expiresInMs <= 0) {
+      return {
+        success: false,
+        error: 'expiresInMs must be a positive number',
+      };
+    }
+
     // Calculate expiration time (default to 24 hours if not provided)
     const defaultExpiresInMs = 24 * 60 * 60 * 1000; // 24 hours
     const expiresAt = new Date(Date.now() + (input.expiresInMs ?? defaultExpiresInMs));

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -92,8 +92,9 @@ export class ApprovalService {
       };
     }
 
-    // Calculate expiration time
-    const expiresAt = input.expiresInMs ? new Date(Date.now() + input.expiresInMs) : null;
+    // Calculate expiration time (default to 24 hours if not provided)
+    const defaultExpiresInMs = 24 * 60 * 60 * 1000; // 24 hours
+    const expiresAt = new Date(Date.now() + (input.expiresInMs ?? defaultExpiresInMs));
 
     // Create the request
     const request = await repositories.approvalRequests.create({
@@ -249,6 +250,18 @@ export class ApprovalService {
     requesterId: string
   ): Promise<ApprovalRequest | null> {
     return this.deps.repositories.approvalRequests.findActiveByRequester(resourceId, requesterId);
+  }
+
+  /**
+   * Automatically expire pending approval requests that have passed their expiration time.
+   * @returns The number of expired requests
+   */
+  async cleanupExpiredRequests(): Promise<number> {
+    const count = await this.deps.repositories.approvalRequests.expireRequests();
+    if (count > 0) {
+      logger.info(`Cleaned up expired approval requests`, { count });
+    }
+    return count;
   }
 }
 

--- a/apps/purrmission-bot/src/index.ts
+++ b/apps/purrmission-bot/src/index.ts
@@ -5,7 +5,6 @@
 import { env } from './config/env.js';
 import { logger } from './logging/logger.js';
 import {
-
   PrismaTOTPRepository,
   PrismaResourceRepository,
   PrismaAuditRepository,
@@ -79,12 +78,32 @@ async function main(): Promise<void> {
   // Announce online status
   const statusService = new StatusService();
   // Don't await this to avoid blocking startup if Discord API is slow
-  statusService.sendOnlineAnnouncement(discordClient).catch(err => {
+  statusService.sendOnlineAnnouncement(discordClient).catch((err) => {
     logger.error('Failed to send ready announcement', {
       error: err instanceof Error ? err.message : String(err),
       stack: err instanceof Error ? err.stack : undefined,
     });
   });
+
+  // Start periodic cleanup tasks (every 15 minutes)
+  const CLEANUP_INTERVAL_MS = 15 * 60 * 1000;
+  const cleanupInterval = setInterval(async () => {
+    try {
+      const expiredRequestsCount = await services.approval.cleanupExpiredRequests();
+      const expiredSessionsCount = await services.auth.cleanupExpiredSessions();
+      if (expiredRequestsCount > 0 || expiredSessionsCount > 0) {
+        logger.info('Periodic cleanup executed', {
+          expiredRequests: expiredRequestsCount,
+          expiredSessions: expiredSessionsCount,
+        });
+      }
+    } catch (error) {
+      logger.error('Failed to run periodic cleanup', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, CLEANUP_INTERVAL_MS);
+  cleanupInterval.unref();
 
   // Log startup summary
   logger.info('========================================');

--- a/apps/purrmission-bot/src/index.ts
+++ b/apps/purrmission-bot/src/index.ts
@@ -87,7 +87,7 @@ async function main(): Promise<void> {
 
   // Start periodic cleanup tasks (every 15 minutes)
   const CLEANUP_INTERVAL_MS = 15 * 60 * 1000;
-  const cleanupInterval = setInterval(async () => {
+  const runCleanup = async () => {
     try {
       const expiredRequestsCount = await services.approval.cleanupExpiredRequests();
       const expiredSessionsCount = await services.auth.cleanupExpiredSessions();
@@ -102,7 +102,16 @@ async function main(): Promise<void> {
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  }, CLEANUP_INTERVAL_MS);
+  };
+
+  // Run immediately on startup
+  runCleanup().catch((error) => {
+    logger.error('Failed to run initial cleanup', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
+  const cleanupInterval = setInterval(runCleanup, CLEANUP_INTERVAL_MS);
   cleanupInterval.unref();
 
   // Log startup summary

--- a/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
+++ b/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
@@ -426,5 +426,13 @@ describe('Credential Sync Logic Smoke Test', () => {
     const expiredCount = await services.approval.cleanupExpiredRequests();
     assert.strictEqual(expiredCount, 1);
     assert.strictEqual(rawReq.status, 'EXPIRED');
+
+    // Verify that creation fails with non-positive expiresInMs
+    const invalidResult = await services.approval.createApprovalRequest({
+      resourceId,
+      expiresInMs: 0,
+    });
+    assert.strictEqual(invalidResult.success, false);
+    assert.strictEqual(invalidResult.error, 'expiresInMs must be a positive number');
   });
 });

--- a/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
+++ b/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
@@ -224,6 +224,7 @@ class MemApprovalRepo implements ApprovalRequestRepository {
     resourceId: string,
     requesterId: string
   ): Promise<ApprovalRequest | null> {
+    const now = new Date();
     // Simple logic: find PENDING or APPROVED req where context.requesterId == requesterId
     // Assuming context is simple object
     return (
@@ -231,6 +232,7 @@ class MemApprovalRepo implements ApprovalRequestRepository {
         (r) =>
           r.resourceId === resourceId &&
           ['PENDING', 'APPROVED'].includes(r.status) &&
+          (!r.expiresAt || r.expiresAt > now) &&
           r.context['requesterId'] === requesterId
       ) || null
     );
@@ -240,6 +242,17 @@ class MemApprovalRepo implements ApprovalRequestRepository {
   }
   async findPendingByResourceId(resourceId: string): Promise<ApprovalRequest[]> {
     return this.requests.filter((r) => r.resourceId === resourceId && r.status === 'PENDING');
+  }
+  async expireRequests(): Promise<number> {
+    const now = new Date();
+    let count = 0;
+    for (const r of this.requests) {
+      if (r.status === 'PENDING' && r.expiresAt && r.expiresAt < now) {
+        r.status = 'EXPIRED';
+        count++;
+      }
+    }
+    return count;
   }
 }
 
@@ -360,5 +373,58 @@ describe('Credential Sync Logic Smoke Test', () => {
     await services.resource.removeGuardian(resource.id, ownerId, guardianId);
     const isGuardianAfter = await services.resource.isGuardian(resource.id, guardianId);
     assert.strictEqual(isGuardianAfter, false);
+  });
+
+  it('should support auto-expiration of pending approval requests', async () => {
+    const ownerId = 'owner-123';
+    const requesterId = 'user-555';
+
+    // Create a project and environment first
+    const project = await services.project.createProject({
+      name: 'expiry-test-proj',
+      ownerId,
+    });
+    const env = await services.project.createEnvironment({
+      name: 'Development',
+      slug: 'dev',
+      projectId: project.id,
+    });
+    const resourceId = env.resourceId;
+
+    // Create approval request with default expiration (24h)
+    const result = await services.approval.createApprovalRequest({
+      resourceId,
+      context: { requesterId },
+    });
+    assert.strictEqual(result.success, true);
+    assert.ok(result.request);
+    assert.ok(result.request.expiresAt);
+
+    // Verify default expiration is roughly 24 hours in the future
+    const diffMs = result.request.expiresAt.getTime() - Date.now();
+    const expectedDiffMs = 24 * 60 * 60 * 1000;
+    assert.ok(
+      Math.abs(diffMs - expectedDiffMs) < 5000,
+      'Expiration should be roughly 24 hours in the future'
+    );
+
+    // Verify active approval request is returned
+    let active = await services.approval.findActiveApproval(resourceId, requesterId);
+    assert.ok(active);
+    assert.strictEqual(active.id, result.request.id);
+
+    // Now, let's manually modify the request in the repo to be expired (expiresAt in the past)
+    const rawReq = approvalRepo.requests.find((r) => r.id === result.request!.id);
+    assert.ok(rawReq);
+    rawReq.expiresAt = new Date(Date.now() - 60000); // 1 minute ago
+
+    // Verify that findActiveApproval now ignores this request because it is expired
+    active = await services.approval.findActiveApproval(resourceId, requesterId);
+    assert.strictEqual(active, null, 'Expired request should be ignored');
+
+    // Run cleanupExpiredRequests and verify status changes to EXPIRED
+    const expiredCount = await services.approval.cleanupExpiredRequests();
+    assert.strictEqual(expiredCount, 1);
+    assert.strictEqual(rawReq.status, 'EXPIRED');
   });
 });

--- a/apps/purrmission-bot/src/test/setup.ts
+++ b/apps/purrmission-bot/src/test/setup.ts
@@ -1,7 +1,7 @@
-
-// Set up mock environment variables for tests
-process.env.DISCORD_BOT_TOKEN = 'mock';
-process.env.DISCORD_CLIENT_ID = 'mock';
-process.env.DISCORD_GUILD_ID = 'mock';
-process.env.DATABASE_URL = 'mock';
-process.env.ENCRYPTION_KEY = '000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f';
+// Set up mock environment variables for tests if not already set
+process.env.DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN || 'mock';
+process.env.DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID || 'mock';
+process.env.DISCORD_GUILD_ID = process.env.DISCORD_GUILD_ID || 'mock';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./data/dev.db';
+process.env.ENCRYPTION_KEY =
+  process.env.ENCRYPTION_KEY || '000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dev:ops:backup": "tsx scripts/backup-db.ts",
     "dev:ops:rotate-keys": "tsx scripts/rotate-keys.ts",
     "dev:ops:encrypt-totp": "tsx scripts/encrypt-totp-secrets.ts",
-    "dev:ops:test": "node --import tsx --test scripts/ops.test.ts",
+    "dev:ops:test": "node --import tsx --import ./apps/purrmission-bot/src/test/setup.ts --test scripts/ops.test.ts",
     "prod:ops:backup": "node dist-scripts/backup-db.js",
     "prod:ops:rotate-keys": "node dist-scripts/rotate-keys.js",
     "prod:ops:encrypt-totp": "node dist-scripts/encrypt-totp-secrets.js",


### PR DESCRIPTION
Closes #59. Implements default 24-hour expiration for new approval requests, filters out expired requests from active approvals check, and registers a periodic unreferenced interval (every 15 minutes) to clean up expired approval requests and auth sessions.