### PR TITLE
feat: Unify ProjectMember and Guardian permission systems

### DIFF
--- a/apps/purrmission-bot/src/discord/client.ts
+++ b/apps/purrmission-bot/src/discord/client.ts
@@ -21,6 +21,7 @@ import { handleSlashCommand, handleAutocomplete } from './commands/index.js';
 import { handleApprovalButton } from './interactions/approvalButtons.js';
 
 import type { Repositories } from '../domain/repositories.js';
+import { getGuardedResourcesForUser } from '../domain/policy.js';
 
 /**
  * Dependencies for the Discord client.
@@ -169,33 +170,18 @@ export function createDiscordClient(deps: DiscordClientDeps): Client {
         const userId = message.author.id;
 
         // Fetch resources guarded by this user
-        const guardianships = await deps.repositories.guardians.findByUserId(userId);
-
-        // Deduplicate resource IDs
-        const resourceIds = Array.from(new Set(guardianships.map((g) => g.resourceId)));
+        const validResources = await getGuardedResourcesForUser(deps.repositories, userId);
+        const resourceIds = validResources.map((r) => r.id);
 
         let guardedList = '_None. You are not registered as a guardian for any resources._';
         let pendingList = '_No pending approval requests waiting for you._';
 
-        if (resourceIds.length > 0) {
-          // Fetch resources details
-          const resources = await Promise.all(
-            resourceIds.map(async (id) => {
-              const res = await deps.repositories.resources.findById(id);
-              return res;
-            })
-          );
-
-          // Use type guard to safely filter and narrow type
-          const validResources = resources.filter((r): r is NonNullable<typeof r> => !!r);
-
+        if (validResources.length > 0) {
           const maxDisplay = 15;
-          if (validResources.length > 0) {
-            const displayedResources = validResources.slice(0, maxDisplay);
-            guardedList = displayedResources.map((r) => `- **${r.name}** (\`${r.id}\`)`).join('\n');
-            if (validResources.length > maxDisplay) {
-              guardedList += `\n_...and ${validResources.length - maxDisplay} more resources_`;
-            }
+          const displayedResources = validResources.slice(0, maxDisplay);
+          guardedList = displayedResources.map((r) => `- **${r.name}** (\`${r.id}\`)`).join('\n');
+          if (validResources.length > maxDisplay) {
+            guardedList += `\n_...and ${validResources.length - maxDisplay} more resources_`;
           }
 
           // Fetch pending approval requests for these resources

--- a/apps/purrmission-bot/src/discord/commands/addGuardian.ts
+++ b/apps/purrmission-bot/src/discord/commands/addGuardian.ts
@@ -41,7 +41,7 @@ export async function handleAddGuardian(
   // }
 
   try {
-    const result = await services.resource.addGuardian(resourceId, targetUser.id);
+    const result = await services.resource.addGuardian(resourceId, targetUser.id, callerId);
 
     if (!result.success) {
       await interaction.reply({

--- a/apps/purrmission-bot/src/discord/commands/guardian.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/guardian.test.ts
@@ -13,7 +13,8 @@ interface MockServices {
   resource: {
     addGuardian: (
       resourceId: string,
-      userId: string
+      userId: string,
+      actorId: string
     ) => Promise<{ success: boolean; guardian?: { id: string; role: string } }>;
     removeGuardian: (
       resourceId: string,
@@ -35,7 +36,7 @@ describe('handleGuardianCommand', () => {
   let mockInteraction: Partial<ChatInputCommandInteraction>;
   let mockOptions: CommandInteractionOptionResolver<CacheType>;
   let mockContext: CommandContext;
-  let addGuardianCalls: { resourceId: string; userId: string }[] = [];
+  let addGuardianCalls: { resourceId: string; userId: string; actorId: string }[] = [];
   let removeGuardianCalls: { resourceId: string; targetUserId: string; actorId: string }[] = [];
   let listGuardiansCalls: { resourceId: string; actorId: string }[] = [];
   let replyCalls: unknown[] = [];
@@ -76,8 +77,8 @@ describe('handleGuardianCommand', () => {
     mockContext = {
       services: {
         resource: {
-          addGuardian: async (resourceId: string, userId: string) => {
-            addGuardianCalls.push({ resourceId, userId });
+          addGuardian: async (resourceId: string, userId: string, actorId: string) => {
+            addGuardianCalls.push({ resourceId, userId, actorId });
             // simulate success so handleAddGuardian completes
             return { success: true, guardian: { id: 'g-1', role: 'GUARDIAN' } };
           },
@@ -113,6 +114,7 @@ describe('handleGuardianCommand', () => {
     assert.deepStrictEqual(addGuardianCalls[0], {
       resourceId: 'res-123',
       userId: 'target-user-id',
+      actorId: 'caller-id',
     });
 
     // Also verify the success reply from handleAddGuardian to be sure

--- a/apps/purrmission-bot/src/discord/commands/resource.ts
+++ b/apps/purrmission-bot/src/discord/commands/resource.ts
@@ -21,7 +21,12 @@ import {
   createAccessRequestEmbed,
 } from '../interactions/approvalButtons.js';
 import { rateLimiter } from '../../infra/rateLimit.js';
-import { checkAccessPolicy, requiresApproval } from '../../domain/policy.js';
+import {
+  checkAccessPolicy,
+  requiresApproval,
+  getEffectiveGuardians,
+  isEffectiveGuardian,
+} from '../../domain/policy.js';
 import { handleResourceIdAutocomplete } from './resourceAutocomplete.js';
 
 const MAX_RESOURCE_NAME_LENGTH = 100;
@@ -340,9 +345,7 @@ async function isOwnerOrGuardian(
   resourceId: string,
   discordUserId: string
 ): Promise<boolean> {
-  const { guardians } = context.repositories;
-  const guardian = await guardians.findByResourceAndUser(resourceId, discordUserId);
-  return guardian !== null;
+  return isEffectiveGuardian(context.repositories, resourceId, discordUserId);
 }
 
 /**
@@ -637,7 +640,7 @@ async function handleFieldsGet(
   }
 
   // Check access policy
-  const guardians = await context.repositories.guardians.findByResourceId(resourceId);
+  const guardians = await getEffectiveGuardians(context.repositories, resourceId);
   const accessResult = await checkAccessPolicy(resource, guardians, userId, context.repositories);
 
   if (requiresApproval(accessResult)) {
@@ -952,7 +955,7 @@ async function handleGet2FA(
   }
 
   // Check access policy
-  const guardians = await context.repositories.guardians.findByResourceId(resourceId);
+  const guardians = await getEffectiveGuardians(context.repositories, resourceId);
   const accessResult = await checkAccessPolicy(resource, guardians, userId, context.repositories);
 
   if (requiresApproval(accessResult)) {

--- a/apps/purrmission-bot/src/discord/commands/resource.ts
+++ b/apps/purrmission-bot/src/discord/commands/resource.ts
@@ -26,6 +26,8 @@ import {
   requiresApproval,
   getEffectiveGuardians,
   isEffectiveGuardian,
+  getGuardedResourcesForUser,
+  isEffectiveOwner,
 } from '../../domain/policy.js';
 import { handleResourceIdAutocomplete } from './resourceAutocomplete.js';
 
@@ -512,11 +514,19 @@ async function handleResourceList(
   context: CommandContext
 ): Promise<void> {
   const userId = interaction.user.id;
-  const { guardians, resources } = context.repositories;
 
-  const userGuardianships = await guardians.findByUserId(userId);
+  const validResources = await getGuardedResourcesForUser(context.repositories, userId);
 
-  if (userGuardianships.length === 0) {
+  if (validResources.length === 0) {
+    const explicitGuardians = await context.repositories.guardians.findByUserId(userId);
+    if (explicitGuardians && explicitGuardians.length > 0) {
+      await interaction.reply({
+        content: 'You do not own or guard any resources (orphaned records found).',
+        ephemeral: true,
+      });
+      return;
+    }
+
     await interaction.reply({
       content: 'You do not own or guard any resources yet.',
       ephemeral: true,
@@ -524,34 +534,12 @@ async function handleResourceList(
     return;
   }
 
-  const resourceIds = userGuardianships.map((g) => g.resourceId);
-  const validResources = await resources.findManyByIds(resourceIds);
-
-  if (validResources.length === 0) {
-    // This might happen if guardianships exist but resources were deleted (orphan records)
-    // Ideally shouldn't happen with proper cascade delete, but good to handle.
-    await interaction.reply({
-      content: 'You do not own or guard any resources (orphaned records found).',
-      ephemeral: true,
-    });
-    return;
+  const lines = ['**📋 Your Resources:**', ''];
+  for (const r of validResources) {
+    const isOwner = await isEffectiveOwner(context.repositories, r.id, userId);
+    const roleBadge = isOwner ? '👑 Owner' : '🛡️ Guardian';
+    lines.push(`• **${r.name}** (\`${r.id}\`) — ${roleBadge}`);
   }
-
-  // Create a map to look up guardian role for each resource
-  const roleMap = new Map<string, string>();
-  userGuardianships.forEach((g) => {
-    roleMap.set(g.resourceId, g.role);
-  });
-
-  const lines = [
-    '**📋 Your Resources:**',
-    '',
-    ...validResources.map((r) => {
-      const role = roleMap.get(r.id);
-      const roleBadge = role === 'OWNER' ? '👑 Owner' : '🛡️ Guardian';
-      return `• **${r.name}** (\`${r.id}\`) — ${roleBadge}`;
-    }),
-  ];
 
   await interaction.reply({
     content: lines.join('\n'),
@@ -1056,7 +1044,7 @@ async function createFieldAccessRequest(
   fieldName: string,
   requesterId: string
 ): Promise<void> {
-  const { guardians, resourceFields } = context.repositories;
+  const { resourceFields } = context.repositories;
   const { approval } = context.services;
 
   // Validate field still exists before creating approval request (prevent race condition)
@@ -1093,7 +1081,7 @@ async function createFieldAccessRequest(
   }
 
   // Get guardians to notify
-  const resourceGuardians = await guardians.findByResourceId(resourceId);
+  const resourceGuardians = await getEffectiveGuardians(context.repositories, resourceId);
 
   // Send approval requests to guardians via DM (in parallel)
   const embed = createAccessRequestEmbed(resourceName, accessContext, result.request.expiresAt);
@@ -1162,7 +1150,6 @@ async function create2FAAccessRequest(
   resourceId: string,
   requesterId: string
 ): Promise<void> {
-  const { guardians } = context.repositories;
   const { approval, resource: resourceService } = context.services;
 
   // Validate TOTP account still linked before creating approval request (prevent race condition)
@@ -1198,7 +1185,7 @@ async function create2FAAccessRequest(
   }
 
   // Get guardians to notify
-  const resourceGuardians = await guardians.findByResourceId(resourceId);
+  const resourceGuardians = await getEffectiveGuardians(context.repositories, resourceId);
 
   // Send approval requests to guardians via DM (in parallel)
   const embed = createAccessRequestEmbed(resourceName, accessContext, result.request.expiresAt);

--- a/apps/purrmission-bot/src/discord/commands/resourceAutocomplete.ts
+++ b/apps/purrmission-bot/src/discord/commands/resourceAutocomplete.ts
@@ -1,6 +1,7 @@
 import type { AutocompleteInteraction } from 'discord.js';
 
 import type { CommandContext } from './context.js';
+import { getGuardedResourcesForUser } from '../../domain/policy.js';
 
 const MAX_AUTOCOMPLETE_RESULTS = 25;
 
@@ -16,19 +17,17 @@ export async function handleResourceIdAutocomplete(
 
   const query = String(focusedOption.value).trim().toLowerCase();
   const userId = interaction.user.id;
-  const { guardians, resources } = context.repositories;
 
-  const resourceIds = [...new Set((await guardians.findByUserId(userId)).map((g) => g.resourceId))];
+  const guardedResources = await getGuardedResourcesForUser(context.repositories, userId, query);
 
-  if (resourceIds.length === 0) {
+  if (guardedResources.length === 0) {
     await interaction.respond([]);
     return true;
   }
 
-  const matchedResources = await resources.findManyByIds(resourceIds, query);
   const filteredResources = query
-    ? matchedResources.filter((resource) => resource.name.toLowerCase().includes(query))
-    : matchedResources;
+    ? guardedResources.filter((resource) => resource.name.toLowerCase().includes(query))
+    : guardedResources;
 
   await interaction.respond(
     filteredResources.slice(0, MAX_AUTOCOMPLETE_RESULTS).map((resource) => ({

--- a/apps/purrmission-bot/src/domain/policy.test.ts
+++ b/apps/purrmission-bot/src/domain/policy.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { checkAccessPolicy, requiresApproval } from './policy.js';
+import {
+  checkAccessPolicy,
+  requiresApproval,
+  getEffectiveGuardians,
+  isEffectiveGuardian,
+  getGuardedResourcesForUser,
+  isEffectiveOwner,
+} from './policy.js';
 import type { Resource, Guardian, ApprovalRequest } from './models.js';
 import type { Repositories, ApprovalRequestRepository } from './repositories.js';
 
@@ -144,5 +151,215 @@ describe('Access Policy', () => {
     );
     assert.equal(result.allowed, false);
     assert.equal(result.requiresApproval, true);
+  });
+
+  describe('Effective Guardians and Unified Permissions', () => {
+    const mockRes1: Resource = {
+      id: 'env-res-1',
+      name: 'Project1:dev',
+      mode: 'ONE_OF_N',
+      apiKey: 'key1',
+      createdAt: new Date(),
+    };
+
+    const mockRes2: Resource = {
+      id: 'standalone-res-1',
+      name: 'Standalone Res',
+      mode: 'ONE_OF_N',
+      apiKey: 'key2',
+      createdAt: new Date(),
+    };
+
+    const projectOwnerId = 'user-project-owner';
+    const writerMemberId = 'user-project-writer';
+    const readerMemberId = 'user-project-reader';
+    const explicitGuardianId = 'user-explicit-guardian';
+
+    const mockProject = {
+      id: 'project-1',
+      name: 'Project 1',
+      ownerId: projectOwnerId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const mockEnv = {
+      id: 'env-1',
+      name: 'Dev',
+      slug: 'dev',
+      projectId: 'project-1',
+      resourceId: 'env-res-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const mockExplicitGuardian: Guardian = {
+      id: 'g-explicit',
+      resourceId: 'env-res-1',
+      discordUserId: explicitGuardianId,
+      role: 'GUARDIAN',
+      createdAt: new Date(),
+    };
+
+    const mockRepos = {
+      guardians: {
+        findByResourceId: async (resId: string) => {
+          if (resId === 'env-res-1') return [mockExplicitGuardian];
+          return [];
+        },
+        findByUserId: async (userId: string) => {
+          if (userId === explicitGuardianId) return [mockExplicitGuardian];
+          return [];
+        },
+        findByResourceAndUser: async (resId: string, userId: string) => {
+          if (resId === 'env-res-1' && userId === explicitGuardianId) return mockExplicitGuardian;
+          return null;
+        },
+      },
+      projects: {
+        findEnvironmentByResourceId: async (resId: string) => {
+          if (resId === 'env-res-1') return mockEnv;
+          return null;
+        },
+        findById: async (projId: string) => {
+          if (projId === 'project-1') return mockProject;
+          return null;
+        },
+        listMembers: async (projId: string) => {
+          if (projId === 'project-1') {
+            return [
+              {
+                id: 'm-writer',
+                projectId: 'project-1',
+                userId: writerMemberId,
+                role: 'WRITER',
+                addedBy: 'owner',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+              {
+                id: 'm-reader',
+                projectId: 'project-1',
+                userId: readerMemberId,
+                role: 'READER',
+                addedBy: 'owner',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+            ];
+          }
+          return [];
+        },
+        listEnvironments: async (projId: string) => {
+          if (projId === 'project-1') return [mockEnv];
+          return [];
+        },
+        listProjectsByOwner: async (ownerId: string) => {
+          if (ownerId === projectOwnerId) return [mockProject];
+          return [];
+        },
+        listMembershipsByUser: async (userId: string) => {
+          if (userId === writerMemberId) {
+            return [
+              {
+                id: 'm-writer',
+                projectId: 'project-1',
+                userId: writerMemberId,
+                role: 'WRITER',
+                addedBy: 'owner',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+            ];
+          }
+          if (userId === readerMemberId) {
+            return [
+              {
+                id: 'm-reader',
+                projectId: 'project-1',
+                userId: readerMemberId,
+                role: 'READER',
+                addedBy: 'owner',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+            ];
+          }
+          return [];
+        },
+        getMemberRole: async (projId: string, userId: string) => {
+          if (projId === 'project-1') {
+            if (userId === writerMemberId) return 'WRITER';
+            if (userId === readerMemberId) return 'READER';
+          }
+          return null;
+        },
+      },
+      resources: {
+        findManyByIds: async (ids: string[]) => {
+          const resList = [];
+          if (ids.includes('env-res-1')) resList.push(mockRes1);
+          if (ids.includes('standalone-res-1')) resList.push(mockRes2);
+          return resList;
+        },
+        findById: async (id: string) => {
+          if (id === 'env-res-1') return mockRes1;
+          if (id === 'standalone-res-1') return mockRes2;
+          return null;
+        },
+      },
+    } as unknown as Repositories;
+
+    it('should resolve effective guardians containing explicit, project owner, and writer member', async () => {
+      const guardians = await getEffectiveGuardians(mockRepos, 'env-res-1');
+      assert.equal(guardians.length, 3);
+
+      const explicit = guardians.find((g) => g.discordUserId === explicitGuardianId);
+      assert.ok(explicit);
+      assert.equal(explicit.role, 'GUARDIAN');
+
+      const owner = guardians.find((g) => g.discordUserId === projectOwnerId);
+      assert.ok(owner);
+      assert.equal(owner.role, 'OWNER');
+
+      const writer = guardians.find((g) => g.discordUserId === writerMemberId);
+      assert.ok(writer);
+      assert.equal(writer.role, 'GUARDIAN');
+
+      const reader = guardians.find((g) => g.discordUserId === readerMemberId);
+      assert.equal(reader, undefined);
+    });
+
+    it('should correctly evaluate isEffectiveGuardian', async () => {
+      assert.equal(await isEffectiveGuardian(mockRepos, 'env-res-1', projectOwnerId), true);
+      assert.equal(await isEffectiveGuardian(mockRepos, 'env-res-1', writerMemberId), true);
+      assert.equal(await isEffectiveGuardian(mockRepos, 'env-res-1', explicitGuardianId), true);
+      assert.equal(await isEffectiveGuardian(mockRepos, 'env-res-1', readerMemberId), false);
+      assert.equal(await isEffectiveGuardian(mockRepos, 'env-res-1', 'random-user'), false);
+    });
+
+    it('should retrieve correctly guarded resources for users', async () => {
+      const ownerResources = await getGuardedResourcesForUser(mockRepos, projectOwnerId);
+      assert.equal(ownerResources.length, 1);
+      assert.equal(ownerResources[0].id, 'env-res-1');
+
+      const writerResources = await getGuardedResourcesForUser(mockRepos, writerMemberId);
+      assert.equal(writerResources.length, 1);
+      assert.equal(writerResources[0].id, 'env-res-1');
+
+      const explicitResources = await getGuardedResourcesForUser(mockRepos, explicitGuardianId);
+      assert.equal(explicitResources.length, 1);
+      assert.equal(explicitResources[0].id, 'env-res-1');
+
+      const readerResources = await getGuardedResourcesForUser(mockRepos, readerMemberId);
+      assert.equal(readerResources.length, 0);
+    });
+
+    it('should correctly evaluate isEffectiveOwner', async () => {
+      assert.equal(await isEffectiveOwner(mockRepos, 'env-res-1', projectOwnerId), true);
+      assert.equal(await isEffectiveOwner(mockRepos, 'env-res-1', explicitGuardianId), false); // explicit but role is GUARDIAN
+      assert.equal(await isEffectiveOwner(mockRepos, 'env-res-1', writerMemberId), false);
+      assert.equal(await isEffectiveOwner(mockRepos, 'env-res-1', readerMemberId), false);
+    });
   });
 });

--- a/apps/purrmission-bot/src/domain/policy.test.ts
+++ b/apps/purrmission-bot/src/domain/policy.test.ts
@@ -355,6 +355,29 @@ describe('Access Policy', () => {
       assert.equal(readerResources.length, 0);
     });
 
+    it('should upgrade project owner to OWNER role even if explicitly registered as GUARDIAN', async () => {
+      const explicitGuardianWithOwnerId: Guardian = {
+        id: 'g-owner-explicit',
+        resourceId: 'env-res-1',
+        discordUserId: projectOwnerId,
+        role: 'GUARDIAN', // Lower privilege role
+        createdAt: new Date(),
+      };
+
+      const customRepos = {
+        ...mockRepos,
+        guardians: {
+          ...mockRepos.guardians,
+          findByResourceId: async () => [explicitGuardianWithOwnerId],
+        },
+      } as unknown as Repositories;
+
+      const guardians = await getEffectiveGuardians(customRepos, 'env-res-1');
+      const owner = guardians.find((g) => g.discordUserId === projectOwnerId);
+      assert.ok(owner);
+      assert.equal(owner.role, 'OWNER', 'Should be upgraded to OWNER role');
+    });
+
     it('should correctly evaluate isEffectiveOwner', async () => {
       assert.equal(await isEffectiveOwner(mockRepos, 'env-res-1', projectOwnerId), true);
       assert.equal(await isEffectiveOwner(mockRepos, 'env-res-1', explicitGuardianId), false); // explicit but role is GUARDIAN

--- a/apps/purrmission-bot/src/domain/policy.ts
+++ b/apps/purrmission-bot/src/domain/policy.ts
@@ -1,4 +1,3 @@
-
 /**
  * Policy definition for accessing sensitive resources (Fields, TOTP Codes).
  */
@@ -6,72 +5,232 @@
 import type { Resource, Guardian } from './models.js';
 
 export interface AccessRequest {
-    resourceId: string;
-    actorDiscordId: string;
+  resourceId: string;
+  actorDiscordId: string;
 }
 
 export interface AccessPolicyResult {
-    allowed: boolean;
-    requiresApproval: boolean;
-    reason?: string;
+  allowed: boolean;
+  requiresApproval: boolean;
+  reason?: string;
 }
 
 import type { Repositories } from './repositories.js';
 
 /**
  * Determine if an actor can access a resource.
- * 
+ *
  * Logic:
  * 1. Owners and Guardians have DIRECT access (no approval needed).
  * 2. If an active, approved request exists for the actor -> ALLOWED.
  * 3. Otherwise -> APPROVAL_REQUIRED (or DENIED if functionality limited).
  */
 export async function checkAccessPolicy(
-    resource: Resource,
-    guardians: Guardian[],
-    actorDiscordId: string,
-    repositories?: Repositories
+  resource: Resource,
+  guardians: Guardian[],
+  actorDiscordId: string,
+  repositories?: Repositories
 ): Promise<AccessPolicyResult> {
-    const isGuardian = guardians.some(g => g.discordUserId === actorDiscordId);
+  const isGuardian = guardians.some((g) => g.discordUserId === actorDiscordId);
 
-    if (isGuardian) {
-        return {
-            allowed: true,
-            requiresApproval: false,
-            reason: 'User is a guardian/owner',
-        };
-    }
-
-    if (repositories) {
-        const activeRequest = await repositories.approvalRequests.findActiveByRequester(resource.id, actorDiscordId);
-        if (activeRequest && activeRequest.status === 'APPROVED') {
-            // Check expiry if applicable
-            if (activeRequest.expiresAt && activeRequest.expiresAt < new Date()) {
-                return {
-                    allowed: false,
-                    requiresApproval: true,
-                    reason: 'Previous approval has expired',
-                };
-            }
-
-            return {
-                allowed: true,
-                requiresApproval: false,
-                reason: 'Active approval granted',
-            };
-        }
-    }
-
+  if (isGuardian) {
     return {
-        allowed: false,
-        requiresApproval: true,
-        reason: 'User is not a guardian',
+      allowed: true,
+      requiresApproval: false,
+      reason: 'User is a guardian/owner',
     };
+  }
+
+  if (repositories) {
+    const activeRequest = await repositories.approvalRequests.findActiveByRequester(
+      resource.id,
+      actorDiscordId
+    );
+    if (activeRequest && activeRequest.status === 'APPROVED') {
+      // Check expiry if applicable
+      if (activeRequest.expiresAt && activeRequest.expiresAt < new Date()) {
+        return {
+          allowed: false,
+          requiresApproval: true,
+          reason: 'Previous approval has expired',
+        };
+      }
+
+      return {
+        allowed: true,
+        requiresApproval: false,
+        reason: 'Active approval granted',
+      };
+    }
+  }
+
+  return {
+    allowed: false,
+    requiresApproval: true,
+    reason: 'User is not a guardian',
+  };
 }
 
 /**
  * Helper to check if approval is required.
  */
 export function requiresApproval(result: AccessPolicyResult): boolean {
-    return result.requiresApproval;
+  return result.requiresApproval;
+}
+
+/**
+ * Retrieve the effective list of guardians for a resource (explicit database guardians
+ * + project owner as OWNER + project WRITER members as GUARDIAN).
+ */
+export async function getEffectiveGuardians(
+  repositories: Repositories,
+  resourceId: string
+): Promise<Guardian[]> {
+  // 1. Get explicit guardians from database
+  const explicitGuardians = (await repositories.guardians.findByResourceId(resourceId)) || [];
+
+  // Use a map keyed by discordUserId to deduplicate/override
+  const guardianMap = new Map<string, Guardian>();
+  explicitGuardians.forEach((g) => guardianMap.set(g.discordUserId || g.id, g));
+
+  // 2. Check if resource is linked to an environment
+  const environment = await repositories.projects.findEnvironmentByResourceId(resourceId);
+  if (environment) {
+    const project = await repositories.projects.findById(environment.projectId);
+    if (project) {
+      // Project owner -> OWNER role
+      if (!guardianMap.has(project.ownerId)) {
+        guardianMap.set(project.ownerId, {
+          id: `project-owner-${project.id}-${project.ownerId}`,
+          resourceId,
+          discordUserId: project.ownerId,
+          role: 'OWNER',
+          createdAt: project.createdAt,
+        });
+      }
+
+      // Project members with WRITER -> GUARDIAN role
+      const members = await repositories.projects.listMembers(project.id);
+      const writers = members.filter((m) => m.role === 'WRITER');
+      for (const writer of writers) {
+        if (!guardianMap.has(writer.userId)) {
+          guardianMap.set(writer.userId, {
+            id: `project-member-${writer.id}`,
+            resourceId,
+            discordUserId: writer.userId,
+            role: 'GUARDIAN',
+            createdAt: writer.createdAt,
+          });
+        }
+      }
+    }
+  }
+
+  return Array.from(guardianMap.values());
+}
+
+/**
+ * Check if a user is an effective guardian (explicit or project owner/writer) for a resource.
+ */
+export async function isEffectiveGuardian(
+  repositories: Repositories,
+  resourceId: string,
+  userId: string
+): Promise<boolean> {
+  // 1. Check explicit guardians table for this user first
+  const explicitGuardian = await repositories.guardians.findByResourceAndUser(resourceId, userId);
+  if (explicitGuardian) {
+    return true;
+  }
+
+  // 2. Resolve other effective guardians (project owner, project writer)
+  const environment = await repositories.projects.findEnvironmentByResourceId(resourceId);
+  if (environment) {
+    const project = await repositories.projects.findById(environment.projectId);
+    if (project) {
+      if (project.ownerId === userId) {
+        return true;
+      }
+      const memberRole = await repositories.projects.getMemberRole(project.id, userId);
+      if (memberRole === 'WRITER') {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a user is an effective owner of a resource.
+ */
+export async function isEffectiveOwner(
+  repositories: Repositories,
+  resourceId: string,
+  userId: string
+): Promise<boolean> {
+  // 1. Check explicit guardians table for this user first
+  const explicitGuardian = await repositories.guardians.findByResourceAndUser(resourceId, userId);
+  if (explicitGuardian && explicitGuardian.role === 'OWNER') {
+    return true;
+  }
+
+  // 2. Resolve other effective guardians (project owner)
+  const environment = await repositories.projects.findEnvironmentByResourceId(resourceId);
+  if (environment) {
+    const project = await repositories.projects.findById(environment.projectId);
+    if (project && project.ownerId === userId) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Get all resources that a user effectively guards.
+ */
+export async function getGuardedResourcesForUser(
+  repositories: Repositories,
+  userId: string
+): Promise<Resource[]> {
+  // Use a Map keyed by resourceId to deduplicate
+  const resourceMap = new Map<string, Resource>();
+
+  // 1. Get explicit guarded resources
+  const explicitGuardians = await repositories.guardians.findByUserId(userId);
+  if (explicitGuardians && explicitGuardians.length > 0) {
+    const resourceIds = explicitGuardians
+      .map((g) => g.resourceId)
+      .filter((id): id is string => !!id);
+    if (resourceIds.length > 0) {
+      const explicitResources = await repositories.resources.findManyByIds(resourceIds);
+      explicitResources.forEach((r) => resourceMap.set(r.id, r));
+    }
+  }
+
+  // 2. Resolve resources inherited via project ownership
+  const ownedProjects = await repositories.projects.listProjectsByOwner(userId);
+  for (const project of ownedProjects) {
+    const envs = await repositories.projects.listEnvironments(project.id);
+    const resourceIds = envs.map((e) => e.resourceId).filter((id): id is string => !!id);
+    if (resourceIds.length > 0) {
+      const projectResources = await repositories.resources.findManyByIds(resourceIds);
+      projectResources.forEach((r) => resourceMap.set(r.id, r));
+    }
+  }
+
+  // 3. Resolve resources inherited via project writer role
+  const memberships = await repositories.projects.listMembershipsByUser(userId);
+  const writerProjectIds = memberships.filter((m) => m.role === 'WRITER').map((m) => m.projectId);
+  for (const projectId of writerProjectIds) {
+    const envs = await repositories.projects.listEnvironments(projectId);
+    const resourceIds = envs.map((e) => e.resourceId).filter((id): id is string => !!id);
+    if (resourceIds.length > 0) {
+      const projectResources = await repositories.resources.findManyByIds(resourceIds);
+      projectResources.forEach((r) => resourceMap.set(r.id, r));
+    }
+  }
+
+  return Array.from(resourceMap.values());
 }

--- a/apps/purrmission-bot/src/domain/policy.ts
+++ b/apps/purrmission-bot/src/domain/policy.ts
@@ -98,8 +98,9 @@ export async function getEffectiveGuardians(
   if (environment) {
     const project = await repositories.projects.findById(environment.projectId);
     if (project) {
-      // Project owner -> OWNER role
-      if (!guardianMap.has(project.ownerId)) {
+      // Project owner -> OWNER role (upgrade if they only have GUARDIAN role explicitly)
+      const existingOwner = guardianMap.get(project.ownerId);
+      if (!existingOwner || existingOwner.role !== 'OWNER') {
         guardianMap.set(project.ownerId, {
           id: `project-owner-${project.id}-${project.ownerId}`,
           resourceId,
@@ -199,37 +200,39 @@ export async function getGuardedResourcesForUser(
 
   // 1. Get explicit guarded resources
   const explicitGuardians = await repositories.guardians.findByUserId(userId);
-  if (explicitGuardians && explicitGuardians.length > 0) {
-    const resourceIds = explicitGuardians
-      .map((g) => g.resourceId)
-      .filter((id): id is string => !!id);
-    if (resourceIds.length > 0) {
-      const explicitResources = await repositories.resources.findManyByIds(resourceIds);
-      explicitResources.forEach((r) => resourceMap.set(r.id, r));
-    }
-  }
+  const explicitResourceIds = explicitGuardians
+    ? explicitGuardians.map((g) => g.resourceId).filter((id): id is string => !!id)
+    : [];
 
   // 2. Resolve resources inherited via project ownership
   const ownedProjects = await repositories.projects.listProjectsByOwner(userId);
-  for (const project of ownedProjects) {
-    const envs = await repositories.projects.listEnvironments(project.id);
-    const resourceIds = envs.map((e) => e.resourceId).filter((id): id is string => !!id);
-    if (resourceIds.length > 0) {
-      const projectResources = await repositories.resources.findManyByIds(resourceIds);
-      projectResources.forEach((r) => resourceMap.set(r.id, r));
-    }
-  }
+  const ownedProjectEnvironments = await Promise.all(
+    ownedProjects.map((project) => repositories.projects.listEnvironments(project.id))
+  );
+  const ownedResourceIds = ownedProjectEnvironments
+    .flat()
+    .map((e) => e.resourceId)
+    .filter((id): id is string => !!id);
 
   // 3. Resolve resources inherited via project writer role
   const memberships = await repositories.projects.listMembershipsByUser(userId);
   const writerProjectIds = memberships.filter((m) => m.role === 'WRITER').map((m) => m.projectId);
-  for (const projectId of writerProjectIds) {
-    const envs = await repositories.projects.listEnvironments(projectId);
-    const resourceIds = envs.map((e) => e.resourceId).filter((id): id is string => !!id);
-    if (resourceIds.length > 0) {
-      const projectResources = await repositories.resources.findManyByIds(resourceIds);
-      projectResources.forEach((r) => resourceMap.set(r.id, r));
-    }
+  const writerProjectEnvironments = await Promise.all(
+    writerProjectIds.map((projectId) => repositories.projects.listEnvironments(projectId))
+  );
+  const writerResourceIds = writerProjectEnvironments
+    .flat()
+    .map((e) => e.resourceId)
+    .filter((id): id is string => !!id);
+
+  // Combine all resource IDs and deduplicate before querying
+  const allResourceIds = Array.from(
+    new Set([...explicitResourceIds, ...ownedResourceIds, ...writerResourceIds])
+  );
+
+  if (allResourceIds.length > 0) {
+    const resources = await repositories.resources.findManyByIds(allResourceIds);
+    resources.forEach((r) => resourceMap.set(r.id, r));
   }
 
   return Array.from(resourceMap.values());

--- a/apps/purrmission-bot/src/domain/policy.ts
+++ b/apps/purrmission-bot/src/domain/policy.ts
@@ -91,11 +91,13 @@ export async function getEffectiveGuardians(
 
   // Use a map keyed by discordUserId to deduplicate/override
   const guardianMap = new Map<string, Guardian>();
-  explicitGuardians.forEach((g) => guardianMap.set(g.discordUserId || g.id, g));
+  explicitGuardians.forEach((g) => guardianMap.set(g.discordUserId, g));
 
   // 2. Check if resource is linked to an environment
-  const environment = await repositories.projects.findEnvironmentByResourceId(resourceId);
-  if (environment) {
+  const environment = repositories.projects
+    ? await repositories.projects.findEnvironmentByResourceId(resourceId)
+    : null;
+  if (environment && repositories.projects) {
     const project = await repositories.projects.findById(environment.projectId);
     if (project) {
       // Project owner -> OWNER role (upgrade if they only have GUARDIAN role explicitly)
@@ -139,14 +141,22 @@ export async function isEffectiveGuardian(
   userId: string
 ): Promise<boolean> {
   // 1. Check explicit guardians table for this user first
-  const explicitGuardian = await repositories.guardians.findByResourceAndUser(resourceId, userId);
+  let explicitGuardian = null;
+  if (repositories.guardians.findByResourceAndUser) {
+    explicitGuardian = await repositories.guardians.findByResourceAndUser(resourceId, userId);
+  } else if (repositories.guardians.findByUserId) {
+    const list = await repositories.guardians.findByUserId(userId);
+    explicitGuardian = list.find((g) => g.resourceId === resourceId) || null;
+  }
   if (explicitGuardian) {
     return true;
   }
 
   // 2. Resolve other effective guardians (project owner, project writer)
-  const environment = await repositories.projects.findEnvironmentByResourceId(resourceId);
-  if (environment) {
+  const environment = repositories.projects
+    ? await repositories.projects.findEnvironmentByResourceId(resourceId)
+    : null;
+  if (environment && repositories.projects) {
     const project = await repositories.projects.findById(environment.projectId);
     if (project) {
       if (project.ownerId === userId) {
@@ -171,14 +181,22 @@ export async function isEffectiveOwner(
   userId: string
 ): Promise<boolean> {
   // 1. Check explicit guardians table for this user first
-  const explicitGuardian = await repositories.guardians.findByResourceAndUser(resourceId, userId);
+  let explicitGuardian = null;
+  if (repositories.guardians.findByResourceAndUser) {
+    explicitGuardian = await repositories.guardians.findByResourceAndUser(resourceId, userId);
+  } else if (repositories.guardians.findByUserId) {
+    const list = await repositories.guardians.findByUserId(userId);
+    explicitGuardian = list.find((g) => g.resourceId === resourceId) || null;
+  }
   if (explicitGuardian && explicitGuardian.role === 'OWNER') {
     return true;
   }
 
   // 2. Resolve other effective guardians (project owner)
-  const environment = await repositories.projects.findEnvironmentByResourceId(resourceId);
-  if (environment) {
+  const environment = repositories.projects
+    ? await repositories.projects.findEnvironmentByResourceId(resourceId)
+    : null;
+  if (environment && repositories.projects) {
     const project = await repositories.projects.findById(environment.projectId);
     if (project && project.ownerId === userId) {
       return true;
@@ -193,7 +211,8 @@ export async function isEffectiveOwner(
  */
 export async function getGuardedResourcesForUser(
   repositories: Repositories,
-  userId: string
+  userId: string,
+  query?: string
 ): Promise<Resource[]> {
   // Use a Map keyed by resourceId to deduplicate
   const resourceMap = new Map<string, Resource>();
@@ -205,7 +224,9 @@ export async function getGuardedResourcesForUser(
     : [];
 
   // 2. Resolve resources inherited via project ownership
-  const ownedProjects = await repositories.projects.listProjectsByOwner(userId);
+  const ownedProjects = repositories.projects
+    ? await repositories.projects.listProjectsByOwner(userId)
+    : [];
   const ownedProjectEnvironments = await Promise.all(
     ownedProjects.map((project) => repositories.projects.listEnvironments(project.id))
   );
@@ -215,7 +236,9 @@ export async function getGuardedResourcesForUser(
     .filter((id): id is string => !!id);
 
   // 3. Resolve resources inherited via project writer role
-  const memberships = await repositories.projects.listMembershipsByUser(userId);
+  const memberships = repositories.projects
+    ? await repositories.projects.listMembershipsByUser(userId)
+    : [];
   const writerProjectIds = memberships.filter((m) => m.role === 'WRITER').map((m) => m.projectId);
   const writerProjectEnvironments = await Promise.all(
     writerProjectIds.map((projectId) => repositories.projects.listEnvironments(projectId))
@@ -231,7 +254,7 @@ export async function getGuardedResourcesForUser(
   );
 
   if (allResourceIds.length > 0) {
-    const resources = await repositories.resources.findManyByIds(allResourceIds);
+    const resources = await repositories.resources.findManyByIds(allResourceIds, query);
     resources.forEach((r) => resourceMap.set(r.id, r));
   }
 

--- a/apps/purrmission-bot/src/domain/repositories.mock.ts
+++ b/apps/purrmission-bot/src/domain/repositories.mock.ts
@@ -572,6 +572,19 @@ export class InMemoryProjectRepository implements ProjectRepository {
     }
     return null;
   }
+
+  async findEnvironmentByResourceId(resourceId: string): Promise<Environment | null> {
+    for (const env of this.environments.values()) {
+      if (env.resourceId === resourceId) {
+        return env;
+      }
+    }
+    return null;
+  }
+
+  async listMembershipsByUser(userId: string): Promise<ProjectMember[]> {
+    return Array.from(this.members.values()).filter((m) => m.userId === userId);
+  }
 }
 
 /**

--- a/apps/purrmission-bot/src/domain/repositories.ts
+++ b/apps/purrmission-bot/src/domain/repositories.ts
@@ -227,19 +227,16 @@ export class PrismaResourceRepository implements ResourceRepository {
   }
 
   async findManyByIds(ids: string[], query?: string): Promise<Resource[]> {
-    const rows = await this.prisma.resource.findMany({
-      where: {
-        id: { in: ids },
-        ...(query
-          ? {
-              name: {
-                contains: query,
-                mode: 'insensitive',
-              } as any,
-            }
-          : {}),
-      },
-    });
+    const where: Prisma.ResourceWhereInput = {
+      id: { in: ids },
+    };
+    if (query) {
+      where.name = {
+        contains: query,
+        mode: 'insensitive',
+      } as any;
+    }
+    const rows = await this.prisma.resource.findMany({ where });
     return rows.map((row) => this.mapPrismaToDomain(row));
   }
 

--- a/apps/purrmission-bot/src/domain/repositories.ts
+++ b/apps/purrmission-bot/src/domain/repositories.ts
@@ -8,6 +8,7 @@
  * TODO: Replace in-memory implementations with Postgres/Prisma for production.
  */
 import type { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 import { decryptValue, encryptValue } from '../infra/crypto.js';
 import { logger } from '../logging/logger.js';
@@ -227,18 +228,17 @@ export class PrismaResourceRepository implements ResourceRepository {
   }
 
   async findManyByIds(ids: string[], query?: string): Promise<Resource[]> {
+    const where: any = {
+      id: { in: ids },
+    };
+    if (query) {
+      where.name = {
+        contains: query,
+        mode: 'insensitive',
+      };
+    }
     const rows = await this.prisma.resource.findMany({
-      where: {
-        id: { in: ids },
-        ...(query
-          ? {
-              name: {
-                contains: query,
-                mode: 'insensitive',
-              },
-            }
-          : {}),
-      },
+      where,
     });
     return rows.map((row) => this.mapPrismaToDomain(row));
   }
@@ -850,11 +850,13 @@ export interface ProjectRepository {
   listEnvironments(projectId: string): Promise<Environment[]>;
   findEnvironment(projectId: string, slug: string): Promise<Environment | null>;
   getEnvironmentById(projectId: string, envId: string): Promise<Environment | null>;
+  findEnvironmentByResourceId(resourceId: string): Promise<Environment | null>;
 
   addMember(input: CreateProjectMemberInput): Promise<ProjectMember>;
   removeMember(projectId: string, userId: string): Promise<void>;
   getMemberRole(projectId: string, userId: string): Promise<ProjectMemberRole | null>;
   listMembers(projectId: string): Promise<ProjectMember[]>;
+  listMembershipsByUser(userId: string): Promise<ProjectMember[]>;
 }
 
 export class PrismaAuthRepository implements AuthRepository {
@@ -1159,6 +1161,28 @@ export class PrismaProjectRepository implements ProjectRepository {
       orderBy: { createdAt: 'desc' },
     });
     return members.map((m) => ({
+      ...m,
+      role: m.role as ProjectMemberRole,
+    }));
+  }
+
+  async findEnvironmentByResourceId(resourceId: string): Promise<Environment | null> {
+    const row = await this.prisma.environment.findUnique({
+      where: { resourceId },
+    });
+    if (!row) return null;
+    return {
+      ...row,
+      resourceId: row.resourceId ?? undefined,
+    };
+  }
+
+  async listMembershipsByUser(userId: string): Promise<ProjectMember[]> {
+    const memberships = await this.prisma.projectMember.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+    return memberships.map((m) => ({
       ...m,
       role: m.role as ProjectMemberRole,
     }));

--- a/apps/purrmission-bot/src/domain/services.test.ts
+++ b/apps/purrmission-bot/src/domain/services.test.ts
@@ -101,6 +101,37 @@ describe('ResourceService', () => {
       assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
     });
 
+    it('should fail with custom error if target is a dynamic guardian', async () => {
+      // Mock Actor is Owner, Target is not in guardians table but is in projects membership
+      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
+        async (_rid: string, uid: string) => {
+          if (uid === ownerId)
+            return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
+          return null;
+        }
+      );
+
+      const customProjectsRepo = {
+        findEnvironmentByResourceId: mock.fn(async () => ({ projectId: 'p-1' })),
+        findById: mock.fn(async () => ({ id: 'p-1', ownerId: 'some-other-owner' })),
+        getMemberRole: mock.fn(async () => 'WRITER'),
+      };
+
+      const customRepos = {
+        ...mockRepositories,
+        projects: customProjectsRepo,
+      } as any;
+
+      const customDeps: ServiceDependencies = { repositories: customRepos };
+      const customService = new ResourceService(customDeps);
+
+      const result = await customService.removeGuardian(resourceId, ownerId, otherId);
+
+      assert.strictEqual(result.success, false);
+      assert.match(result.error!, /inherit guardian status/);
+      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
+    });
+
     it('should fail if target is owner', async () => {
       // Mock Actor is Owner, Target is Owner
       (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
@@ -134,8 +165,8 @@ describe('ResourceService', () => {
 
       // Mock List return
       (mockGuardianRepo.findByResourceId as any).mock.mockImplementation(async () => [
-        { id: 'g1', role: 'OWNER' },
-        { id: 'g2', role: 'GUARDIAN' },
+        { id: 'g1', role: 'OWNER', discordUserId: 'owner-id' },
+        { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId },
       ]);
 
       const result = await resourceService.listGuardians(resourceId, guardianId);

--- a/apps/purrmission-bot/src/domain/services.test.ts
+++ b/apps/purrmission-bot/src/domain/services.test.ts
@@ -35,6 +35,9 @@ describe('ResourceService', () => {
     mockRepositories = {
       guardians: mockGuardianRepo as GuardianRepository,
       resources: mockResourceRepo as ResourceRepository,
+      projects: {
+        findEnvironmentByResourceId: mock.fn(async () => null),
+      } as any,
     } as Repositories;
 
     const deps: ServiceDependencies = { repositories: mockRepositories };
@@ -211,6 +214,9 @@ describe('ApprovalService', () => {
       approvalRequests: mockApprovalRepo as ApprovalRequestRepository,
       resources: mockResourceRepo as ResourceRepository,
       guardians: mockGuardianRepo as GuardianRepository,
+      projects: {
+        findEnvironmentByResourceId: mock.fn(async () => null),
+      } as any,
     } as Repositories;
 
     const deps: ServiceDependencies = { repositories: mockRepositories };

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -421,6 +421,14 @@ export class ResourceService {
       targetUserId
     );
     if (!targetGuardian) {
+      const isDynamic = await isEffectiveGuardian(repositories, resourceId, targetUserId);
+      if (isDynamic) {
+        return {
+          success: false,
+          error:
+            'Cannot remove this user directly because they inherit guardian status from a project role (Project Owner or Writer member). Remove them from the project instead.',
+        };
+      }
       return { success: false, error: 'User is not a guardian of this resource.' };
     }
     if (targetGuardian.role === 'OWNER') {

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -23,6 +23,7 @@ import { AuditService } from './audit.js';
 import { AuthService } from './auth.js';
 import { ProjectService } from './project.js';
 import { ResourceNotFoundError, DuplicateError } from './errors.js';
+import { getEffectiveGuardians, isEffectiveGuardian, isEffectiveOwner } from './policy.js';
 
 /**
  * Service dependencies.
@@ -84,7 +85,7 @@ export class ApprovalService {
     }
 
     // Get guardians for the resource
-    const guardians = await repositories.guardians.findByResourceId(input.resourceId);
+    const guardians = await getEffectiveGuardians(repositories, input.resourceId);
     if (guardians.length === 0) {
       return {
         success: false,
@@ -171,23 +172,22 @@ export class ApprovalService {
       };
     }
 
-    // TODO: Verify that the user is actually a guardian for this resource
-    // For MVP, we accept any user but log a warning
-    const guardian = await repositories.guardians.findByResourceAndUser(
+    // Verify that the user is actually a guardian for this resource
+    const isGuardian = await isEffectiveGuardian(
+      repositories,
       request.resourceId,
       byGuardianDiscordId
     );
-    if (!guardian) {
+    if (!isGuardian) {
       logger.warn('Decision made by non-guardian user', {
         requestId,
         discordUserId: byGuardianDiscordId,
         resourceId: request.resourceId,
       });
-      // TODO: In production, reject decisions from non-guardians
-      // return {
-      //   success: false,
-      //   error: 'User is not a guardian for this resource',
-      // };
+      return {
+        success: false,
+        error: 'User is not a guardian for this resource',
+      };
     }
 
     // Update the request status
@@ -300,11 +300,7 @@ export class ResourceService {
    * Check if a user is a guardian (or owner) of a resource.
    */
   async isGuardian(resourceId: string, userId: string): Promise<boolean> {
-    const guardian = await this.deps.repositories.guardians.findByResourceAndUser(
-      resourceId,
-      userId
-    );
-    return !!guardian;
+    return isEffectiveGuardian(this.deps.repositories, resourceId, userId);
   }
 
   /**
@@ -357,7 +353,8 @@ export class ResourceService {
    */
   async addGuardian(
     resourceId: string,
-    discordUserId: string
+    discordUserId: string,
+    actorId: string
   ): Promise<{ success: boolean; guardian?: Guardian; error?: string }> {
     const { repositories } = this.deps;
 
@@ -368,6 +365,12 @@ export class ResourceService {
         success: false,
         error: `Resource not found: ${resourceId}`,
       };
+    }
+
+    // Verify Actor is Owner
+    const hasOwnerAccess = await isEffectiveOwner(repositories, resourceId, actorId);
+    if (!hasOwnerAccess) {
+      return { success: false, error: 'Only the resource owner can add guardians.' };
     }
 
     // Check if user is already a guardian
@@ -407,8 +410,8 @@ export class ResourceService {
     const { repositories } = this.deps;
 
     // Verify Actor is Owner
-    const actorGuardian = await repositories.guardians.findByResourceAndUser(resourceId, actorId);
-    if (!actorGuardian || actorGuardian.role !== 'OWNER') {
+    const hasOwnerAccess = await isEffectiveOwner(repositories, resourceId, actorId);
+    if (!hasOwnerAccess) {
       return { success: false, error: 'Only the resource owner can remove guardians.' };
     }
 
@@ -448,7 +451,7 @@ export class ResourceService {
       return { success: false, error: 'Access denied. You must be a guardian to list guardians.' };
     }
 
-    const guardians = await this.deps.repositories.guardians.findByResourceId(resourceId);
+    const guardians = await getEffectiveGuardians(this.deps.repositories, resourceId);
     return { success: true, guardians };
   }
 
@@ -463,7 +466,7 @@ export class ResourceService {
    * Get guardians for a resource.
    */
   async getGuardians(resourceId: string): Promise<Guardian[]> {
-    return this.deps.repositories.guardians.findByResourceId(resourceId);
+    return getEffectiveGuardians(this.deps.repositories, resourceId);
   }
 
   /**

--- a/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
+++ b/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
@@ -101,6 +101,12 @@ class MemProjectRepo implements ProjectRepository {
   async findEnvironment(projectId: string, slug: string): Promise<Environment | null> {
     return this.environments.find((e) => e.projectId === projectId && e.slug === slug) || null;
   }
+  async findEnvironmentByResourceId(resourceId: string): Promise<Environment | null> {
+    return this.environments.find((e) => e.resourceId === resourceId) || null;
+  }
+  async listMembershipsByUser(userId: string): Promise<ProjectMember[]> {
+    return this.members.filter((m) => m.userId === userId);
+  }
 }
 
 class MemResourceRepo implements ResourceRepository {
@@ -339,7 +345,7 @@ describe('Credential Sync Logic Smoke Test', () => {
 
     // 4. Guardian Access Flow
     // 4a. Add Guardian
-    await services.resource.addGuardian(resource.id, guardianId);
+    await services.resource.addGuardian(resource.id, guardianId, ownerId);
     const isGuardian = await services.resource.isGuardian(resource.id, guardianId);
     assert.strictEqual(isGuardian, true);
 
@@ -390,6 +396,7 @@ describe('Credential Sync Logic Smoke Test', () => {
       projectId: project.id,
     });
     const resourceId = env.resourceId;
+    if (!resourceId) throw new Error('resourceId is not defined');
 
     // Create approval request with default expiration (24h)
     const result = await services.approval.createApprovalRequest({

--- a/scripts/ops.test.ts
+++ b/scripts/ops.test.ts
@@ -6,24 +6,41 @@ import { env } from '../apps/purrmission-bot/src/config/env.js';
 import { backupDatabase } from './backup-db.js';
 
 describe('Operations Scripts', () => {
+  let dummyDbCreated = false;
+  let resolvedDbPath = '';
+
   before(() => {
     // Find where the script thinks the DB is
     const dbUrl = env.DATABASE_URL;
     if (dbUrl.startsWith('file:')) {
-      const dbPath = path.resolve(process.cwd(), dbUrl.slice(5));
-      const dir = path.dirname(dbPath);
+      let dbPath = dbUrl.replace(/^file:/, '');
+      if (dbPath.startsWith('///')) {
+        dbPath = dbPath.slice(2);
+      } else if (dbPath.startsWith('//')) {
+        dbPath = dbPath.slice(1);
+      }
+      dbPath = dbPath.split('?')[0];
+
+      resolvedDbPath = path.resolve(process.cwd(), dbPath);
+      const dir = path.dirname(resolvedDbPath);
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
-      if (!fs.existsSync(dbPath)) {
-        fs.writeFileSync(dbPath, 'dummy data');
+      if (!fs.existsSync(resolvedDbPath)) {
+        fs.writeFileSync(resolvedDbPath, 'dummy data');
+        dummyDbCreated = true;
       }
     }
   });
 
   after(() => {
-    // We could clean up the dummy DB but maybe not if it's the real dev one?
-    // For safety in this environment, we'll just let it be or only delete if we created it.
+    if (dummyDbCreated && resolvedDbPath && fs.existsSync(resolvedDbPath)) {
+      try {
+        fs.unlinkSync(resolvedDbPath);
+      } catch {
+        // ignore
+      }
+    }
   });
 
   describe('backup-db', () => {

--- a/scripts/ops.test.ts
+++ b/scripts/ops.test.ts
@@ -6,51 +6,53 @@ import { env } from '../apps/purrmission-bot/src/config/env.js';
 import { backupDatabase } from './backup-db.js';
 
 describe('Operations Scripts', () => {
+  before(() => {
+    // Find where the script thinks the DB is
+    const dbUrl = env.DATABASE_URL;
+    if (dbUrl.startsWith('file:')) {
+      const dbPath = path.resolve(process.cwd(), dbUrl.slice(5));
+      const dir = path.dirname(dbPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      if (!fs.existsSync(dbPath)) {
+        fs.writeFileSync(dbPath, 'dummy data');
+      }
+    }
+  });
 
+  after(() => {
+    // We could clean up the dummy DB but maybe not if it's the real dev one?
+    // For safety in this environment, we'll just let it be or only delete if we created it.
+  });
 
-    before(() => {
-        // Find where the script thinks the DB is
-        const dbUrl = env.DATABASE_URL;
-        if (dbUrl.startsWith('file:')) {
-            const dbPath = path.resolve(process.cwd(), dbUrl.slice(5));
-            if (!fs.existsSync(dbPath)) {
-                fs.writeFileSync(dbPath, 'dummy data');
-            }
+  describe('backup-db', () => {
+    it('should create a backup file for a valid SQLite DB', async () => {
+      // Mock env.DATABASE_URL if possible, or just rely on existing dev.db if it exists
+      // Since we can't easily mock the 'env' import here without a more complex setup,
+      // we'll assume the function uses the current env.
+      // If DATABASE_URL is not set to a file: path, it will throw.
+
+      try {
+        const backupPath = await backupDatabase();
+        assert.ok(fs.existsSync(backupPath));
+        assert.ok(backupPath.includes('backups'));
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('only supported for SQLite')) {
+          // Skip if not SQLite
+          return;
         }
+        throw err;
+      }
     });
+  });
 
-    after(() => {
-        // We could clean up the dummy DB but maybe not if it's the real dev one?
-        // For safety in this environment, we'll just let it be or only delete if we created it.
+  // rotate-keys.ts is harder to test without a full Prisma mock setup,
+  // but we can verify it exports what we expect and doesn't crash on import.
+  describe('rotate-keys', () => {
+    it('should be importable without side effects', async () => {
+      const module = await import('./rotate-keys.js');
+      assert.ok(module);
     });
-
-    describe('backup-db', () => {
-        it('should create a backup file for a valid SQLite DB', async () => {
-            // Mock env.DATABASE_URL if possible, or just rely on existing dev.db if it exists
-            // Since we can't easily mock the 'env' import here without a more complex setup,
-            // we'll assume the function uses the current env.
-            // If DATABASE_URL is not set to a file: path, it will throw.
-
-            try {
-                const backupPath = await backupDatabase();
-                assert.ok(fs.existsSync(backupPath));
-                assert.ok(backupPath.includes('backups'));
-            } catch (err) {
-                if (err instanceof Error && err.message.includes('only supported for SQLite')) {
-                    // Skip if not SQLite
-                    return;
-                }
-                throw err;
-            }
-        });
-    });
-
-    // rotate-keys.ts is harder to test without a full Prisma mock setup,
-    // but we can verify it exports what we expect and doesn't crash on import.
-    describe('rotate-keys', () => {
-        it('should be importable without side effects', async () => {
-            const module = await import('./rotate-keys.js');
-            assert.ok(module);
-        });
-    });
+  });
 });


### PR DESCRIPTION
### Summary
This Pull Request addresses and resolves #75 by unifying the disconnected `ProjectMember` and `Guardian` permission systems dynamically.

### Why
Previously, the system maintained two disconnected permission graphs:
1. **ProjectMember** (`READER`, `WRITER` roles) controlling CLI secrets sync.
2. **Guardian** (`OWNER`, `GUARDIAN` roles) controlling approval request decisions.

This split caused design debt: a project writer or owner could manage environments and secrets but did not automatically get guardian permissions to approve resource/TOTP access requests, and resource owners did not auto-sync when project ownership changed.

### How
Instead of complex, error-prone database sync state machines, we unified the permissions dynamically at the policy/evaluation layer:
1. **Dynamic Resolution Helpers**:
   - `getEffectiveGuardians`: Resolves both explicit guardians and dynamic project-level guardians (project owner as `OWNER`, project `WRITER` members as `GUARDIAN`).
   - `isEffectiveGuardian`: Checks if a user is an explicit guardian, project owner, or project writer.
   - `isEffectiveOwner`: Checks if a user is an explicit owner or the project owner.
   - `getGuardedResourcesForUser`: Resolves all resources a user has effective guardianship over (explicitly or via project memberships).
2. **Repository API Extensions**:
   - Implemented `findEnvironmentByResourceId` and `listMembershipsByUser` to map resource boundaries to projects and environments.
3. **Command & Handler Integration**:
   - Refactored `/resource` slash commands, `/guardian` commands, dynamic DM status connectivity reports, and Approval/Resource domain services to check effective guards instead of raw database checks.
4. **Testing**:
   - Added exhaustive tests in `policy.test.ts` to verify the resolution behavior under all role variations.
   - Updated existing mock service interfaces, command assertions, and credential sync tests to ensure backward compatibility and type-safety.

Closes #75
