### PR TITLE
test(bot): implement end-to-end API system tests

### DIFF
--- a/apps/purrmission-bot/src/test/setup.ts
+++ b/apps/purrmission-bot/src/test/setup.ts
@@ -1,7 +1,7 @@
-
-// Set up mock environment variables for tests
-process.env.DISCORD_BOT_TOKEN = 'mock';
-process.env.DISCORD_CLIENT_ID = 'mock';
-process.env.DISCORD_GUILD_ID = 'mock';
-process.env.DATABASE_URL = 'mock';
-process.env.ENCRYPTION_KEY = '000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f';
+// Set up mock environment variables for tests if not already set
+process.env.DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN || 'mock';
+process.env.DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID || 'mock';
+process.env.DISCORD_GUILD_ID = process.env.DISCORD_GUILD_ID || 'mock';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'file:./data/dev.db';
+process.env.ENCRYPTION_KEY =
+  process.env.ENCRYPTION_KEY || '000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f';

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import type { Client } from 'discord.js';
+import type { Services } from '../domain/services.js';
+import { createHttpServer } from '../http/server.js';
+
+// Minimal mock Discord client
+const mockDiscordClient = {
+  isReady: () => true,
+  user: { tag: 'TestBot#0000' },
+  channels: { fetch: async () => null },
+  users: { fetch: async () => null },
+  login: async () => 'token',
+  destroy: () => {},
+  on: () => {},
+  once: () => {},
+} as unknown as Client;
+
+describe('System API E2E Tests', () => {
+  let server: any;
+
+  // Shared mock implementations that tests can override
+  const mockVerifyApiKey = { fn: async (_apiKey: string): Promise<any> => null };
+  const mockCreateApprovalRequest = {
+    fn: async (_input: any): Promise<any> => ({ success: false }),
+  };
+  const mockGetApprovalRequest = { fn: async (_id: string): Promise<any> => null };
+  const mockFindActiveApproval = {
+    fn: async (_resourceId: string, _userId: string): Promise<any> => null,
+  };
+  const mockValidateToken = { fn: async (_token: string): Promise<any> => null };
+  const mockGetProject = { fn: async (_projectId: string): Promise<any> => null };
+  const mockGetEnvironmentById = {
+    fn: async (_projectId: string, _envId: string): Promise<any> => null,
+  };
+  const mockGetMemberRole = {
+    fn: async (_projectId: string, _userId: string): Promise<any> => null,
+  };
+  const mockIsGuardian = {
+    fn: async (_resourceId: string, _userId: string): Promise<boolean> => false,
+  };
+  const mockListFields = { fn: async (_resourceId: string): Promise<any[]> => [] };
+  const mockUpsertField = {
+    fn: async (_resourceId: string, _key: string, _value: string): Promise<void> => {},
+  };
+
+  const servicesMock = {
+    resource: {
+      verifyApiKey: (apiKey: string) => mockVerifyApiKey.fn(apiKey),
+      isGuardian: (resourceId: string, userId: string) => mockIsGuardian.fn(resourceId, userId),
+      listFields: (resourceId: string) => mockListFields.fn(resourceId),
+      upsertField: (resourceId: string, key: string, value: string) =>
+        mockUpsertField.fn(resourceId, key, value),
+    },
+    approval: {
+      createApprovalRequest: (input: any) => mockCreateApprovalRequest.fn(input),
+      getApprovalRequest: (id: string) => mockGetApprovalRequest.fn(id),
+      findActiveApproval: (resourceId: string, userId: string) =>
+        mockFindActiveApproval.fn(resourceId, userId),
+    },
+    auth: {
+      validateToken: (token: string) => mockValidateToken.fn(token),
+    },
+    project: {
+      getProject: (projectId: string) => mockGetProject.fn(projectId),
+      getEnvironmentById: (projectId: string, envId: string) =>
+        mockGetEnvironmentById.fn(projectId, envId),
+      getMemberRole: (projectId: string, userId: string) => mockGetMemberRole.fn(projectId, userId),
+    },
+  } as unknown as Services;
+
+  beforeEach(async () => {
+    // Reset mocks to default behavior
+    mockVerifyApiKey.fn = async () => null;
+    mockCreateApprovalRequest.fn = async () => ({ success: false });
+    mockGetApprovalRequest.fn = async () => null;
+    mockFindActiveApproval.fn = async () => null;
+    mockValidateToken.fn = async () => null;
+    mockGetProject.fn = async () => null;
+    mockGetEnvironmentById.fn = async () => null;
+    mockGetMemberRole.fn = async () => null;
+    mockIsGuardian.fn = async () => false;
+    mockListFields.fn = async () => [];
+    mockUpsertField.fn = async () => {};
+
+    server = createHttpServer({
+      services: servicesMock,
+      discordClient: mockDiscordClient,
+    });
+    await server.ready();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  describe('POST /api/requests', () => {
+    it('should return 400 when body validation fails', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/requests',
+        payload: {
+          // missing required apiKey and resourceId
+        },
+      });
+      assert.strictEqual(response.statusCode, 400);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.error, 'Invalid request body');
+    });
+
+    it('should return 401 when API key is invalid', async () => {
+      mockVerifyApiKey.fn = async () => null;
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/requests',
+        payload: {
+          resourceId: 'res-1',
+          apiKey: 'invalid-key',
+        },
+      });
+      assert.strictEqual(response.statusCode, 401);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.error, 'Invalid API key');
+    });
+
+    it('should return 401 when resourceId does not match API key resource', async () => {
+      mockVerifyApiKey.fn = async () => ({
+        id: 'res-correct',
+        name: 'Correct Resource',
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/requests',
+        payload: {
+          resourceId: 'res-incorrect',
+          apiKey: 'valid-key',
+        },
+      });
+      assert.strictEqual(response.statusCode, 401);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.error, 'Resource ID does not match API key');
+    });
+
+    it('should return 201 when request is created successfully', async () => {
+      const mockResource = {
+        id: 'res-1',
+        name: 'Test Resource',
+      };
+      mockVerifyApiKey.fn = async () => mockResource;
+      mockCreateApprovalRequest.fn = async () => ({
+        success: true,
+        request: {
+          id: 'req-1',
+          status: 'PENDING',
+          expiresAt: new Date(Date.now() + 60000),
+        },
+        resource: mockResource,
+        guardians: [{ discordUserId: 'g-1', role: 'GUARDIAN' }],
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/requests',
+        payload: {
+          resourceId: 'res-1',
+          apiKey: 'valid-key',
+        },
+      });
+      assert.strictEqual(response.statusCode, 201);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.requestId, 'req-1');
+      assert.strictEqual(data.status, 'PENDING');
+      assert.strictEqual(data.resourceId, 'res-1');
+      assert.strictEqual(data.resourceName, 'Test Resource');
+    });
+  });
+
+  describe('GET /api/projects/:projectId/environments/:envId/secrets', () => {
+    it('should return 401 when Authorization header is missing', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+      });
+      assert.strictEqual(response.statusCode, 401);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.error, 'unauthorized');
+    });
+
+    it('should return 401 when Bearer token is invalid', async () => {
+      mockValidateToken.fn = async () => null;
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        headers: {
+          Authorization: 'Bearer invalid-token',
+        },
+      });
+      assert.strictEqual(response.statusCode, 401);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.error, 'unauthorized');
+    });
+
+    it('should return 200 with secrets when requester is the project owner', async () => {
+      mockValidateToken.fn = async () => ({ userId: 'user-owner' });
+      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
+      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
+      mockListFields.fn = async () => [
+        { name: 'DB_PASS', value: 'my-pass' },
+        { name: 'API_SECRET', value: 'my-secret' },
+      ];
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        headers: {
+          Authorization: 'Bearer valid-token',
+        },
+      });
+      assert.strictEqual(response.statusCode, 200);
+      const data = JSON.parse(response.payload);
+      assert.deepStrictEqual(data.secrets, {
+        DB_PASS: 'my-pass',
+        API_SECRET: 'my-secret',
+      });
+    });
+
+    it('should return 202 pending when approval is required and is currently pending', async () => {
+      mockValidateToken.fn = async () => ({ userId: 'user-requester' });
+      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
+      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
+      mockGetMemberRole.fn = async () => null; // not a project member
+      mockIsGuardian.fn = async () => false; // not a guardian
+      mockFindActiveApproval.fn = async () => ({
+        id: 'req-1',
+        status: 'PENDING',
+      });
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        headers: {
+          Authorization: 'Bearer valid-token',
+        },
+      });
+      assert.strictEqual(response.statusCode, 202);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.status, 'pending');
+      assert.strictEqual(data.requestId, 'req-1');
+    });
+
+    it('should return 200 with secrets when approval has been approved', async () => {
+      mockValidateToken.fn = async () => ({ userId: 'user-requester' });
+      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
+      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
+      mockGetMemberRole.fn = async () => null;
+      mockIsGuardian.fn = async () => false;
+      mockFindActiveApproval.fn = async () => ({
+        id: 'req-1',
+        status: 'APPROVED',
+      });
+      mockListFields.fn = async () => [{ name: 'SECRET_KEY', value: 'approved-value' }];
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        headers: {
+          Authorization: 'Bearer valid-token',
+        },
+      });
+      assert.strictEqual(response.statusCode, 200);
+      const data = JSON.parse(response.payload);
+      assert.deepStrictEqual(data.secrets, {
+        SECRET_KEY: 'approved-value',
+      });
+    });
+
+    it('should automatically trigger a new approval request and return 202 when no active request exists', async () => {
+      mockValidateToken.fn = async () => ({ userId: 'user-requester' });
+      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
+      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
+      mockGetMemberRole.fn = async () => null;
+      mockIsGuardian.fn = async () => false;
+      mockFindActiveApproval.fn = async () => null; // none exists yet
+
+      let createdRequest = false;
+      mockCreateApprovalRequest.fn = async (input: any) => {
+        createdRequest = true;
+        assert.strictEqual(input.resourceId, 'res-1');
+        return {
+          success: true,
+          request: {
+            id: 'req-new',
+            status: 'PENDING',
+          },
+          resource: { id: 'res-1', name: 'MyProject:Production' },
+          guardians: [{ discordUserId: 'g-1', role: 'OWNER' }],
+        };
+      };
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        headers: {
+          Authorization: 'Bearer valid-token',
+        },
+      });
+      assert.strictEqual(response.statusCode, 202);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.status, 'pending');
+      assert.strictEqual(data.requestId, 'req-new');
+      assert.strictEqual(createdRequest, true);
+    });
+
+    it('should return 401 when access is explicitly denied', async () => {
+      mockValidateToken.fn = async () => ({ userId: 'user-requester' });
+      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
+      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
+      mockGetMemberRole.fn = async () => null;
+      mockIsGuardian.fn = async () => false;
+      mockFindActiveApproval.fn = async () => ({
+        id: 'req-1',
+        status: 'DENIED',
+      });
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        headers: {
+          Authorization: 'Bearer valid-token',
+        },
+      });
+      assert.strictEqual(response.statusCode, 401);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.error, 'unauthorized');
+    });
+  });
+});

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import type { Client } from 'discord.js';
+import type { FastifyInstance } from 'fastify';
 import type { Services } from '../domain/services.js';
 import { createHttpServer } from '../http/server.js';
 
@@ -17,7 +18,7 @@ const mockDiscordClient = {
 } as unknown as Client;
 
 describe('System API E2E Tests', () => {
-  let server: any;
+  let server: FastifyInstance | undefined;
 
   // Shared mock implementations that tests can override
   const mockVerifyApiKey = { fn: async (_apiKey: string): Promise<any> => null };
@@ -91,7 +92,9 @@ describe('System API E2E Tests', () => {
   });
 
   afterEach(async () => {
-    await server.close();
+    if (server) {
+      await server.close();
+    }
   });
 
   describe('POST /api/requests', () => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dev:ops:backup": "tsx scripts/backup-db.ts",
     "dev:ops:rotate-keys": "tsx scripts/rotate-keys.ts",
     "dev:ops:encrypt-totp": "tsx scripts/encrypt-totp-secrets.ts",
-    "dev:ops:test": "node --import tsx --test scripts/ops.test.ts",
+    "dev:ops:test": "node --import tsx --import ./apps/purrmission-bot/src/test/setup.ts --test scripts/ops.test.ts",
     "prod:ops:backup": "node dist-scripts/backup-db.js",
     "prod:ops:rotate-keys": "node dist-scripts/rotate-keys.js",
     "prod:ops:encrypt-totp": "node dist-scripts/encrypt-totp-secrets.js",


### PR DESCRIPTION
Closes #31. Adds end-to-end system API test coverage in `src/test/system_api.test.ts`. This verifies Fastify request/response contracts, validation behavior for POST `/api/requests`, and authorization error boundaries for GET `/api/projects/:projectId/environments/:envId/secrets`.