### PR TITLE
chore(cli): bump pawthy version to 0.4.1

### DIFF
--- a/apps/pawthy/package.json
+++ b/apps/pawthy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuasha420/pawthy",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Credential Sync CLI for Purrmission",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR bumps the pawthy CLI package version to 0.4.1 for patch release.