### PR TITLE
feat(bot): decouple audit log failures from core business flows

### DIFF
--- a/apps/purrmission-bot/src/domain/services.test.ts
+++ b/apps/purrmission-bot/src/domain/services.test.ts
@@ -2,180 +2,274 @@ import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert';
 import { ResourceService, ApprovalService, type ServiceDependencies } from './services.js';
 import {
-    type GuardianRepository,
-    type ResourceRepository,
-    type ApprovalRequestRepository,
-    type Repositories
+  type GuardianRepository,
+  type ResourceRepository,
+  type ApprovalRequestRepository,
+  type Repositories,
 } from './repositories.js';
 import type { Guardian } from './models.js';
 
 describe('ResourceService', () => {
-    let resourceService: ResourceService;
-    let mockRepositories: Repositories;
-    let mockGuardianRepo: Partial<GuardianRepository>;
-    let mockResourceRepo: Partial<ResourceRepository>;
+  let resourceService: ResourceService;
+  let mockRepositories: Repositories;
+  let mockGuardianRepo: Partial<GuardianRepository>;
+  let mockResourceRepo: Partial<ResourceRepository>;
 
-    const resourceId = 'res-1';
-    const ownerId = 'owner-1';
-    const guardianId = 'guardian-1';
-    const otherId = 'other-1';
+  const resourceId = 'res-1';
+  const ownerId = 'owner-1';
+  const guardianId = 'guardian-1';
+  const otherId = 'other-1';
 
-    beforeEach(() => {
-        mockGuardianRepo = {
-            findByResourceAndUser: mock.fn() as any,
-            findByResourceId: mock.fn() as any,
-            remove: mock.fn() as any,
-            add: mock.fn() as any,
-        };
+  beforeEach(() => {
+    mockGuardianRepo = {
+      findByResourceAndUser: mock.fn() as any,
+      findByResourceId: mock.fn() as any,
+      remove: mock.fn() as any,
+      add: mock.fn() as any,
+    };
 
-        mockResourceRepo = {
-            findById: mock.fn() as any,
-        };
+    mockResourceRepo = {
+      findById: mock.fn() as any,
+    };
 
-        mockRepositories = {
-            guardians: mockGuardianRepo as GuardianRepository,
-            resources: mockResourceRepo as ResourceRepository,
-        } as Repositories;
+    mockRepositories = {
+      guardians: mockGuardianRepo as GuardianRepository,
+      resources: mockResourceRepo as ResourceRepository,
+    } as Repositories;
 
-        const deps: ServiceDependencies = { repositories: mockRepositories };
-        resourceService = new ResourceService(deps);
+    const deps: ServiceDependencies = { repositories: mockRepositories };
+    resourceService = new ResourceService(deps);
+  });
+
+  describe('removeGuardian', () => {
+    it('should remove guardian if actor is owner', async () => {
+      // Mock Actor is Owner
+      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
+        async (_rid: string, uid: string) => {
+          if (uid === ownerId)
+            return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
+          if (uid === guardianId)
+            return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
+          return null;
+        }
+      );
+
+      const result = await resourceService.removeGuardian(resourceId, ownerId, guardianId);
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 1);
+      assert.deepStrictEqual((mockGuardianRepo.remove as any).mock.calls[0].arguments, [
+        resourceId,
+        guardianId,
+      ]);
     });
 
-    describe('removeGuardian', () => {
-        it('should remove guardian if actor is owner', async () => {
-            // Mock Actor is Owner
-            (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(async (_rid: string, uid: string) => {
-                if (uid === ownerId) return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
-                if (uid === guardianId) return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
-                return null;
-            });
+    it('should fail if actor is not owner', async () => {
+      // Mock Actor is Guardian (not Owner)
+      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
+        async (_rid: string, uid: string) => {
+          if (uid === guardianId)
+            return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
+          return null;
+        }
+      );
 
-            const result = await resourceService.removeGuardian(resourceId, ownerId, guardianId);
+      const result = await resourceService.removeGuardian(resourceId, guardianId, otherId);
 
-            assert.strictEqual(result.success, true);
-            assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 1);
-            assert.deepStrictEqual((mockGuardianRepo.remove as any).mock.calls[0].arguments, [resourceId, guardianId]);
-        });
-
-        it('should fail if actor is not owner', async () => {
-            // Mock Actor is Guardian (not Owner)
-            (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(async (_rid: string, uid: string) => {
-                if (uid === guardianId) return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
-                return null;
-            });
-
-            const result = await resourceService.removeGuardian(resourceId, guardianId, otherId);
-
-            assert.strictEqual(result.success, false);
-            assert.match(result.error!, /Only the resource owner/);
-            assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
-        });
-
-        it('should fail if target is not a guardian', async () => {
-            // Mock Actor is Owner, Target not found
-            (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(async (_rid: string, uid: string) => {
-                if (uid === ownerId) return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
-                return null;
-            });
-
-            const result = await resourceService.removeGuardian(resourceId, ownerId, otherId);
-
-            assert.strictEqual(result.success, false);
-            assert.match(result.error!, /not a guardian/);
-            assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
-        });
-
-        it('should fail if target is owner', async () => {
-            // Mock Actor is Owner, Target is Owner
-            (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(async (_rid: string, uid: string) => {
-                if (uid === ownerId) return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
-                if (uid === guardianId) return { id: 'g2', role: 'OWNER', discordUserId: guardianId } as Guardian; // Simulate target as another owner or same owner
-                return null;
-            });
-
-            const result = await resourceService.removeGuardian(resourceId, ownerId, guardianId);
-
-            assert.strictEqual(result.success, false);
-            assert.match(result.error!, /Cannot remove the resource owner/);
-            assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
-        });
+      assert.strictEqual(result.success, false);
+      assert.match(result.error!, /Only the resource owner/);
+      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
     });
 
-    describe('listGuardians', () => {
-        it('should list guardians if actor is authorized', async () => {
-            // Mock Actor is Guardian
-            (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(async (_rid: string, uid: string) => {
-                if (uid === guardianId) return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
-                return null;
-            });
+    it('should fail if target is not a guardian', async () => {
+      // Mock Actor is Owner, Target not found
+      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
+        async (_rid: string, uid: string) => {
+          if (uid === ownerId)
+            return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
+          return null;
+        }
+      );
 
-            // Mock List return
-            (mockGuardianRepo.findByResourceId as any).mock.mockImplementation(async () => [
-                { id: 'g1', role: 'OWNER' }, { id: 'g2', role: 'GUARDIAN' }
-            ]);
+      const result = await resourceService.removeGuardian(resourceId, ownerId, otherId);
 
-            const result = await resourceService.listGuardians(resourceId, guardianId);
-
-            assert.strictEqual(result.success, true);
-            assert.strictEqual(result.guardians!.length, 2);
-        });
-
-        it('should fail if actor is unauthorized', async () => {
-            // Mock Actor not found
-            (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(async () => null);
-
-            const result = await resourceService.listGuardians(resourceId, otherId);
-
-            assert.strictEqual(result.success, false);
-            assert.match(result.error!, /Access denied/);
-        });
+      assert.strictEqual(result.success, false);
+      assert.match(result.error!, /not a guardian/);
+      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
     });
+
+    it('should fail if target is owner', async () => {
+      // Mock Actor is Owner, Target is Owner
+      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
+        async (_rid: string, uid: string) => {
+          if (uid === ownerId)
+            return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
+          if (uid === guardianId)
+            return { id: 'g2', role: 'OWNER', discordUserId: guardianId } as Guardian; // Simulate target as another owner or same owner
+          return null;
+        }
+      );
+
+      const result = await resourceService.removeGuardian(resourceId, ownerId, guardianId);
+
+      assert.strictEqual(result.success, false);
+      assert.match(result.error!, /Cannot remove the resource owner/);
+      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
+    });
+  });
+
+  describe('listGuardians', () => {
+    it('should list guardians if actor is authorized', async () => {
+      // Mock Actor is Guardian
+      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
+        async (_rid: string, uid: string) => {
+          if (uid === guardianId)
+            return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
+          return null;
+        }
+      );
+
+      // Mock List return
+      (mockGuardianRepo.findByResourceId as any).mock.mockImplementation(async () => [
+        { id: 'g1', role: 'OWNER' },
+        { id: 'g2', role: 'GUARDIAN' },
+      ]);
+
+      const result = await resourceService.listGuardians(resourceId, guardianId);
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.guardians!.length, 2);
+    });
+
+    it('should fail if actor is unauthorized', async () => {
+      // Mock Actor not found
+      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(async () => null);
+
+      const result = await resourceService.listGuardians(resourceId, otherId);
+
+      assert.strictEqual(result.success, false);
+      assert.match(result.error!, /Access denied/);
+    });
+  });
+
+  describe('linkTOTPAccount', () => {
+    it('should succeed even if audit logging throws an error', async () => {
+      const mockResource = { id: resourceId, totpAccountId: null };
+      const mockTotpAccount = { id: 'totp-1' };
+      const mockTotpRepo = {
+        findById: mock.fn(async () => mockTotpAccount),
+      };
+      mockResourceRepo.findById = mock.fn(async () => mockResource) as any;
+      mockResourceRepo.update = mock.fn(async () => mockResource) as any;
+
+      const failingAuditService = {
+        log: mock.fn(async () => {
+          throw new Error('Audit service unavailable');
+        }),
+      };
+
+      const deps: ServiceDependencies = {
+        repositories: {
+          ...mockRepositories,
+          totp: mockTotpRepo as any,
+        },
+        audit: failingAuditService as any,
+      };
+      const svc = new ResourceService(deps);
+
+      // Should complete successfully without throwing
+      await svc.linkTOTPAccount(resourceId, 'totp-1', ownerId);
+
+      assert.strictEqual((mockResourceRepo.update as any).mock.calls.length, 1);
+      assert.strictEqual(failingAuditService.log.mock.calls.length, 1);
+    });
+  });
 });
 
 describe('ApprovalService', () => {
-    let approvalService: ApprovalService;
-    let mockRepositories: Repositories;
-    let mockApprovalRepo: Partial<ApprovalRequestRepository>;
-    let mockResourceRepo: Partial<ResourceRepository>;
-    let mockGuardianRepo: Partial<GuardianRepository>;
+  let approvalService: ApprovalService;
+  let mockRepositories: Repositories;
+  let mockApprovalRepo: Partial<ApprovalRequestRepository>;
+  let mockResourceRepo: Partial<ResourceRepository>;
+  let mockGuardianRepo: Partial<GuardianRepository>;
 
-    beforeEach(() => {
-        mockApprovalRepo = {
-            create: mock.fn() as any,
-            findById: mock.fn() as any,
-            updateStatus: mock.fn() as any,
-            findActiveByRequester: mock.fn() as any,
-        };
-        mockResourceRepo = {
-            findById: mock.fn() as any,
-        };
-        mockGuardianRepo = {
-            findByResourceId: mock.fn() as any,
-        };
+  beforeEach(() => {
+    mockApprovalRepo = {
+      create: mock.fn() as any,
+      findById: mock.fn() as any,
+      updateStatus: mock.fn() as any,
+      findActiveByRequester: mock.fn() as any,
+    };
+    mockResourceRepo = {
+      findById: mock.fn() as any,
+    };
+    mockGuardianRepo = {
+      findByResourceId: mock.fn() as any,
+    };
 
-        mockRepositories = {
-            approvalRequests: mockApprovalRepo as ApprovalRequestRepository,
-            resources: mockResourceRepo as ResourceRepository,
-            guardians: mockGuardianRepo as GuardianRepository,
-        } as Repositories;
+    mockRepositories = {
+      approvalRequests: mockApprovalRepo as ApprovalRequestRepository,
+      resources: mockResourceRepo as ResourceRepository,
+      guardians: mockGuardianRepo as GuardianRepository,
+    } as Repositories;
 
-        const deps: ServiceDependencies = { repositories: mockRepositories };
-        approvalService = new ApprovalService(deps);
+    const deps: ServiceDependencies = { repositories: mockRepositories };
+    approvalService = new ApprovalService(deps);
+  });
+
+  describe('findActiveApproval', () => {
+    it('should call repository.findActiveByRequester', async () => {
+      const resourceId = 'res-1';
+      const requesterId = 'user-1';
+      const mockRequest = { id: 'req-1', status: 'PENDING' };
+
+      (mockApprovalRepo.findActiveByRequester as any).mock.mockImplementation(
+        async () => mockRequest
+      );
+
+      const result = await approvalService.findActiveApproval(resourceId, requesterId);
+
+      assert.strictEqual(result, mockRequest);
+      assert.strictEqual((mockApprovalRepo.findActiveByRequester as any).mock.calls.length, 1);
+      assert.deepStrictEqual(
+        (mockApprovalRepo.findActiveByRequester as any).mock.calls[0].arguments,
+        [resourceId, requesterId]
+      );
     });
+  });
 
-    describe('findActiveApproval', () => {
-        it('should call repository.findActiveByRequester', async () => {
-            const resourceId = 'res-1';
-            const requesterId = 'user-1';
-            const mockRequest = { id: 'req-1', status: 'PENDING' };
+  describe('recordDecision', () => {
+    it('should succeed even if audit logging throws an error', async () => {
+      const mockRequest = {
+        id: 'req-1',
+        status: 'PENDING',
+        resourceId: 'res-1',
+        context: { requesterId: 'requester-1' },
+      };
+      mockApprovalRepo.findById = mock.fn(async () => mockRequest) as any;
+      mockApprovalRepo.updateStatus = mock.fn(async () => {}) as any;
+      mockGuardianRepo.findByResourceAndUser = mock.fn(async () => ({
+        id: 'g-1',
+        role: 'OWNER',
+      })) as any;
 
-            (mockApprovalRepo.findActiveByRequester as any).mock.mockImplementation(async () => mockRequest);
+      const failingAuditService = {
+        log: mock.fn(async () => {
+          throw new Error('Audit service unavailable');
+        }),
+      };
 
-            const result = await approvalService.findActiveApproval(resourceId, requesterId);
+      const deps: ServiceDependencies = {
+        repositories: mockRepositories,
+        audit: failingAuditService as any,
+      };
+      const svc = new ApprovalService(deps);
 
-            assert.strictEqual(result, mockRequest);
-            assert.strictEqual((mockApprovalRepo.findActiveByRequester as any).mock.calls.length, 1);
-            assert.deepStrictEqual((mockApprovalRepo.findActiveByRequester as any).mock.calls[0].arguments, [resourceId, requesterId]);
-        });
+      const result = await svc.recordDecision('req-1', 'APPROVE', 'guardian-1');
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual((mockApprovalRepo.updateStatus as any).mock.calls.length, 1);
+      assert.strictEqual(failingAuditService.log.mock.calls.length, 1);
     });
+  });
 });

--- a/apps/purrmission-bot/src/domain/services.test.ts
+++ b/apps/purrmission-bot/src/domain/services.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert';
 import { ResourceService, ApprovalService, type ServiceDependencies } from './services.js';
-import { AuditService } from './audit.js';
 import {
   type GuardianRepository,
   type ResourceRepository,
@@ -154,7 +153,7 @@ describe('ResourceService', () => {
   });
 
   describe('linkTOTPAccount', () => {
-    it('should succeed even if audit logging repository throws an error', async () => {
+    it('should succeed even if audit logging throws an error', async () => {
       const mockResource = { id: resourceId, totpAccountId: null };
       const mockTotpAccount = { id: 'totp-1' };
       const mockTotpRepo = {
@@ -163,23 +162,18 @@ describe('ResourceService', () => {
       mockResourceRepo.findById = mock.fn(async () => mockResource) as any;
       mockResourceRepo.update = mock.fn(async () => mockResource) as any;
 
-      const failingAuditRepo = {
-        create: mock.fn(async () => {
-          throw new Error('Audit repository failed');
+      const failingAuditService = {
+        log: mock.fn(async () => {
+          throw new Error('Audit service unavailable');
         }),
       };
-      const realAuditService = new AuditService({
-        repositories: {
-          audit: failingAuditRepo as any,
-        },
-      } as any);
 
       const deps: ServiceDependencies = {
         repositories: {
           ...mockRepositories,
           totp: mockTotpRepo as any,
         },
-        audit: realAuditService,
+        audit: failingAuditService as any,
       };
       const svc = new ResourceService(deps);
 
@@ -187,7 +181,7 @@ describe('ResourceService', () => {
       await svc.linkTOTPAccount(resourceId, 'totp-1', ownerId);
 
       assert.strictEqual((mockResourceRepo.update as any).mock.calls.length, 1);
-      assert.strictEqual(failingAuditRepo.create.mock.calls.length, 1);
+      assert.strictEqual(failingAuditService.log.mock.calls.length, 1);
     });
   });
 });
@@ -245,7 +239,7 @@ describe('ApprovalService', () => {
   });
 
   describe('recordDecision', () => {
-    it('should succeed even if audit logging repository throws an error', async () => {
+    it('should succeed even if audit logging throws an error', async () => {
       const mockRequest = {
         id: 'req-1',
         status: 'PENDING',
@@ -259,20 +253,15 @@ describe('ApprovalService', () => {
         role: 'OWNER',
       })) as any;
 
-      const failingAuditRepo = {
-        create: mock.fn(async () => {
-          throw new Error('Audit repository failed');
+      const failingAuditService = {
+        log: mock.fn(async () => {
+          throw new Error('Audit service unavailable');
         }),
       };
-      const realAuditService = new AuditService({
-        repositories: {
-          audit: failingAuditRepo as any,
-        },
-      } as any);
 
       const deps: ServiceDependencies = {
         repositories: mockRepositories,
-        audit: realAuditService,
+        audit: failingAuditService as any,
       };
       const svc = new ApprovalService(deps);
 
@@ -280,7 +269,7 @@ describe('ApprovalService', () => {
 
       assert.strictEqual(result.success, true);
       assert.strictEqual((mockApprovalRepo.updateStatus as any).mock.calls.length, 1);
-      assert.strictEqual(failingAuditRepo.create.mock.calls.length, 1);
+      assert.strictEqual(failingAuditService.log.mock.calls.length, 1);
     });
   });
 });

--- a/apps/purrmission-bot/src/domain/services.test.ts
+++ b/apps/purrmission-bot/src/domain/services.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert';
 import { ResourceService, ApprovalService, type ServiceDependencies } from './services.js';
+import { AuditService } from './audit.js';
 import {
   type GuardianRepository,
   type ResourceRepository,
@@ -153,7 +154,7 @@ describe('ResourceService', () => {
   });
 
   describe('linkTOTPAccount', () => {
-    it('should succeed even if audit logging throws an error', async () => {
+    it('should succeed even if audit logging repository throws an error', async () => {
       const mockResource = { id: resourceId, totpAccountId: null };
       const mockTotpAccount = { id: 'totp-1' };
       const mockTotpRepo = {
@@ -162,18 +163,23 @@ describe('ResourceService', () => {
       mockResourceRepo.findById = mock.fn(async () => mockResource) as any;
       mockResourceRepo.update = mock.fn(async () => mockResource) as any;
 
-      const failingAuditService = {
-        log: mock.fn(async () => {
-          throw new Error('Audit service unavailable');
+      const failingAuditRepo = {
+        create: mock.fn(async () => {
+          throw new Error('Audit repository failed');
         }),
       };
+      const realAuditService = new AuditService({
+        repositories: {
+          audit: failingAuditRepo as any,
+        },
+      } as any);
 
       const deps: ServiceDependencies = {
         repositories: {
           ...mockRepositories,
           totp: mockTotpRepo as any,
         },
-        audit: failingAuditService as any,
+        audit: realAuditService,
       };
       const svc = new ResourceService(deps);
 
@@ -181,7 +187,7 @@ describe('ResourceService', () => {
       await svc.linkTOTPAccount(resourceId, 'totp-1', ownerId);
 
       assert.strictEqual((mockResourceRepo.update as any).mock.calls.length, 1);
-      assert.strictEqual(failingAuditService.log.mock.calls.length, 1);
+      assert.strictEqual(failingAuditRepo.create.mock.calls.length, 1);
     });
   });
 });
@@ -239,7 +245,7 @@ describe('ApprovalService', () => {
   });
 
   describe('recordDecision', () => {
-    it('should succeed even if audit logging throws an error', async () => {
+    it('should succeed even if audit logging repository throws an error', async () => {
       const mockRequest = {
         id: 'req-1',
         status: 'PENDING',
@@ -253,15 +259,20 @@ describe('ApprovalService', () => {
         role: 'OWNER',
       })) as any;
 
-      const failingAuditService = {
-        log: mock.fn(async () => {
-          throw new Error('Audit service unavailable');
+      const failingAuditRepo = {
+        create: mock.fn(async () => {
+          throw new Error('Audit repository failed');
         }),
       };
+      const realAuditService = new AuditService({
+        repositories: {
+          audit: failingAuditRepo as any,
+        },
+      } as any);
 
       const deps: ServiceDependencies = {
         repositories: mockRepositories,
-        audit: failingAuditService as any,
+        audit: realAuditService,
       };
       const svc = new ApprovalService(deps);
 
@@ -269,7 +280,7 @@ describe('ApprovalService', () => {
 
       assert.strictEqual(result.success, true);
       assert.strictEqual((mockApprovalRepo.updateStatus as any).mock.calls.length, 1);
-      assert.strictEqual(failingAuditService.log.mock.calls.length, 1);
+      assert.strictEqual(failingAuditRepo.create.mock.calls.length, 1);
     });
   });
 });

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -216,21 +216,14 @@ export class ApprovalService {
     }
 
     // Audit log
-    try {
-      await this.deps.audit?.log({
-        action: 'APPROVAL_DECISION',
-        resourceId: request.resourceId,
-        actorId: requesterId,
-        resolverId: byGuardianDiscordId,
-        status: newStatus,
-        context: JSON.stringify({ requestId, decision, originalContext: request.context }),
-      });
-    } catch (error) {
-      logger.warn('Failed to record audit log for approval decision', {
-        requestId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    await this.deps.audit?.log({
+      action: 'APPROVAL_DECISION',
+      resourceId: request.resourceId,
+      actorId: requesterId,
+      resolverId: byGuardianDiscordId,
+      status: newStatus,
+      context: JSON.stringify({ requestId, decision, originalContext: request.context }),
+    });
 
     // Prepare callback action if URL is configured
     const result: DecisionResult = {
@@ -500,21 +493,13 @@ export class ResourceService {
       totpAccountId,
     });
 
-    try {
-      await this.deps.audit?.log({
-        action: 'TOTP_LINKED',
-        resourceId,
-        actorId,
-        status: 'SUCCESS',
-        context: JSON.stringify({ totpAccountId }),
-      });
-    } catch (error) {
-      logger.warn('Failed to record audit log for linking TOTP account', {
-        resourceId,
-        totpAccountId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    await this.deps.audit?.log({
+      action: 'TOTP_LINKED',
+      resourceId,
+      actorId,
+      status: 'SUCCESS',
+      context: JSON.stringify({ totpAccountId }),
+    });
   }
 
   /**

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -216,14 +216,21 @@ export class ApprovalService {
     }
 
     // Audit log
-    await this.deps.audit?.log({
-      action: 'APPROVAL_DECISION',
-      resourceId: request.resourceId,
-      actorId: requesterId,
-      resolverId: byGuardianDiscordId,
-      status: newStatus,
-      context: JSON.stringify({ requestId, decision, originalContext: request.context }),
-    });
+    try {
+      await this.deps.audit?.log({
+        action: 'APPROVAL_DECISION',
+        resourceId: request.resourceId,
+        actorId: requesterId,
+        resolverId: byGuardianDiscordId,
+        status: newStatus,
+        context: JSON.stringify({ requestId, decision, originalContext: request.context }),
+      });
+    } catch (error) {
+      logger.warn('Failed to record audit log for approval decision', {
+        requestId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     // Prepare callback action if URL is configured
     const result: DecisionResult = {
@@ -493,13 +500,21 @@ export class ResourceService {
       totpAccountId,
     });
 
-    await this.deps.audit?.log({
-      action: 'TOTP_LINKED',
-      resourceId,
-      actorId,
-      status: 'SUCCESS',
-      context: JSON.stringify({ totpAccountId }),
-    });
+    try {
+      await this.deps.audit?.log({
+        action: 'TOTP_LINKED',
+        resourceId,
+        actorId,
+        status: 'SUCCESS',
+        context: JSON.stringify({ totpAccountId }),
+      });
+    } catch (error) {
+      logger.warn('Failed to record audit log for linking TOTP account', {
+        resourceId,
+        totpAccountId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Context
Currently, audit logging calls are awaited directly in `ApprovalService` and `ResourceService`. If the audit service itself fails (such as database connectivity issues), it can fail the primary business operation (e.g. recording approval decision or linking TOTP).

## Changes
- Wrapped `this.deps.audit?.log` calls in both services inside try/catch blocks.
- Logged any audit logging failure as warnings using `logger.warn` to preserve original error context without throwing.
- Added comprehensive unit tests in `services.test.ts` checking both `recordDecision` and `linkTOTPAccount` flows to assert they complete successfully even if the audit log function fails.

Closes #30