### PR TITLE
chore(lint): Eliminate all remaining ESLint warnings (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.1] - 2025-12-10
 
 ### Added
+
 - Initial Purrmission 2FA MVP for Discord (`@purrfecthq/purrmission-bot`).
 - `/purrmission 2fa` command group:
   - `add`: Store TOTP secrets via URI or Base32 secret.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,11 +1,13 @@
 # Deploying Purrmission
 
 ## Prerequisites
+
 - Node.js v24.10.1+
 - PNPM (v9+) via Corepack
 - PM2 installed globally on the server
 
 ## Setup
+
 1. **Clone/Copy Project**: Ensure the project files are on the server (usually via CI/CD `deploy.yml`).
 2. **Environment Variables**:
    - Create a `.env` file in the **project root directory** (where `package.json` is).
@@ -16,7 +18,7 @@
      - `DATABASE_URL` - Database connection URL (e.g., `file:./data/prod.db`)
      - `ENCRYPTION_KEY` - **Required** - 32-byte hex string (64 hexadecimal characters) for encrypting TOTP secrets and resource fields at rest
    - Generate an encryption key with: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
-   - *Note*: If `ecosystem.config.cjs` sets `cwd: "./"`, the `.env` must be in the root.
+   - _Note_: If `ecosystem.config.cjs` sets `cwd: "./"`, the `.env` must be in the root.
    - **Security**: Keep your `ENCRYPTION_KEY` secure and backed up. Without it, encrypted data cannot be recovered.
 
 ## Data Persistence
@@ -27,16 +29,16 @@ The deployment workflow **aggressively flushes** the target directory on each de
 
 The following are **never deleted** during deployment:
 
-| Pattern | Description |
-|---------|-------------|
-| `.env*` | Environment files (`.env`, `.env.local`, etc.) |
-| `*.db` | SQLite database files |
-| `*.sqlite` | SQLite database files |
-| `*.sqlite3` | SQLite database files |
-| `*.db-*` | SQLite WAL mode sidecars (`-wal`, `-shm`) |
-| `*.sqlite-*` | SQLite WAL mode sidecars |
-| `*.sqlite3-*` | SQLite WAL mode sidecars |
-| `data/` | Persistent data directory (recursive) |
+| Pattern       | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `.env*`       | Environment files (`.env`, `.env.local`, etc.) |
+| `*.db`        | SQLite database files                          |
+| `*.sqlite`    | SQLite database files                          |
+| `*.sqlite3`   | SQLite database files                          |
+| `*.db-*`      | SQLite WAL mode sidecars (`-wal`, `-shm`)      |
+| `*.sqlite-*`  | SQLite WAL mode sidecars                       |
+| `*.sqlite3-*` | SQLite WAL mode sidecars                       |
+| `data/`       | Persistent data directory (recursive)          |
 
 ### Recommended Database Location
 
@@ -56,9 +58,11 @@ This provides a clear separation between code artifacts (which get flushed) and 
 If using PostgreSQL, MySQL, or other external databases, persistence is handled by the database server itself. The `DATABASE_URL` will point to the external service, so deployment flushes have no effect on your data.
 
 ## Running in Production
+
 You can use the provided script or PM2.
 
 ### Using Script
+
 ```bash
 pnpm install
 pnpm build
@@ -67,6 +71,7 @@ pnpm prod:purrmission
 ```
 
 ### Using PM2 (Recommended)
+
 ```bash
 # Ensure deps are installed first
 pnpm install --frozen-lockfile
@@ -87,21 +92,27 @@ pm2 startOrRestart ecosystem.config.cjs
 The bot supports rotating encryption keys or migrating legacy ciphertext to the new `v1:` format.
 
 ### Dry Run (Recommended)
+
 Always run a dry run first to see how many records need updating:
+
 ```bash
 pnpm prod:ops:rotate-keys -- --dry-run
 ```
 
 ### Rotating to a New Key
+
 To rotate to a completely new key:
+
 1. Generate a new key: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
 2. Run rotation:
+
 ```bash
 # Pass old and new keys via CLI or ENV
 export ENCRYPTION_KEY_OLD=<current-key>
 export ENCRYPTION_KEY_NEW=<new-key>
 pnpm prod:ops:rotate-keys -- --from-key $ENCRYPTION_KEY_OLD --to-key $ENCRYPTION_KEY_NEW
 ```
+
 3. Update `.env` with the `ENCRYPTION_KEY_NEW` value as `ENCRYPTION_KEY`.
 4. Restart the bot.
 
@@ -111,10 +122,12 @@ pnpm prod:ops:rotate-keys -- --from-key $ENCRYPTION_KEY_OLD --to-key $ENCRYPTION
 ## Audit Logs
 
 Sensitive application flows (field access, TOTP code retrieval, approval decisions) emit audit events to the `AuditLog` table.
+
 - **Viewing Logs**: Access via Prisma Studio: `pnpm prisma:studio`
 - **Actions Logged**: `APPROVAL_DECISION`, `TOTP_LINKED`, `FIELD_ACCESS_THROTTLED`, `TOTP_ACCESS_THROTTLED`.
 
 ## Troubleshooting
+
 - **`MODULE_NOT_FOUND` (dotenv)**: Ensure `dotenv` is installed in the root `node_modules`.
 - **`Prisma Client` errors**: Run `pnpm prisma:generate`.
 - **Deployment fails silently**: Check `pm2 logs Purrmission`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,7 @@ Purrmission uses **AES-256-GCM** for authenticated encryption of sensitive data 
 - **Legacy Support**: The system recognizes and can decrypt the older `base64(iv):base64(authTag):base64(ciphertext)` format without the version prefix.
 
 ### Key Management
+
 - **Environment**: Keys MUST be stored in the `ENCRYPTION_KEY` environment variable.
 - **Rotation**: Keys can be rotated using `scripts/rotate-keys.ts`.
 - **Loss**: Loss of the `ENCRYPTION_KEY` results in permanent loss of access to encrypted secrets (TOTP keys, etc.).
@@ -19,16 +20,19 @@ Purrmission uses **AES-256-GCM** for authenticated encryption of sensitive data 
 ## Threat Model
 
 ### Mitigated Threats
+
 1. **Database Leak**: If the SQLite database is leaked, sensitive values (TOTP secrets, API keys) remain protected by AES-256-GCM encryption.
 2. **Access Token Spam**: Rate limiting prevents brute-forcing of TOTP codes or field values via Discord commands.
 3. **Misconfiguration**: The application fails to start if the `ENCRYPTION_KEY` is missing or invalid, preventing "silent failures" where data is written unencrypted.
 4. **Malformatted Secrets**: TOTP secrets are automatically sanitized (whitespace removal) upon entry to prevent copy-paste errors from causing generation failures.
 
 ### Operational Guardrails
+
 - **Audit Logging**: All sensitive access is logged to the `AuditLog` table, providing a trail for forensic analysis.
 - **Atomic Rotation**: The key rotation tool performs a backup before writing and verifies every record immediately after update.
 
 ## Best Practices for Operators
+
 - **Backups**: Regularly backup the `.db` files and the `.env` file (containing the encryption key).
 - **Least Privilege**: Only authorized users should have access to the server environment where the encryption key is stored.
 - **Rate Limits**: The bot implements default rate limits (e.g., 10 per minute for sensitive code retrieval). Monitor audit logs for `*_THROTTLED` events as an indicator of potential abuse.

--- a/all_review_comments.md
+++ b/all_review_comments.md
@@ -44,7 +44,10 @@ Code context:
 +      return { success: false, error: 'User is not a guardian of this resource.' };
 +    }
 
-------------------------------------------------------------
+---
+
+---
+
 Comment #2693231044 by gemini-code-assist[bot] on apps/purrmission-bot/src/discord/commands/guardian.test.ts:N/A
 State: N/A | Created: 2026-01-15T07:10:15Z
 
@@ -58,21 +61,24 @@ There's a type mismatch in the `removeGuardianCalls` array definition. The type 
 
 Code context:
 @@ -12,17 +12,23 @@ import type {
- interface MockServices {
-     resource: {
-         addGuardian: (resourceId: string, userId: string) => Promise<{ success: boolean; guardian?: { id: string; role: string } }>;
-+        removeGuardian: (resourceId: string, actorId: string, targetUserId: string) => Promise<{ success: boolean; error?: string }>;
-+        listGuardians: (resourceId: string, actorId: string) => Promise<{ success: boolean; guardians?: { discordUserId: string; role: string }[]; error?: string }>;
-     }
- }
- 
- describe('handlePurrmissionCommand - Guardian Routing', () => {
-     let mockInteraction: Partial<ChatInputCommandInteraction>;
-     let mockContext: CommandContext;
-     let addGuardianCalls: { resourceId: string; userId: string }[] = [];
-+    let removeGuardianCalls: { resourceId: string; userId: string; actorId: string }[] = [];
+interface MockServices {
+resource: {
+addGuardian: (resourceId: string, userId: string) => Promise<{ success: boolean; guardian?: { id: string; role: string } }>;
 
-------------------------------------------------------------
+-        removeGuardian: (resourceId: string, actorId: string, targetUserId: string) => Promise<{ success: boolean; error?: string }>;
+-        listGuardians: (resourceId: string, actorId: string) => Promise<{ success: boolean; guardians?: { discordUserId: string; role: string }[]; error?: string }>;
+      }
+  }
+
+describe('handlePurrmissionCommand - Guardian Routing', () => {
+let mockInteraction: Partial<ChatInputCommandInteraction>;
+let mockContext: CommandContext;
+let addGuardianCalls: { resourceId: string; userId: string }[] = [];
+
+- let removeGuardianCalls: { resourceId: string; userId: string; actorId: string }[] = [];
+
+---
+
 Comment #2693231054 by gemini-code-assist[bot] on apps/purrmission-bot/src/discord/commands/listGuardians.ts:N/A
 State: N/A | Created: 2026-01-15T07:10:15Z
 
@@ -92,33 +98,33 @@ The condition `!result.guardians` is redundant. The `listGuardians` service meth
 
 Code context:
 @@ -0,0 +1,55 @@
-+/**
-+ * Handler for /purrmission guardian list command.
-+ */
-+
-+import type { ChatInputCommandInteraction } from 'discord.js';
-+import type { Services } from '../../domain/services.js';
-+import { logger } from '../../logging/logger.js';
-+
-+export async function handleListGuardians(
-+    interaction: ChatInputCommandInteraction,
-+    services: Services
-+): Promise<void> {
-+    const resourceId = interaction.options.getString('resource-id', true);
-+    const callerId = interaction.user.id;
-+
-+    try {
-+        const result = await services.resource.listGuardians(resourceId, callerId);
-+
-+        if (!result.success || !result.guardians) {
-+            await interaction.reply({
-+                content: `❌ ${result.error || 'Failed to list guardians'}`,
-+                ephemeral: true,
-+            });
-+            return;
-+        }
++/\*\*
 
-------------------------------------------------------------
+- - Handler for /purrmission guardian list command.
+- \*/
+- +import type { ChatInputCommandInteraction } from 'discord.js';
+  +import type { Services } from '../../domain/services.js';
+  +import { logger } from '../../logging/logger.js';
+- +export async function handleListGuardians(
+- interaction: ChatInputCommandInteraction,
+- services: Services
+  +): Promise<void> {
+- const resourceId = interaction.options.getString('resource-id', true);
+- const callerId = interaction.user.id;
+-
+- try {
+-        const result = await services.resource.listGuardians(resourceId, callerId);
+-
+-        if (!result.success || !result.guardians) {
+-            await interaction.reply({
+-                content: `❌ ${result.error || 'Failed to list guardians'}`,
+-                ephemeral: true,
+-            });
+-            return;
+-        }
+
+---
+
 Comment #2693231065 by gemini-code-assist[bot] on apps/purrmission-bot/src/domain/repositories.ts:N/A
 State: N/A | Created: 2026-01-15T07:10:16Z
 
@@ -128,25 +134,26 @@ These comments are overly verbose and describe the developer's thought process r
 
 Code context:
 @@ -642,6 +647,24 @@ export class PrismaGuardianRepository implements GuardianRepository {
-     return rows.map((row) => this.mapPrismaToDomain(row));
-   }
- 
-+  async remove(resourceId: string, discordUserId: string): Promise<void> {
-+    // Delete validation is implicit: if not found, Prisma throws or deletes 0.
-+    // We want to delete specific entry.
-+    // Since composite key or fields are not id, we use deleteMany or delete with unique constraint if exists.
-+    // The schema likely has a unique compound index on [resourceId, discordUserId] or logic handles it.
-+    // Let's check if we can delete by ID if we find it first, or use deleteMany.
-+    // Safer to use deleteMany for non-unique-id based deletions if uncertain of schema constraints, 
-+    // but typically guardians are unique per resource/user.
-+
-+    // Using deleteMany is safe and idempotent-ish (won't fail if not found).
+return rows.map((row) => this.mapPrismaToDomain(row));
+}
 
-------------------------------------------------------------
+- async remove(resourceId: string, discordUserId: string): Promise<void> {
+- // Delete validation is implicit: if not found, Prisma throws or deletes 0.
+- // We want to delete specific entry.
+- // Since composite key or fields are not id, we use deleteMany or delete with unique constraint if exists.
+- // The schema likely has a unique compound index on [resourceId, discordUserId] or logic handles it.
+- // Let's check if we can delete by ID if we find it first, or use deleteMany.
+- // Safer to use deleteMany for non-unique-id based deletions if uncertain of schema constraints,
+- // but typically guardians are unique per resource/user.
+-
+- // Using deleteMany is safe and idempotent-ish (won't fail if not found).
+
+---
+
 Comment #2693233839 by chatgpt-codex-connector[bot] on apps/purrmission-bot/src/domain/services.ts:N/A
 State: N/A | Created: 2026-01-15T07:11:33Z
 
-**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Prevent removing the sole OWNER guardian**
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Prevent removing the sole OWNER guardian**
 
 The new `removeGuardian` flow allows deleting any guardian without checking `targetGuardian.role`. Because the only OWNER is created in `createResource` and `addGuardian` only adds `GUARDIAN` roles, this means an owner can remove themselves (or another OWNER if added externally), leaving the resource with no OWNER. At that point no one can add/remove guardians, effectively orphaning the resource. Consider blocking removal when `targetGuardian.role === 'OWNER'` or ensuring another OWNER remains.
 
@@ -154,30 +161,29 @@ Useful? React with 👍 / 👎.
 
 Code context:
 @@ -359,6 +359,56 @@ export class ResourceService {
-     return { success: true, guardian };
-   }
- 
-+  /**
-+   * Remove a guardian from a resource.
-+   */
-+  async removeGuardian(
-+    resourceId: string,
-+    actorId: string,
-+    targetUserId: string
-+  ): Promise<{ success: boolean; error?: string }> {
-+    const { repositories } = this.deps;
-+
-+    // Verify Actor is Owner
-+    const actorGuardian = await repositories.guardians.findByResourceAndUser(resourceId, actorId);
-+    if (!actorGuardian || actorGuardian.role !== 'OWNER') {
-+      return { success: false, error: 'Only the resource owner can remove guardians.' };
-+    }
-+
-+    // Verify Target is a Guardian
-+    const targetGuardian = await repositories.guardians.findByResourceAndUser(resourceId, targetUserId);
-+    if (!targetGuardian) {
-+      return { success: false, error: 'User is not a guardian of this resource.' };
-+    }
-+
-+    await repositories.guardians.remove(resourceId, targetUserId);
+return { success: true, guardian };
+}
 
+- /\*\*
+- - Remove a guardian from a resource.
+- \*/
+- async removeGuardian(
+- resourceId: string,
+- actorId: string,
+- targetUserId: string
+- ): Promise<{ success: boolean; error?: string }> {
+- const { repositories } = this.deps;
+-
+- // Verify Actor is Owner
+- const actorGuardian = await repositories.guardians.findByResourceAndUser(resourceId, actorId);
+- if (!actorGuardian || actorGuardian.role !== 'OWNER') {
+-      return { success: false, error: 'Only the resource owner can remove guardians.' };
+- }
+-
+- // Verify Target is a Guardian
+- const targetGuardian = await repositories.guardians.findByResourceAndUser(resourceId, targetUserId);
+- if (!targetGuardian) {
+-      return { success: false, error: 'User is not a guardian of this resource.' };
+- }
+-
+- await repositories.guardians.remove(resourceId, targetUserId);

--- a/apps/pawthy/src/commands/init.ts
+++ b/apps/pawthy/src/commands/init.ts
@@ -7,240 +7,271 @@ import path from 'path';
 import { getToken, getApiUrl, findProjectRoot } from '../config.js';
 
 interface Project {
-    id: string;
-    name: string;
+  id: string;
+  name: string;
 }
 
 interface Environment {
-    id: string;
-    name: string;
-    slug: string;
+  id: string;
+  name: string;
+  slug: string;
 }
 
 export const initCommand = new Command('init')
-    .description('Initialize a new project in the current directory')
-    .action(async () => {
-        const token = getToken();
-        const apiUrl = getApiUrl();
+  .description('Initialize a new project in the current directory')
+  .action(async () => {
+    const token = getToken();
+    const apiUrl = getApiUrl();
 
-        if (!token) {
-            console.error(chalk.red('You must be logged in to initialize a project. Run `pawthy login` first.'));
-            process.exit(1);
-        }
+    if (!token) {
+      console.error(
+        chalk.red('You must be logged in to initialize a project. Run `pawthy login` first.')
+      );
+      process.exit(1);
+    }
+
+    try {
+      console.log(chalk.dim('Fetching projects...'));
+
+      // 1. Fetch Projects
+      const projectsRes = await axios.get<Project[]>(`${apiUrl}/api/projects`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      let projects = projectsRes.data;
+
+      // Helper to create a project
+      const createProject = async () => {
+        // Prompt for project details
+        const { projectName, projectDescription } = await inquirer.prompt([
+          {
+            type: 'input',
+            name: 'projectName',
+            message: 'Project name:',
+            validate: (input: string) => input.trim().length > 0 || 'Project name is required',
+          },
+          {
+            type: 'input',
+            name: 'projectDescription',
+            message: 'Project description (optional):',
+          },
+        ]);
+
+        console.log(chalk.dim('Creating project...'));
 
         try {
-            console.log(chalk.dim('Fetching projects...'));
+          const createRes = await axios.post<Project>(
+            `${apiUrl}/api/projects`,
+            {
+              name: projectName.trim(),
+              description: projectDescription?.trim() || undefined,
+            },
+            { headers: { Authorization: `Bearer ${token}` } }
+          );
 
-            // 1. Fetch Projects
-            const projectsRes = await axios.get<Project[]>(`${apiUrl}/api/projects`, {
-                headers: { Authorization: `Bearer ${token}` },
-            });
-
-            let projects = projectsRes.data;
-
-
-            // Helper to create a project
-            const createProject = async () => {
-                // Prompt for project details
-                const { projectName, projectDescription } = await inquirer.prompt([
-                    {
-                        type: 'input',
-                        name: 'projectName',
-                        message: 'Project name:',
-                        validate: (input: string) => input.trim().length > 0 || 'Project name is required'
-                    },
-                    {
-                        type: 'input',
-                        name: 'projectDescription',
-                        message: 'Project description (optional):',
-                    }
-                ]);
-
-                console.log(chalk.dim('Creating project...'));
-
-                try {
-                    const createRes = await axios.post<Project>(
-                        `${apiUrl}/api/projects`,
-                        {
-                            name: projectName.trim(),
-                            description: projectDescription?.trim() || undefined
-                        },
-                        { headers: { Authorization: `Bearer ${token}` } }
-                    );
-
-                    const newProject = createRes.data;
-                    console.log(chalk.green(`✅ Project "${newProject.name}" created!`));
-                    return newProject;
-
-                } catch (error) {
-                    if (axios.isAxiosError(error)) {
-                        const status = error.response?.status;
-                        if (status === 409) {
-                            console.error(chalk.red('A project with this name already exists. Please choose a different name.'));
-                        } else if (status === 400) {
-                            const message = error.response?.data?.error || error.response?.data?.message;
-                            console.error(chalk.red(`Invalid project data.${message ? ` ${String(message)}` : ''}`));
-                        } else if (status === 403) {
-                            console.error(chalk.red('You do not have permission to create a project.'));
-                        } else {
-                            console.error(chalk.red(`Failed to create project: ${error.message}`));
-                        }
-                    } else {
-                        console.error(chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`));
-                    }
-                    process.exit(1);
-                }
-            };
-
-            let selectedProjectId: string;
-
-            if (projects.length === 0) {
-                const { shouldCreate } = await inquirer.prompt([{
-                    type: 'confirm',
-                    name: 'shouldCreate',
-                    message: 'No projects found. Create one?',
-                    default: false
-                }]);
-
-                if (!shouldCreate) {
-                    console.log(chalk.yellow('No project selected. Exiting.'));
-                    process.exit(0);
-                }
-
-                const newProject = await createProject();
-                projects = [newProject];
-                selectedProjectId = newProject.id;
-            } else {
-                // 2. Select Project (with Create Option)
-                const choices = [
-                    ...projects.map(p => ({
-                        name: p.name,
-                        value: p.id
-                    })),
-                    new inquirer.Separator(),
-                    { name: chalk.green('+ Create New Project'), value: 'CREATE_NEW' }
-                ];
-
-                const { projectId } = await inquirer.prompt([{
-                    type: 'list',
-                    name: 'projectId',
-                    message: 'Select a project:',
-                    choices: choices,
-                    loop: false
-                }]);
-
-                if (projectId === 'CREATE_NEW') {
-                    const newProject = await createProject();
-                    projects.push(newProject);
-                    selectedProjectId = newProject.id;
-                } else {
-                    selectedProjectId = projectId;
-                }
-            }
-
-
-            // 3. Fetch Environments
-            const envsRes = await axios.get<Environment[]>(`${apiUrl}/api/projects/${selectedProjectId}/environments`, {
-                headers: { Authorization: `Bearer ${token}` },
-            });
-
-            let envs = envsRes.data;
-
-            if (envs.length === 0) {
-                const { shouldCreateEnv } = await inquirer.prompt([{
-                    type: 'confirm',
-                    name: 'shouldCreateEnv',
-                    message: 'No environments found. Create one?',
-                    default: true
-                }]);
-
-                if (!shouldCreateEnv) {
-                    console.log(chalk.yellow('No environment selected. Exiting.'));
-                    process.exit(0);
-                }
-
-                // Prompt for environment details
-                const { envName, envSlug } = await inquirer.prompt([
-                    {
-                        type: 'input',
-                        name: 'envName',
-                        message: 'Environment name (e.g., Production):',
-                        default: 'Production',
-                        validate: (input: string) => input.trim().length > 0 || 'Environment name is required'
-                    },
-                    {
-                        type: 'input',
-                        name: 'envSlug',
-                        message: 'Environment slug (e.g., prod):',
-                        default: 'prod',
-                        validate: (input: string) => input.trim().length > 0 || 'Environment slug is required'
-                    }
-                ]);
-
-                console.log(chalk.dim('Creating environment...'));
-
-                try {
-                    const createEnvRes = await axios.post<Environment>(
-                        `${apiUrl}/api/projects/${selectedProjectId}/environments`,
-                        {
-                            name: envName.trim(),
-                            slug: envSlug.trim()
-                        },
-                        { headers: { Authorization: `Bearer ${token}` } }
-                    );
-
-                    const newEnv = createEnvRes.data;
-                    console.log(chalk.green(`✅ Environment "${newEnv.name}" created!`));
-                    envs = [newEnv];
-                } catch (error) {
-                    if (axios.isAxiosError(error)) {
-                        const status = error.response?.status;
-                        if (status === 409) {
-                            console.error(chalk.red('An environment with this slug already exists.'));
-                        } else if (status === 400) {
-                            const message = error.response?.data?.error || error.response?.data?.message;
-                            console.error(chalk.red(`Invalid environment data.${message ? ` ${String(message)}` : ''}`));
-                        } else {
-                            console.error(chalk.red(`Failed to create environment: ${error.message}`));
-                        }
-                    } else {
-                        console.error(chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`));
-                    }
-                    process.exit(1);
-                }
-            }
-
-            // 4. Select Environment
-            const { envId } = await inquirer.prompt([{
-                type: 'list',
-                name: 'envId',
-                message: 'Select an environment:',
-                choices: envs.map(e => ({
-                    name: `${e.name} (${e.slug})`,
-                    value: e.id
-                }))
-            }]);
-
-            // 5. Write .pawthyrc
-            const config = {
-                projectId: selectedProjectId,
-                envId
-            };
-
-            const targetDir = findProjectRoot();
-            await fs.writeFile(path.join(targetDir, '.pawthyrc'), JSON.stringify(config, null, 2));
-            console.log(chalk.green(`\n✅ Project initialized! Configuration saved to ${path.join(targetDir, '.pawthyrc')}`));
-
+          const newProject = createRes.data;
+          console.log(chalk.green(`✅ Project "${newProject.name}" created!`));
+          return newProject;
         } catch (error) {
-            if (axios.isAxiosError(error)) {
-                if (error.response?.status === 401) {
-                    console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
-                } else {
-                    console.error(chalk.red(`Failed to fetch data: ${error.message}`));
-                }
+          if (axios.isAxiosError(error)) {
+            const status = error.response?.status;
+            if (status === 409) {
+              console.error(
+                chalk.red(
+                  'A project with this name already exists. Please choose a different name.'
+                )
+              );
+            } else if (status === 400) {
+              const message = error.response?.data?.error || error.response?.data?.message;
+              console.error(
+                chalk.red(`Invalid project data.${message ? ` ${String(message)}` : ''}`)
+              );
+            } else if (status === 403) {
+              console.error(chalk.red('You do not have permission to create a project.'));
             } else {
-                console.error(chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`));
+              console.error(chalk.red(`Failed to create project: ${error.message}`));
             }
-            process.exit(1);
+          } else {
+            console.error(
+              chalk.red(
+                `An error occurred: ${error instanceof Error ? error.message : String(error)}`
+              )
+            );
+          }
+          process.exit(1);
         }
-    });
+      };
+
+      let selectedProjectId: string;
+
+      if (projects.length === 0) {
+        const { shouldCreate } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'shouldCreate',
+            message: 'No projects found. Create one?',
+            default: false,
+          },
+        ]);
+
+        if (!shouldCreate) {
+          console.log(chalk.yellow('No project selected. Exiting.'));
+          process.exit(0);
+        }
+
+        const newProject = await createProject();
+        projects = [newProject];
+        selectedProjectId = newProject.id;
+      } else {
+        // 2. Select Project (with Create Option)
+        const choices = [
+          ...projects.map((p) => ({
+            name: p.name,
+            value: p.id,
+          })),
+          new inquirer.Separator(),
+          { name: chalk.green('+ Create New Project'), value: 'CREATE_NEW' },
+        ];
+
+        const { projectId } = await inquirer.prompt([
+          {
+            type: 'list',
+            name: 'projectId',
+            message: 'Select a project:',
+            choices: choices,
+            loop: false,
+          },
+        ]);
+
+        if (projectId === 'CREATE_NEW') {
+          const newProject = await createProject();
+          projects.push(newProject);
+          selectedProjectId = newProject.id;
+        } else {
+          selectedProjectId = projectId;
+        }
+      }
+
+      // 3. Fetch Environments
+      const envsRes = await axios.get<Environment[]>(
+        `${apiUrl}/api/projects/${selectedProjectId}/environments`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+
+      let envs = envsRes.data;
+
+      if (envs.length === 0) {
+        const { shouldCreateEnv } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'shouldCreateEnv',
+            message: 'No environments found. Create one?',
+            default: true,
+          },
+        ]);
+
+        if (!shouldCreateEnv) {
+          console.log(chalk.yellow('No environment selected. Exiting.'));
+          process.exit(0);
+        }
+
+        // Prompt for environment details
+        const { envName, envSlug } = await inquirer.prompt([
+          {
+            type: 'input',
+            name: 'envName',
+            message: 'Environment name (e.g., Production):',
+            default: 'Production',
+            validate: (input: string) => input.trim().length > 0 || 'Environment name is required',
+          },
+          {
+            type: 'input',
+            name: 'envSlug',
+            message: 'Environment slug (e.g., prod):',
+            default: 'prod',
+            validate: (input: string) => input.trim().length > 0 || 'Environment slug is required',
+          },
+        ]);
+
+        console.log(chalk.dim('Creating environment...'));
+
+        try {
+          const createEnvRes = await axios.post<Environment>(
+            `${apiUrl}/api/projects/${selectedProjectId}/environments`,
+            {
+              name: envName.trim(),
+              slug: envSlug.trim(),
+            },
+            { headers: { Authorization: `Bearer ${token}` } }
+          );
+
+          const newEnv = createEnvRes.data;
+          console.log(chalk.green(`✅ Environment "${newEnv.name}" created!`));
+          envs = [newEnv];
+        } catch (error) {
+          if (axios.isAxiosError(error)) {
+            const status = error.response?.status;
+            if (status === 409) {
+              console.error(chalk.red('An environment with this slug already exists.'));
+            } else if (status === 400) {
+              const message = error.response?.data?.error || error.response?.data?.message;
+              console.error(
+                chalk.red(`Invalid environment data.${message ? ` ${String(message)}` : ''}`)
+              );
+            } else {
+              console.error(chalk.red(`Failed to create environment: ${error.message}`));
+            }
+          } else {
+            console.error(
+              chalk.red(
+                `An error occurred: ${error instanceof Error ? error.message : String(error)}`
+              )
+            );
+          }
+          process.exit(1);
+        }
+      }
+
+      // 4. Select Environment
+      const { envId } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'envId',
+          message: 'Select an environment:',
+          choices: envs.map((e) => ({
+            name: `${e.name} (${e.slug})`,
+            value: e.id,
+          })),
+        },
+      ]);
+
+      // 5. Write .pawthyrc
+      const config = {
+        projectId: selectedProjectId,
+        envId,
+      };
+
+      const targetDir = findProjectRoot();
+      await fs.writeFile(path.join(targetDir, '.pawthyrc'), JSON.stringify(config, null, 2));
+      console.log(
+        chalk.green(
+          `\n✅ Project initialized! Configuration saved to ${path.join(targetDir, '.pawthyrc')}`
+        )
+      );
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) {
+          console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
+        } else {
+          console.error(chalk.red(`Failed to fetch data: ${error.message}`));
+        }
+      } else {
+        console.error(
+          chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`)
+        );
+      }
+      process.exit(1);
+    }
+  });

--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -8,453 +8,465 @@ import { pullCommand } from './pull.js';
 import { config } from '../config.js';
 
 describe('Pull Command', () => {
-    let exitCode: number | null = null;
-    let tempDir: string;
+  let exitCode: number | null = null;
+  let tempDir: string;
 
-    beforeEach(async () => {
-        exitCode = null;
+  beforeEach(async () => {
+    exitCode = null;
 
-        // Reset commander options to prevent test pollution
-        pullCommand.setOptionValue('file', '.env');
-        pullCommand.setOptionValue('projectId', undefined);
-        pullCommand.setOptionValue('envId', undefined);
-        pullCommand.setOptionValue('keys', undefined);
-        pullCommand.setOptionValue('merge', undefined);
+    // Reset commander options to prevent test pollution
+    pullCommand.setOptionValue('file', '.env');
+    pullCommand.setOptionValue('projectId', undefined);
+    pullCommand.setOptionValue('envId', undefined);
+    pullCommand.setOptionValue('keys', undefined);
+    pullCommand.setOptionValue('merge', undefined);
 
-        // Create a unique temp directory outside the repository
-        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-'));
+    // Create a unique temp directory outside the repository
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-'));
 
-        // Mock process.cwd to return our temp directory
-        mock.method(process, 'cwd', () => tempDir);
+    // Mock process.cwd to return our temp directory
+    mock.method(process, 'cwd', () => tempDir);
 
-        // Mock process.exit
-        mock.method(process, 'exit', (code?: number) => {
-            exitCode = code ?? null;
-            throw new Error(`process.exit called with ${code}`);
-        });
-
-        // Write a dummy .pawthyrc file in the temp directory
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc'),
-            JSON.stringify({ projectId: 'test-project', envId: 'test-env' })
-        );
+    // Mock process.exit
+    mock.method(process, 'exit', (code?: number) => {
+      exitCode = code ?? null;
+      throw new Error(`process.exit called with ${code}`);
     });
 
-    afterEach(async () => {
-        mock.restoreAll();
-        // Clean up environment variables to prevent test pollution
-        delete process.env.PAWTHY_PROJECT_ID;
-        delete process.env.PAWTHY_ENV_ID;
+    // Write a dummy .pawthyrc file in the temp directory
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({ projectId: 'test-project', envId: 'test-env' })
+    );
+  });
 
-        // Clean up the temp directory
-        try {
-            await fs.rm(tempDir, { recursive: true, force: true });
-        } catch {
-            // Ignore
-        }
+  afterEach(async () => {
+    mock.restoreAll();
+    // Clean up environment variables to prevent test pollution
+    delete process.env.PAWTHY_PROJECT_ID;
+    delete process.env.PAWTHY_ENV_ID;
+
+    // Clean up the temp directory
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it('should exit with code 1 when pull status is 202 (Pending Approval)', async () => {
+    // Mock config.get for token
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should exit with code 1 when pull status is 202 (Pending Approval)', async () => {
-        // Mock config.get for token
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
-
-        // Mock axios.get to return 202 status
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'get', async (): Promise<any> => {
-            return {
-                status: 202,
-                data: {
-                    status: 'pending',
-                    message: 'Secret access is pending approval in Discord',
-                },
-            };
-        });
-
-        // Suppress console.log / console.error for clean test output
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        try {
-            await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
-        } catch {
-            // Expected to throw because process.exit throws
-        }
-
-        assert.strictEqual(exitCode, 1);
+    // Mock axios.get to return 202 status
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'get', async (): Promise<any> => {
+      return {
+        status: 202,
+        data: {
+          status: 'pending',
+          message: 'Secret access is pending approval in Discord',
+        },
+      };
     });
 
-    it('should prioritize CLI flags over env vars and .pawthyrc', async () => {
-        let requestedUrl = '';
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Suppress console.log / console.error for clean test output
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        // Set env vars
-        process.env.PAWTHY_PROJECT_ID = 'env-project';
-        process.env.PAWTHY_ENV_ID = 'env-env';
+    try {
+      await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+    } catch {
+      // Expected to throw because process.exit throws
+    }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'get', async (url: string): Promise<any> => {
-            requestedUrl = url;
-            return {
-                status: 200,
-                data: { secrets: { FOO: 'bar' } },
-            };
-        });
+    assert.strictEqual(exitCode, 1);
+  });
 
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pullCommand.parseAsync([
-            'node',
-            'pawthy',
-            'pull',
-            '-p',
-            'flag-project',
-            '-e',
-            'flag-env',
-        ]);
-
-        // Verify the URL contained the flag values
-        assert.ok(requestedUrl.includes('/projects/flag-project/environments/flag-env/secrets'));
+  it('should prioritize CLI flags over env vars and .pawthyrc', async () => {
+    let requestedUrl = '';
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should prioritize .pawthyrc over env vars', async () => {
-        let requestedUrl = '';
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Set env vars
+    process.env.PAWTHY_PROJECT_ID = 'env-project';
+    process.env.PAWTHY_ENV_ID = 'env-env';
 
-        // Set env vars
-        process.env.PAWTHY_PROJECT_ID = 'env-project';
-        process.env.PAWTHY_ENV_ID = 'env-env';
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'get', async (url: string): Promise<any> => {
-            requestedUrl = url;
-            return {
-                status: 200,
-                data: { secrets: { FOO: 'bar' } },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
-
-        // Verify the URL contained the .pawthyrc values, not the env var values
-        assert.ok(requestedUrl.includes('/projects/test-project/environments/test-env/secrets'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'get', async (url: string): Promise<any> => {
+      requestedUrl = url;
+      return {
+        status: 200,
+        data: { secrets: { FOO: 'bar' } },
+      };
     });
 
-    it('should use env vars if .pawthyrc is missing', async () => {
-        let requestedUrl = '';
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        // Delete the .pawthyrc file
-        await fs.unlink(path.join(tempDir, '.pawthyrc'));
+    await pullCommand.parseAsync([
+      'node',
+      'pawthy',
+      'pull',
+      '-p',
+      'flag-project',
+      '-e',
+      'flag-env',
+    ]);
 
-        // Set env vars
-        process.env.PAWTHY_PROJECT_ID = 'env-project';
-        process.env.PAWTHY_ENV_ID = 'env-env';
+    // Verify the URL contained the flag values
+    assert.ok(requestedUrl.includes('/projects/flag-project/environments/flag-env/secrets'));
+  });
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'get', async (url: string): Promise<any> => {
-            requestedUrl = url;
-            return {
-                status: 200,
-                data: { secrets: { FOO: 'bar' } },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
-
-        // Verify the URL contained the env var values
-        assert.ok(requestedUrl.includes('/projects/env-project/environments/env-env/secrets'));
+  it('should prioritize .pawthyrc over env vars', async () => {
+    let requestedUrl = '';
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should exit with code 1 if project ID or environment ID is missing and no .pawthyrc', async () => {
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Set env vars
+    process.env.PAWTHY_PROJECT_ID = 'env-project';
+    process.env.PAWTHY_ENV_ID = 'env-env';
 
-        // Delete the .pawthyrc file so it cannot be resolved there
-        await fs.unlink(path.join(tempDir, '.pawthyrc'));
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        try {
-            await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
-        } catch {
-            // Expected to throw because process.exit throws
-        }
-
-        assert.strictEqual(exitCode, 1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'get', async (url: string): Promise<any> => {
+      requestedUrl = url;
+      return {
+        status: 200,
+        data: { secrets: { FOO: 'bar' } },
+      };
     });
 
-    it('should natively merge secrets with existing .env file preserving comments and local variables', async () => {
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        // Write initial .env file with comments and local variables
-        const initialEnv = [
-            '# DB config',
-            'DATABASE_URL=postgres://localhost/db',
-            '',
-            '# Spacing and quotes tests',
-            '  SPACED_KEY  =  "old-value"  ',
-            'SINGLE_QUOTED = \'old-single\'',
-            'WITH_COMMENT = old-val # preserve this comment',
-            'MULTILINE = "line 1',
-            'line 2"',
-            '',
-            '# Local variables',
-            'LOCAL_ONLY=123',
-            'EXISTING_OVERWRITE=old-value',
-        ].join('\n');
-        await fs.writeFile(path.join(tempDir, '.env'), initialEnv);
+    await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
 
-        // Mock axios.get to return updated and new secrets
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'get', async (): Promise<any> => {
-            return {
-                status: 200,
-                data: {
-                    secrets: {
-                        DATABASE_URL: 'postgres://prod-host/db',
-                        SPACED_KEY: 'new-value',
-                        SINGLE_QUOTED: 'new-single',
-                        WITH_COMMENT: 'new-val',
-                        MULTILINE: 'new line 1\nnew line 2',
-                        EXISTING_OVERWRITE: 'new-value',
-                        NEW_SECRET: 'new-secret-val',
-                    },
-                },
-            };
-        });
+    // Verify the URL contained the .pawthyrc values, not the env var values
+    assert.ok(requestedUrl.includes('/projects/test-project/environments/test-env/secrets'));
+  });
 
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pullCommand.parseAsync(['node', 'pawthy', 'pull', '--merge']);
-
-        // Read the resulting .env file
-        const mergedContent = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
-        const lines = mergedContent.split('\n');
-
-        // Check that DATABASE_URL and EXISTING_OVERWRITE were updated
-        assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
-        assert.ok(lines.includes('EXISTING_OVERWRITE=new-value'));
-
-        // Check spacing, quotes, and comments preservation
-        assert.ok(lines.includes('  SPACED_KEY  =  "new-value"  '));
-        assert.ok(lines.includes('SINGLE_QUOTED = \'new-single\''));
-        assert.ok(lines.includes('WITH_COMMENT = new-val # preserve this comment'));
-
-        // Check multiline preservation/updating
-        // The multiline value contains a newline, so it should be double-quoted
-        const multilineStartIndex = lines.findIndex(l => l.startsWith('MULTILINE ='));
-        assert.notStrictEqual(multilineStartIndex, -1);
-        assert.strictEqual(lines[multilineStartIndex], 'MULTILINE = "new line 1');
-        assert.strictEqual(lines[multilineStartIndex + 1], 'new line 2"');
-
-        // Check that LOCAL_ONLY and comments were preserved
-        assert.ok(lines.includes('# DB config'));
-        assert.ok(lines.includes('LOCAL_ONLY=123'));
-        assert.ok(lines.includes('# Local variables'));
-
-        // Check that NEW_SECRET was appended
-        assert.ok(lines.includes('NEW_SECRET=new-secret-val'));
+  it('should use env vars if .pawthyrc is missing', async () => {
+    let requestedUrl = '';
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should support whitelisting via CLI keys flag in pull command and preserve local-only variables', async () => {
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Delete the .pawthyrc file
+    await fs.unlink(path.join(tempDir, '.pawthyrc'));
 
-        // Write a pre-existing .env file
-        await fs.writeFile(
-            path.join(tempDir, '.env'),
-            'DATABASE_URL=postgres://localhost/db\nLOCAL_ONLY=123\n'
-        );
+    // Set env vars
+    process.env.PAWTHY_PROJECT_ID = 'env-project';
+    process.env.PAWTHY_ENV_ID = 'env-env';
 
-        mock.method(axios, 'get', async () => {
-            return {
-                status: 200,
-                data: {
-                    secrets: {
-                        DATABASE_URL: 'postgres://prod-host/db',
-                        API_KEY: 'secret-key',
-                        ANOTHER_VAR: 'val',
-                    },
-                },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        // Request only DATABASE_URL and API_KEY
-        await pullCommand.parseAsync(['node', 'pawthy', 'pull', '-k', 'DATABASE_URL, API_KEY']);
-
-        const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
-        const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
-
-        assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
-        assert.ok(lines.includes('API_KEY=secret-key'));
-        // LOCAL_ONLY should be preserved because whitelisting forces merge behavior
-        assert.ok(lines.includes('LOCAL_ONLY=123'));
-        assert.ok(!lines.includes('ANOTHER_VAR=val'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'get', async (url: string): Promise<any> => {
+      requestedUrl = url;
+      return {
+        status: 200,
+        data: { secrets: { FOO: 'bar' } },
+      };
     });
 
-    it('should support whitelisting via keys array in .pawthyrc in pull command', async () => {
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        // Write a .pawthyrc containing a keys whitelist
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc'),
-            JSON.stringify({
-                projectId: 'test-project',
-                envId: 'test-env',
-                keys: ['DATABASE_URL'],
-            })
-        );
+    await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
 
-        mock.method(axios, 'get', async () => {
-            return {
-                status: 200,
-                data: {
-                    secrets: {
-                        DATABASE_URL: 'postgres://prod-host/db',
-                        API_KEY: 'secret-key',
-                    },
-                },
-            };
-        });
+    // Verify the URL contained the env var values
+    assert.ok(requestedUrl.includes('/projects/env-project/environments/env-env/secrets'));
+  });
 
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
-
-        const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
-        const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
-
-        assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
-        assert.ok(!lines.includes('API_KEY=secret-key'));
+  it('should exit with code 1 if project ID or environment ID is missing and no .pawthyrc', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should support whitelisting via keys array in .pawthyrc.local in pull command', async () => {
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Delete the .pawthyrc file so it cannot be resolved there
+    await fs.unlink(path.join(tempDir, '.pawthyrc'));
 
-        // Write a .pawthyrc and a .pawthyrc.local
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc'),
-            JSON.stringify({
-                projectId: 'test-project',
-                envId: 'test-env',
-            })
-        );
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc.local'),
-            JSON.stringify({
-                keys: ['API_KEY'],
-            })
-        );
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        mock.method(axios, 'get', async () => {
-            return {
-                status: 200,
-                data: {
-                    secrets: {
-                        DATABASE_URL: 'postgres://prod-host/db',
-                        API_KEY: 'secret-key',
-                    },
-                },
-            };
-        });
+    try {
+      await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+    } catch {
+      // Expected to throw because process.exit throws
+    }
 
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
+    assert.strictEqual(exitCode, 1);
+  });
 
-        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
-
-        const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
-        const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
-
-        assert.ok(!lines.includes('DATABASE_URL=postgres://prod-host/db'));
-        assert.ok(lines.includes('API_KEY=secret-key'));
+  it('should natively merge secrets with existing .env file preserving comments and local variables', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should support whitelisting via syncKeys array in .pawthyrc in pull command', async () => {
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Write initial .env file with comments and local variables
+    const initialEnv = [
+      '# DB config',
+      'DATABASE_URL=postgres://localhost/db',
+      '',
+      '# Spacing and quotes tests',
+      '  SPACED_KEY  =  "old-value"  ',
+      "SINGLE_QUOTED = 'old-single'",
+      'WITH_COMMENT = old-val # preserve this comment',
+      'MULTILINE = "line 1',
+      'line 2"',
+      '',
+      '# Local variables',
+      'LOCAL_ONLY=123',
+      'EXISTING_OVERWRITE=old-value',
+    ].join('\n');
+    await fs.writeFile(path.join(tempDir, '.env'), initialEnv);
 
-        // Write a .pawthyrc containing syncKeys alias
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc'),
-            JSON.stringify({
-                projectId: 'test-project',
-                envId: 'test-env',
-                syncKeys: ['DATABASE_URL'],
-            })
-        );
-
-        mock.method(axios, 'get', async () => {
-            return {
-                status: 200,
-                data: {
-                    secrets: {
-                        DATABASE_URL: 'postgres://prod-host/db',
-                        API_KEY: 'secret-key',
-                    },
-                },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
-
-        const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
-        const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
-
-        assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
-        assert.ok(!lines.includes('API_KEY=secret-key'));
+    // Mock axios.get to return updated and new secrets
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'get', async (): Promise<any> => {
+      return {
+        status: 200,
+        data: {
+          secrets: {
+            DATABASE_URL: 'postgres://prod-host/db',
+            SPACED_KEY: 'new-value',
+            SINGLE_QUOTED: 'new-single',
+            WITH_COMMENT: 'new-val',
+            MULTILINE: 'new line 1\nnew line 2',
+            EXISTING_OVERWRITE: 'new-value',
+            NEW_SECRET: 'new-secret-val',
+          },
+        },
+      };
     });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pullCommand.parseAsync(['node', 'pawthy', 'pull', '--merge']);
+
+    // Read the resulting .env file
+    const mergedContent = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+    const lines = mergedContent.split('\n');
+
+    // Check that DATABASE_URL and EXISTING_OVERWRITE were updated
+    assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
+    assert.ok(lines.includes('EXISTING_OVERWRITE=new-value'));
+
+    // Check spacing, quotes, and comments preservation
+    assert.ok(lines.includes('  SPACED_KEY  =  "new-value"  '));
+    assert.ok(lines.includes("SINGLE_QUOTED = 'new-single'"));
+    assert.ok(lines.includes('WITH_COMMENT = new-val # preserve this comment'));
+
+    // Check multiline preservation/updating
+    // The multiline value contains a newline, so it should be double-quoted
+    const multilineStartIndex = lines.findIndex((l) => l.startsWith('MULTILINE ='));
+    assert.notStrictEqual(multilineStartIndex, -1);
+    assert.strictEqual(lines[multilineStartIndex], 'MULTILINE = "new line 1');
+    assert.strictEqual(lines[multilineStartIndex + 1], 'new line 2"');
+
+    // Check that LOCAL_ONLY and comments were preserved
+    assert.ok(lines.includes('# DB config'));
+    assert.ok(lines.includes('LOCAL_ONLY=123'));
+    assert.ok(lines.includes('# Local variables'));
+
+    // Check that NEW_SECRET was appended
+    assert.ok(lines.includes('NEW_SECRET=new-secret-val'));
+  });
+
+  it('should support whitelisting via CLI keys flag in pull command and preserve local-only variables', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    // Write a pre-existing .env file
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      'DATABASE_URL=postgres://localhost/db\nLOCAL_ONLY=123\n'
+    );
+
+    mock.method(axios, 'get', async () => {
+      return {
+        status: 200,
+        data: {
+          secrets: {
+            DATABASE_URL: 'postgres://prod-host/db',
+            API_KEY: 'secret-key',
+            ANOTHER_VAR: 'val',
+          },
+        },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    // Request only DATABASE_URL and API_KEY
+    await pullCommand.parseAsync(['node', 'pawthy', 'pull', '-k', 'DATABASE_URL, API_KEY']);
+
+    const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+    const lines = content
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
+    assert.ok(lines.includes('API_KEY=secret-key'));
+    // LOCAL_ONLY should be preserved because whitelisting forces merge behavior
+    assert.ok(lines.includes('LOCAL_ONLY=123'));
+    assert.ok(!lines.includes('ANOTHER_VAR=val'));
+  });
+
+  it('should support whitelisting via keys array in .pawthyrc in pull command', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    // Write a .pawthyrc containing a keys whitelist
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({
+        projectId: 'test-project',
+        envId: 'test-env',
+        keys: ['DATABASE_URL'],
+      })
+    );
+
+    mock.method(axios, 'get', async () => {
+      return {
+        status: 200,
+        data: {
+          secrets: {
+            DATABASE_URL: 'postgres://prod-host/db',
+            API_KEY: 'secret-key',
+          },
+        },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+
+    const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+    const lines = content
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
+    assert.ok(!lines.includes('API_KEY=secret-key'));
+  });
+
+  it('should support whitelisting via keys array in .pawthyrc.local in pull command', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    // Write a .pawthyrc and a .pawthyrc.local
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({
+        projectId: 'test-project',
+        envId: 'test-env',
+      })
+    );
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc.local'),
+      JSON.stringify({
+        keys: ['API_KEY'],
+      })
+    );
+
+    mock.method(axios, 'get', async () => {
+      return {
+        status: 200,
+        data: {
+          secrets: {
+            DATABASE_URL: 'postgres://prod-host/db',
+            API_KEY: 'secret-key',
+          },
+        },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+
+    const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+    const lines = content
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    assert.ok(!lines.includes('DATABASE_URL=postgres://prod-host/db'));
+    assert.ok(lines.includes('API_KEY=secret-key'));
+  });
+
+  it('should support whitelisting via syncKeys array in .pawthyrc in pull command', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    // Write a .pawthyrc containing syncKeys alias
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({
+        projectId: 'test-project',
+        envId: 'test-env',
+        syncKeys: ['DATABASE_URL'],
+      })
+    );
+
+    mock.method(axios, 'get', async () => {
+      return {
+        status: 200,
+        data: {
+          secrets: {
+            DATABASE_URL: 'postgres://prod-host/db',
+            API_KEY: 'secret-key',
+          },
+        },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pullCommand.parseAsync(['node', 'pawthy', 'pull']);
+
+    const content = await fs.readFile(path.join(tempDir, '.env'), 'utf-8');
+    const lines = content
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
+    assert.ok(!lines.includes('API_KEY=secret-key'));
+  });
 });

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -6,393 +6,419 @@ import path from 'path';
 import { getToken, getApiUrl, getProjectConfig } from '../config.js';
 
 export const pullCommand = new Command('pull')
-    .description('Pull secrets from Purrmission to local .env')
-    .option('-f, --file <path>', 'Path to .env file', '.env')
-    .option('-p, --project-id <id>', 'Project ID')
-    .option('-e, --env-id <id>', 'Environment ID')
-    .option('-m, --merge', 'Merge with existing .env file instead of overwriting')
-    .option('-k, --keys <list>', 'Comma-separated list of keys to pull')
-    .action(async (options) => {
-        const token = getToken();
-        const apiUrl = getApiUrl();
-        if (!token) {
-            console.error(chalk.red('You must be logged in. Run `pawthy login` first.'));
-            process.exit(1);
-            return;
+  .description('Pull secrets from Purrmission to local .env')
+  .option('-f, --file <path>', 'Path to .env file', '.env')
+  .option('-p, --project-id <id>', 'Project ID')
+  .option('-e, --env-id <id>', 'Environment ID')
+  .option('-m, --merge', 'Merge with existing .env file instead of overwriting')
+  .option('-k, --keys <list>', 'Comma-separated list of keys to pull')
+  .action(async (options) => {
+    const token = getToken();
+    const apiUrl = getApiUrl();
+    if (!token) {
+      console.error(chalk.red('You must be logged in. Run `pawthy login` first.'));
+      process.exit(1);
+      return;
+    }
+
+    let projectId = options.projectId;
+    let envId = options.envId;
+    let config: {
+      projectId?: string;
+      envId?: string;
+      keys?: string[];
+      syncKeys?: string[];
+    } | null = null;
+
+    if (!projectId || !envId || !options.keys) {
+      config = await getProjectConfig();
+      projectId = projectId || config?.projectId || process.env.PAWTHY_PROJECT_ID;
+      envId = envId || config?.envId || process.env.PAWTHY_ENV_ID;
+    }
+
+    if (!projectId || !envId) {
+      console.error(
+        chalk.red(
+          'Project ID and Environment ID must be specified (via CLI flags -p/-e, env vars PAWTHY_PROJECT_ID/PAWTHY_ENV_ID, or .pawthyrc config).'
+        )
+      );
+      process.exit(1);
+      return;
+    }
+
+    const envPath = path.resolve(process.cwd(), options.file);
+
+    try {
+      console.log(chalk.dim('Fetching secrets from Purrmission...'));
+
+      // 1. Fetch Secrets
+      const res = await axios.get<{
+        secrets?: Record<string, string>;
+        status?: string;
+        message?: string;
+      }>(`${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`, {
+        headers: { Authorization: `Bearer ${token}` },
+        validateStatus: (status) => status >= 200 && status < 300,
+      });
+
+      if (res.status === 202) {
+        console.log(`\n${chalk.yellow('⏳ Access Pending Approval')}`);
+        console.log(chalk.white(res.data.message));
+        console.log(
+          chalk.dim(
+            '\nPlease run this command again once your request has been approved in Discord.'
+          )
+        );
+        process.exit(1);
+        return;
+      }
+
+      let secrets = res.data.secrets || {};
+
+      // Whitelisting / selective keys sync (Issue #80)
+      const keysWhitelist = getKeysWhitelist(options.keys, config);
+
+      if (keysWhitelist) {
+        const ignoredKeys: string[] = [];
+        const filteredSecrets: Record<string, string> = {};
+        for (const [key, value] of Object.entries(secrets)) {
+          if (keysWhitelist.has(key)) {
+            filteredSecrets[key] = value;
+          } else {
+            ignoredKeys.push(key);
+          }
         }
-
-        let projectId = options.projectId;
-        let envId = options.envId;
-        let config: { projectId?: string; envId?: string; keys?: string[]; syncKeys?: string[] } | null = null;
-
-        if (!projectId || !envId || !options.keys) {
-            config = await getProjectConfig();
-            projectId = projectId || config?.projectId || process.env.PAWTHY_PROJECT_ID;
-            envId = envId || config?.envId || process.env.PAWTHY_ENV_ID;
+        secrets = filteredSecrets;
+        if (ignoredKeys.length > 0) {
+          console.log(
+            chalk.yellow(`\n⚠️  Ignored remote keys not in whitelist: ${ignoredKeys.join(', ')}`)
+          );
         }
+      }
 
-        if (!projectId || !envId) {
-            console.error(
-                chalk.red(
-                    'Project ID and Environment ID must be specified (via CLI flags -p/-e, env vars PAWTHY_PROJECT_ID/PAWTHY_ENV_ID, or .pawthyrc config).'
-                )
-            );
-            process.exit(1);
-            return;
-        }
+      if (Object.keys(secrets).length === 0) {
+        console.log(chalk.yellow('No matching secrets found for this environment.'));
+        return;
+      }
 
-        const envPath = path.resolve(process.cwd(), options.file);
+      let content = '';
+      let isMerged = false;
 
+      // Whitelisting forces merge behavior to avoid deleting non-whitelisted local variables (Issue #80)
+      const shouldMerge = options.merge || keysWhitelist !== null;
+
+      if (shouldMerge) {
         try {
-            console.log(chalk.dim('Fetching secrets from Purrmission...'));
-
-            // 1. Fetch Secrets
-            const res = await axios.get<{ secrets?: Record<string, string>; status?: string; message?: string }>(
-                `${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`,
-                {
-                    headers: { Authorization: `Bearer ${token}` },
-                    validateStatus: (status) => status >= 200 && status < 300,
-                }
-            );
-
-            if (res.status === 202) {
-                console.log(`\n${chalk.yellow('⏳ Access Pending Approval')}`);
-                console.log(chalk.white(res.data.message));
-                console.log(chalk.dim('\nPlease run this command again once your request has been approved in Discord.'));
-                process.exit(1);
-                return;
-            }
-
-            let secrets = res.data.secrets || {};
-
-            // Whitelisting / selective keys sync (Issue #80)
-            const keysWhitelist = getKeysWhitelist(options.keys, config);
-
-            if (keysWhitelist) {
-                const ignoredKeys: string[] = [];
-                const filteredSecrets: Record<string, string> = {};
-                for (const [key, value] of Object.entries(secrets)) {
-                    if (keysWhitelist.has(key)) {
-                        filteredSecrets[key] = value;
-                    } else {
-                        ignoredKeys.push(key);
-                    }
-                }
-                secrets = filteredSecrets;
-                if (ignoredKeys.length > 0) {
-                    console.log(chalk.yellow(`\n⚠️  Ignored remote keys not in whitelist: ${ignoredKeys.join(', ')}`));
-                }
-            }
-
-            if (Object.keys(secrets).length === 0) {
-                console.log(chalk.yellow('No matching secrets found for this environment.'));
-                return;
-            }
-
-            let content = '';
-            let isMerged = false;
-
-            // Whitelisting forces merge behavior to avoid deleting non-whitelisted local variables (Issue #80)
-            const shouldMerge = options.merge || keysWhitelist !== null;
-
-            if (shouldMerge) {
-                try {
-                    const existingContent = await fs.readFile(envPath, 'utf-8');
-                    content = mergeEnvSecrets(existingContent, secrets);
-                    isMerged = true;
-                } catch (e: unknown) {
-                    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-                        throw e;
-                    }
-                    // File doesn't exist, fallback to regular pull behavior
-                }
-            }
-
-            if (!isMerged) {
-                // 2. Format as .env
-                content = Object.entries(secrets)
-                    .map(([key, value]) => `${key}=${formatEnvValue(value)}`)
-                    .join('\n') + '\n';
-
-                // 3. Write to file with safety check
-                try {
-                    await fs.access(envPath);
-                    console.warn(chalk.yellow(`\n⚠️  File ${options.file} already exists.`));
-                    console.warn(chalk.yellow('Overwriting existing file...'));
-                } catch {
-                    // File doesn't exist, proceed safe.
-                }
-            }
-
-            // 3. Write to file
-            await fs.writeFile(envPath, content);
-
-            console.log(chalk.green(`\n✅ Successfully pulled ${Object.keys(secrets).length} secrets to ${options.file}`));
-
-        } catch (error) {
-            if (axios.isAxiosError(error)) {
-                if (error.response?.status === 401) {
-                    console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
-                } else if (error.response?.status === 403) {
-                    console.error(chalk.red('Access denied. You do not have permission to view secrets in this environment.'));
-                } else if (error.response?.status === 404) {
-                    console.error(chalk.red('Project or Environment not found. It may have been deleted.'));
-                } else {
-                    console.error(chalk.red(`Failed to pull secrets: ${error.message}`));
-                }
-            } else {
-                console.error(chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`));
-            }
-            process.exit(1);
+          const existingContent = await fs.readFile(envPath, 'utf-8');
+          content = mergeEnvSecrets(existingContent, secrets);
+          isMerged = true;
+        } catch (e: unknown) {
+          if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw e;
+          }
+          // File doesn't exist, fallback to regular pull behavior
         }
-    });
+      }
+
+      if (!isMerged) {
+        // 2. Format as .env
+        content =
+          Object.entries(secrets)
+            .map(([key, value]) => `${key}=${formatEnvValue(value)}`)
+            .join('\n') + '\n';
+
+        // 3. Write to file with safety check
+        try {
+          await fs.access(envPath);
+          console.warn(chalk.yellow(`\n⚠️  File ${options.file} already exists.`));
+          console.warn(chalk.yellow('Overwriting existing file...'));
+        } catch {
+          // File doesn't exist, proceed safe.
+        }
+      }
+
+      // 3. Write to file
+      await fs.writeFile(envPath, content);
+
+      console.log(
+        chalk.green(
+          `\n✅ Successfully pulled ${Object.keys(secrets).length} secrets to ${options.file}`
+        )
+      );
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) {
+          console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
+        } else if (error.response?.status === 403) {
+          console.error(
+            chalk.red(
+              'Access denied. You do not have permission to view secrets in this environment.'
+            )
+          );
+        } else if (error.response?.status === 404) {
+          console.error(chalk.red('Project or Environment not found. It may have been deleted.'));
+        } else {
+          console.error(chalk.red(`Failed to pull secrets: ${error.message}`));
+        }
+      } else {
+        console.error(
+          chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`)
+        );
+      }
+      process.exit(1);
+    }
+  });
 
 interface EnvBlock {
-    type: 'comment' | 'empty' | 'key-value';
-    raw: string;
-    key?: string;
-    value?: string;
-    leadingWhitespace?: string;
-    middleWhitespace?: string;
-    quote?: '"' | "'" | null;
-    comment?: string;
+  type: 'comment' | 'empty' | 'key-value';
+  raw: string;
+  key?: string;
+  value?: string;
+  leadingWhitespace?: string;
+  middleWhitespace?: string;
+  quote?: '"' | "'" | null;
+  comment?: string;
 }
 
 function parseEnv(content: string, eol: string = '\n'): EnvBlock[] {
-    const lines = content.split(/\r?\n/);
-    const blocks: EnvBlock[] = [];
-    let i = 0;
-    while (i < lines.length) {
-        const line = lines[i];
-        
-        if (/^\s*#/.test(line) || /^\s*$/.test(line)) {
-            blocks.push({
-                type: /^\s*#/.test(line) ? 'comment' : 'empty',
-                raw: line,
-            });
-            i++;
-            continue;
-        }
+  const lines = content.split(/\r?\n/);
+  const blocks: EnvBlock[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
 
-        const declMatch = line.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
-        if (!declMatch) {
-            blocks.push({
-                type: 'comment',
-                raw: line,
-            });
-            i++;
-            continue;
-        }
-
-        const leadingWhitespace = declMatch[1];
-        const key = declMatch[2];
-        const rest = declMatch[3];
-
-        const prefixLength = leadingWhitespace.length + key.length;
-        const middleWhitespaceMatch = line.slice(prefixLength).match(/^\s*=\s*/);
-        const middleWhitespace = middleWhitespaceMatch ? middleWhitespaceMatch[0] : '=';
-
-        let value = '';
-        let quote: '"' | "'" | null = null;
-        let trailingComment = '';
-        const rawBlockLines = [line];
-
-        if (rest.startsWith('"')) {
-            quote = '"';
-            const restValue = rest.slice(1);
-            let currentLineIndex = i;
-            let foundEnd = false;
-            let valAcc = '';
-            
-            while (currentLineIndex < lines.length) {
-                const curLine = currentLineIndex === i ? restValue : lines[currentLineIndex];
-                let escaped = false;
-                let quoteIndex = -1;
-                for (let charIdx = 0; charIdx < curLine.length; charIdx++) {
-                    const char = curLine[charIdx];
-                    if (char === '\\') {
-                        escaped = !escaped;
-                    } else if (char === '"' && !escaped) {
-                        quoteIndex = charIdx;
-                        break;
-                    } else {
-                        escaped = false;
-                    }
-                }
-
-                if (quoteIndex !== -1) {
-                    valAcc += curLine.slice(0, quoteIndex);
-                    trailingComment = curLine.slice(quoteIndex + 1);
-                    foundEnd = true;
-                    break;
-                } else {
-                    valAcc += curLine + '\n';
-                    if (currentLineIndex > i) {
-                        rawBlockLines.push(lines[currentLineIndex]);
-                    }
-                    currentLineIndex++;
-                }
-            }
-
-            if (foundEnd) {
-                value = valAcc;
-                i = currentLineIndex + 1;
-            } else {
-                quote = null;
-                value = rest;
-                i++;
-            }
-        } else if (rest.startsWith("'")) {
-            quote = "'";
-            const restValue = rest.slice(1);
-            let currentLineIndex = i;
-            let foundEnd = false;
-            let valAcc = '';
-
-            while (currentLineIndex < lines.length) {
-                const curLine = currentLineIndex === i ? restValue : lines[currentLineIndex];
-                let escaped = false;
-                let quoteIndex = -1;
-                for (let charIdx = 0; charIdx < curLine.length; charIdx++) {
-                    const char = curLine[charIdx];
-                    if (char === '\\') {
-                        escaped = !escaped;
-                    } else if (char === "'" && !escaped) {
-                        quoteIndex = charIdx;
-                        break;
-                    } else {
-                        escaped = false;
-                    }
-                }
-
-                if (quoteIndex !== -1) {
-                    valAcc += curLine.slice(0, quoteIndex);
-                    trailingComment = curLine.slice(quoteIndex + 1);
-                    foundEnd = true;
-                    break;
-                } else {
-                    valAcc += curLine + '\n';
-                    if (currentLineIndex > i) {
-                        rawBlockLines.push(lines[currentLineIndex]);
-                    }
-                    currentLineIndex++;
-                }
-            }
-
-            if (foundEnd) {
-                value = valAcc;
-                i = currentLineIndex + 1;
-            } else {
-                quote = null;
-                value = rest;
-                i++;
-            }
-        } else {
-            const commentMatch = rest.match(/(\s+#.*)$/);
-            if (commentMatch) {
-                value = rest.slice(0, rest.length - commentMatch[1].length).trim();
-                trailingComment = commentMatch[1];
-            } else {
-                value = rest.trim();
-                trailingComment = '';
-            }
-            quote = null;
-            i++;
-        }
-
-        blocks.push({
-            type: 'key-value',
-            raw: rawBlockLines.join(eol),
-            key,
-            value,
-            leadingWhitespace,
-            middleWhitespace,
-            quote,
-            comment: trailingComment,
-        });
+    if (/^\s*#/.test(line) || /^\s*$/.test(line)) {
+      blocks.push({
+        type: /^\s*#/.test(line) ? 'comment' : 'empty',
+        raw: line,
+      });
+      i++;
+      continue;
     }
-    return blocks;
+
+    const declMatch = line.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!declMatch) {
+      blocks.push({
+        type: 'comment',
+        raw: line,
+      });
+      i++;
+      continue;
+    }
+
+    const leadingWhitespace = declMatch[1];
+    const key = declMatch[2];
+    const rest = declMatch[3];
+
+    const prefixLength = leadingWhitespace.length + key.length;
+    const middleWhitespaceMatch = line.slice(prefixLength).match(/^\s*=\s*/);
+    const middleWhitespace = middleWhitespaceMatch ? middleWhitespaceMatch[0] : '=';
+
+    let value = '';
+    let quote: '"' | "'" | null = null;
+    let trailingComment = '';
+    const rawBlockLines = [line];
+
+    if (rest.startsWith('"')) {
+      quote = '"';
+      const restValue = rest.slice(1);
+      let currentLineIndex = i;
+      let foundEnd = false;
+      let valAcc = '';
+
+      while (currentLineIndex < lines.length) {
+        const curLine = currentLineIndex === i ? restValue : lines[currentLineIndex];
+        let escaped = false;
+        let quoteIndex = -1;
+        for (let charIdx = 0; charIdx < curLine.length; charIdx++) {
+          const char = curLine[charIdx];
+          if (char === '\\') {
+            escaped = !escaped;
+          } else if (char === '"' && !escaped) {
+            quoteIndex = charIdx;
+            break;
+          } else {
+            escaped = false;
+          }
+        }
+
+        if (quoteIndex !== -1) {
+          valAcc += curLine.slice(0, quoteIndex);
+          trailingComment = curLine.slice(quoteIndex + 1);
+          foundEnd = true;
+          break;
+        } else {
+          valAcc += curLine + '\n';
+          if (currentLineIndex > i) {
+            rawBlockLines.push(lines[currentLineIndex]);
+          }
+          currentLineIndex++;
+        }
+      }
+
+      if (foundEnd) {
+        value = valAcc;
+        i = currentLineIndex + 1;
+      } else {
+        quote = null;
+        value = rest;
+        i++;
+      }
+    } else if (rest.startsWith("'")) {
+      quote = "'";
+      const restValue = rest.slice(1);
+      let currentLineIndex = i;
+      let foundEnd = false;
+      let valAcc = '';
+
+      while (currentLineIndex < lines.length) {
+        const curLine = currentLineIndex === i ? restValue : lines[currentLineIndex];
+        let escaped = false;
+        let quoteIndex = -1;
+        for (let charIdx = 0; charIdx < curLine.length; charIdx++) {
+          const char = curLine[charIdx];
+          if (char === '\\') {
+            escaped = !escaped;
+          } else if (char === "'" && !escaped) {
+            quoteIndex = charIdx;
+            break;
+          } else {
+            escaped = false;
+          }
+        }
+
+        if (quoteIndex !== -1) {
+          valAcc += curLine.slice(0, quoteIndex);
+          trailingComment = curLine.slice(quoteIndex + 1);
+          foundEnd = true;
+          break;
+        } else {
+          valAcc += curLine + '\n';
+          if (currentLineIndex > i) {
+            rawBlockLines.push(lines[currentLineIndex]);
+          }
+          currentLineIndex++;
+        }
+      }
+
+      if (foundEnd) {
+        value = valAcc;
+        i = currentLineIndex + 1;
+      } else {
+        quote = null;
+        value = rest;
+        i++;
+      }
+    } else {
+      const commentMatch = rest.match(/(\s+#.*)$/);
+      if (commentMatch) {
+        value = rest.slice(0, rest.length - commentMatch[1].length).trim();
+        trailingComment = commentMatch[1];
+      } else {
+        value = rest.trim();
+        trailingComment = '';
+      }
+      quote = null;
+      i++;
+    }
+
+    blocks.push({
+      type: 'key-value',
+      raw: rawBlockLines.join(eol),
+      key,
+      value,
+      leadingWhitespace,
+      middleWhitespace,
+      quote,
+      comment: trailingComment,
+    });
+  }
+  return blocks;
 }
 
 function formatEnvValue(value: string, originalQuote?: '"' | "'" | null): string {
-    if (value.includes('\n') || value.includes('\r')) {
-        return `"${value.replace(/"/g, '\\"')}"`;
+  if (value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '\\"')}"`;
+  }
+
+  if (/[#=\s'"]/.test(value)) {
+    const quote = originalQuote === '"' || originalQuote === "'" ? originalQuote : '"';
+    if (quote === '"') {
+      return `"${value.replace(/"/g, '\\"')}"`;
+    } else {
+      return `'${value.replace(/'/g, "\\'")}'`;
     }
-    
-    if (/[#=\s'"]/.test(value)) {
-        const quote = (originalQuote === '"' || originalQuote === "'") ? originalQuote : '"';
-        if (quote === '"') {
-            return `"${value.replace(/"/g, '\\"')}"`;
-        } else {
-            return `'${value.replace(/'/g, "\\'")}'`;
-        }
-    }
-    
-    if (originalQuote === '"') {
-        return `"${value.replace(/"/g, '\\"')}"`;
-    } else if (originalQuote === "'") {
-        return `'${value.replace(/'/g, "\\'")}'`;
-    }
-    
-    return value;
+  }
+
+  if (originalQuote === '"') {
+    return `"${value.replace(/"/g, '\\"')}"`;
+  } else if (originalQuote === "'") {
+    return `'${value.replace(/'/g, "\\'")}'`;
+  }
+
+  return value;
 }
 
 function mergeEnvSecrets(existingContent: string, secrets: Record<string, string>): string {
-    const eol = existingContent.includes('\r\n') ? '\r\n' : '\n';
-    const blocks = parseEnv(existingContent, eol);
-    const updatedKeys = new Set<string>();
-    const resultLines: string[] = [];
+  const eol = existingContent.includes('\r\n') ? '\r\n' : '\n';
+  const blocks = parseEnv(existingContent, eol);
+  const updatedKeys = new Set<string>();
+  const resultLines: string[] = [];
 
-    for (const block of blocks) {
-        if (block.type === 'key-value' && block.key) {
-            const key = block.key;
-            if (Object.prototype.hasOwnProperty.call(secrets, key)) {
-                const value = secrets[key];
-                resultLines.push(
-                    block.leadingWhitespace +
-                    key +
-                    block.middleWhitespace +
-                    formatEnvValue(value, block.quote) +
-                    block.comment
-                );
-                updatedKeys.add(key);
-                continue;
-            }
-        }
-        resultLines.push(block.raw);
+  for (const block of blocks) {
+    if (block.type === 'key-value' && block.key) {
+      const key = block.key;
+      if (Object.prototype.hasOwnProperty.call(secrets, key)) {
+        const value = secrets[key];
+        resultLines.push(
+          block.leadingWhitespace +
+            key +
+            block.middleWhitespace +
+            formatEnvValue(value, block.quote) +
+            block.comment
+        );
+        updatedKeys.add(key);
+        continue;
+      }
     }
+    resultLines.push(block.raw);
+  }
 
-    const newKeys = Object.keys(secrets).filter((k) => !updatedKeys.has(k));
-    if (newKeys.length > 0) {
-        if (resultLines.length > 0 && resultLines[resultLines.length - 1].trim() !== '') {
-            resultLines.push('');
-        }
-        for (const key of newKeys) {
-            const value = secrets[key];
-            resultLines.push(key + '=' + formatEnvValue(value));
-        }
+  const newKeys = Object.keys(secrets).filter((k) => !updatedKeys.has(k));
+  if (newKeys.length > 0) {
+    if (resultLines.length > 0 && resultLines[resultLines.length - 1].trim() !== '') {
+      resultLines.push('');
     }
+    for (const key of newKeys) {
+      const value = secrets[key];
+      resultLines.push(key + '=' + formatEnvValue(value));
+    }
+  }
 
-    return resultLines.join(eol);
+  return resultLines.join(eol);
 }
 
-function getKeysWhitelist(optionsKeys?: string, config?: { keys?: string[]; syncKeys?: string[] } | null): Set<string> | null {
-    if (optionsKeys) {
-        const keys = optionsKeys.split(',')
-            .map(k => k.trim())
-            .filter(k => k.length > 0);
-        return keys.length > 0 ? new Set(keys) : null;
+function getKeysWhitelist(
+  optionsKeys?: string,
+  config?: { keys?: string[]; syncKeys?: string[] } | null
+): Set<string> | null {
+  if (optionsKeys) {
+    const keys = optionsKeys
+      .split(',')
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0);
+    return keys.length > 0 ? new Set(keys) : null;
+  }
+
+  if (config) {
+    const keys = config.keys || config.syncKeys;
+    if (Array.isArray(keys)) {
+      const normalized = keys
+        .map((k) => (typeof k === 'string' ? k.trim() : ''))
+        .filter((k) => k.length > 0);
+      return normalized.length > 0 ? new Set(normalized) : null;
     }
-    
-    if (config) {
-        const keys = config.keys || config.syncKeys;
-        if (Array.isArray(keys)) {
-            const normalized = keys
-                .map(k => typeof k === 'string' ? k.trim() : '')
-                .filter(k => k.length > 0);
-            return normalized.length > 0 ? new Set(normalized) : null;
-        }
-    }
-    
-    return null;
+  }
+
+  return null;
 }

--- a/apps/pawthy/src/commands/push.test.ts
+++ b/apps/pawthy/src/commands/push.test.ts
@@ -8,352 +8,352 @@ import { pushCommand } from './push.js';
 import { config } from '../config.js';
 
 describe('Push Command', () => {
-    let exitCode: number | null = null;
-    let tempDir: string;
+  let exitCode: number | null = null;
+  let tempDir: string;
 
-    beforeEach(async () => {
-        exitCode = null;
+  beforeEach(async () => {
+    exitCode = null;
 
-        // Reset commander options to prevent test pollution
-        pushCommand.setOptionValue('file', '.env');
-        pushCommand.setOptionValue('force', undefined);
-        pushCommand.setOptionValue('projectId', undefined);
-        pushCommand.setOptionValue('envId', undefined);
-        pushCommand.setOptionValue('keys', undefined);
+    // Reset commander options to prevent test pollution
+    pushCommand.setOptionValue('file', '.env');
+    pushCommand.setOptionValue('force', undefined);
+    pushCommand.setOptionValue('projectId', undefined);
+    pushCommand.setOptionValue('envId', undefined);
+    pushCommand.setOptionValue('keys', undefined);
 
-        // Create a unique temp directory outside the repository
-        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-push-'));
+    // Create a unique temp directory outside the repository
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-test-push-'));
 
-        // Mock process.cwd to return our temp directory
-        mock.method(process, 'cwd', () => tempDir);
+    // Mock process.cwd to return our temp directory
+    mock.method(process, 'cwd', () => tempDir);
 
-        // Mock process.exit
-        mock.method(process, 'exit', (code?: number) => {
-            exitCode = code ?? null;
-            throw new Error(`process.exit called with ${code}`);
-        });
-
-        // Write a dummy .pawthyrc file in the temp directory
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc'),
-            JSON.stringify({ projectId: 'test-project', envId: 'test-env' })
-        );
-
-        // Write a dummy .env file
-        await fs.writeFile(path.join(tempDir, '.env'), 'MY_VAR=value');
+    // Mock process.exit
+    mock.method(process, 'exit', (code?: number) => {
+      exitCode = code ?? null;
+      throw new Error(`process.exit called with ${code}`);
     });
 
-    afterEach(async () => {
-        mock.restoreAll();
-        // Clean up environment variables to prevent test pollution
-        delete process.env.PAWTHY_PROJECT_ID;
-        delete process.env.PAWTHY_ENV_ID;
+    // Write a dummy .pawthyrc file in the temp directory
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({ projectId: 'test-project', envId: 'test-env' })
+    );
 
-        // Clean up the temp directory
-        try {
-            await fs.rm(tempDir, { recursive: true, force: true });
-        } catch {
-            // Ignore
-        }
+    // Write a dummy .env file
+    await fs.writeFile(path.join(tempDir, '.env'), 'MY_VAR=value');
+  });
+
+  afterEach(async () => {
+    mock.restoreAll();
+    // Clean up environment variables to prevent test pollution
+    delete process.env.PAWTHY_PROJECT_ID;
+    delete process.env.PAWTHY_ENV_ID;
+
+    // Clean up the temp directory
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it('should prioritize CLI flags over env vars and .pawthyrc', async () => {
+    let requestedUrl = '';
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should prioritize CLI flags over env vars and .pawthyrc', async () => {
-        let requestedUrl = '';
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Set env vars
+    process.env.PAWTHY_PROJECT_ID = 'env-project';
+    process.env.PAWTHY_ENV_ID = 'env-env';
 
-        // Set env vars
-        process.env.PAWTHY_PROJECT_ID = 'env-project';
-        process.env.PAWTHY_ENV_ID = 'env-env';
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'put', async (url: string): Promise<any> => {
-            requestedUrl = url;
-            return {
-                status: 200,
-                data: { success: true },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pushCommand.parseAsync([
-            'node',
-            'pawthy',
-            'push',
-            '--force',
-            '-p',
-            'flag-project',
-            '-e',
-            'flag-env',
-        ]);
-
-        // Verify the URL contained the flag values
-        assert.ok(requestedUrl.includes('/projects/flag-project/environments/flag-env/secrets'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string): Promise<any> => {
+      requestedUrl = url;
+      return {
+        status: 200,
+        data: { success: true },
+      };
     });
 
-    it('should prioritize .pawthyrc over env vars', async () => {
-        let requestedUrl = '';
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        // Set env vars
-        process.env.PAWTHY_PROJECT_ID = 'env-project';
-        process.env.PAWTHY_ENV_ID = 'env-env';
+    await pushCommand.parseAsync([
+      'node',
+      'pawthy',
+      'push',
+      '--force',
+      '-p',
+      'flag-project',
+      '-e',
+      'flag-env',
+    ]);
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'put', async (url: string): Promise<any> => {
-            requestedUrl = url;
-            return {
-                status: 200,
-                data: { success: true },
-            };
-        });
+    // Verify the URL contained the flag values
+    assert.ok(requestedUrl.includes('/projects/flag-project/environments/flag-env/secrets'));
+  });
 
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
-
-        // Verify the URL contained the .pawthyrc values, not the env var values
-        assert.ok(requestedUrl.includes('/projects/test-project/environments/test-env/secrets'));
+  it('should prioritize .pawthyrc over env vars', async () => {
+    let requestedUrl = '';
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should use env vars if .pawthyrc is missing', async () => {
-        let requestedUrl = '';
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Set env vars
+    process.env.PAWTHY_PROJECT_ID = 'env-project';
+    process.env.PAWTHY_ENV_ID = 'env-env';
 
-        // Delete the .pawthyrc file
-        await fs.unlink(path.join(tempDir, '.pawthyrc'));
-
-        // Set env vars
-        process.env.PAWTHY_PROJECT_ID = 'env-project';
-        process.env.PAWTHY_ENV_ID = 'env-env';
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'put', async (url: string): Promise<any> => {
-            requestedUrl = url;
-            return {
-                status: 200,
-                data: { success: true },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
-
-        // Verify the URL contained the env var values
-        assert.ok(requestedUrl.includes('/projects/env-project/environments/env-env/secrets'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string): Promise<any> => {
+      requestedUrl = url;
+      return {
+        status: 200,
+        data: { success: true },
+      };
     });
 
-    it('should exit with code 1 if project ID or environment ID is missing and no .pawthyrc', async () => {
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        // Delete the .pawthyrc file so it cannot be resolved there
-        await fs.unlink(path.join(tempDir, '.pawthyrc'));
+    await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
 
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
+    // Verify the URL contained the .pawthyrc values, not the env var values
+    assert.ok(requestedUrl.includes('/projects/test-project/environments/test-env/secrets'));
+  });
 
-        try {
-            await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
-        } catch {
-            // Expected to throw because process.exit throws
-        }
-
-        assert.strictEqual(exitCode, 1);
+  it('should use env vars if .pawthyrc is missing', async () => {
+    let requestedUrl = '';
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should support whitelisting via CLI keys flag in push command', async () => {
-        let pushedSecrets: Record<string, string> = {};
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Delete the .pawthyrc file
+    await fs.unlink(path.join(tempDir, '.pawthyrc'));
 
-        // Write a .env with multiple variables
-        await fs.writeFile(
-            path.join(tempDir, '.env'),
-            ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key', 'LOCAL_VAR=123'].join('\n')
-        );
+    // Set env vars
+    process.env.PAWTHY_PROJECT_ID = 'env-project';
+    process.env.PAWTHY_ENV_ID = 'env-env';
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
-            pushedSecrets = data.secrets;
-            return {
-                status: 200,
-                data: { success: true },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        // Request only DATABASE_URL and API_KEY
-        await pushCommand.parseAsync([
-            'node',
-            'pawthy',
-            'push',
-            '--force',
-            '-k',
-            'DATABASE_URL, API_KEY',
-        ]);
-
-        assert.deepStrictEqual(pushedSecrets, {
-            DATABASE_URL: 'postgres://localhost/db',
-            API_KEY: 'secret-key',
-        });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string): Promise<any> => {
+      requestedUrl = url;
+      return {
+        status: 200,
+        data: { success: true },
+      };
     });
 
-    it('should support whitelisting via keys array in .pawthyrc in push command', async () => {
-        let pushedSecrets: Record<string, string> = {};
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        // Write a .pawthyrc containing a keys whitelist
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc'),
-            JSON.stringify({
-                projectId: 'test-project',
-                envId: 'test-env',
-                keys: ['DATABASE_URL'],
-            })
-        );
+    await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
 
-        // Write a .env with multiple variables
-        await fs.writeFile(
-            path.join(tempDir, '.env'),
-            ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
-        );
+    // Verify the URL contained the env var values
+    assert.ok(requestedUrl.includes('/projects/env-project/environments/env-env/secrets'));
+  });
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
-            pushedSecrets = data.secrets;
-            return {
-                status: 200,
-                data: { success: true },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
-
-        assert.deepStrictEqual(pushedSecrets, {
-            DATABASE_URL: 'postgres://localhost/db',
-        });
+  it('should exit with code 1 if project ID or environment ID is missing and no .pawthyrc', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should support whitelisting via keys array in .pawthyrc.local in push command', async () => {
-        let pushedSecrets: Record<string, string> = {};
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Delete the .pawthyrc file so it cannot be resolved there
+    await fs.unlink(path.join(tempDir, '.pawthyrc'));
 
-        // Write .pawthyrc and .pawthyrc.local
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc'),
-            JSON.stringify({
-                projectId: 'test-project',
-                envId: 'test-env',
-            })
-        );
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc.local'),
-            JSON.stringify({
-                keys: ['API_KEY'],
-            })
-        );
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
 
-        // Write a .env with multiple variables
-        await fs.writeFile(
-            path.join(tempDir, '.env'),
-            ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
-        );
+    try {
+      await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+    } catch {
+      // Expected to throw because process.exit throws
+    }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
-            pushedSecrets = data.secrets;
-            return {
-                status: 200,
-                data: { success: true },
-            };
-        });
+    assert.strictEqual(exitCode, 1);
+  });
 
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
-
-        assert.deepStrictEqual(pushedSecrets, {
-            API_KEY: 'secret-key',
-        });
+  it('should support whitelisting via CLI keys flag in push command', async () => {
+    let pushedSecrets: Record<string, string> = {};
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
     });
 
-    it('should support whitelisting via syncKeys array in .pawthyrc in push command', async () => {
-        let pushedSecrets: Record<string, string> = {};
-        mock.method(config, 'get', (key: string) => {
-            if (key === 'token') return 'test-token';
-            if (key === 'apiUrl') return 'http://localhost:3000';
-            return undefined;
-        });
+    // Write a .env with multiple variables
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key', 'LOCAL_VAR=123'].join('\n')
+    );
 
-        // Write a .pawthyrc containing syncKeys alias
-        await fs.writeFile(
-            path.join(tempDir, '.pawthyrc'),
-            JSON.stringify({
-                projectId: 'test-project',
-                envId: 'test-env',
-                syncKeys: ['DATABASE_URL'],
-            })
-        );
-
-        // Write a .env with multiple variables
-        await fs.writeFile(
-            path.join(tempDir, '.env'),
-            ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
-        );
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
-            pushedSecrets = data.secrets;
-            return {
-                status: 200,
-                data: { success: true },
-            };
-        });
-
-        mock.method(console, 'log', () => {});
-        mock.method(console, 'error', () => {});
-
-        await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
-
-        assert.deepStrictEqual(pushedSecrets, {
-            DATABASE_URL: 'postgres://localhost/db',
-        });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+      pushedSecrets = data.secrets;
+      return {
+        status: 200,
+        data: { success: true },
+      };
     });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    // Request only DATABASE_URL and API_KEY
+    await pushCommand.parseAsync([
+      'node',
+      'pawthy',
+      'push',
+      '--force',
+      '-k',
+      'DATABASE_URL, API_KEY',
+    ]);
+
+    assert.deepStrictEqual(pushedSecrets, {
+      DATABASE_URL: 'postgres://localhost/db',
+      API_KEY: 'secret-key',
+    });
+  });
+
+  it('should support whitelisting via keys array in .pawthyrc in push command', async () => {
+    let pushedSecrets: Record<string, string> = {};
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    // Write a .pawthyrc containing a keys whitelist
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({
+        projectId: 'test-project',
+        envId: 'test-env',
+        keys: ['DATABASE_URL'],
+      })
+    );
+
+    // Write a .env with multiple variables
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+      pushedSecrets = data.secrets;
+      return {
+        status: 200,
+        data: { success: true },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+
+    assert.deepStrictEqual(pushedSecrets, {
+      DATABASE_URL: 'postgres://localhost/db',
+    });
+  });
+
+  it('should support whitelisting via keys array in .pawthyrc.local in push command', async () => {
+    let pushedSecrets: Record<string, string> = {};
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    // Write .pawthyrc and .pawthyrc.local
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({
+        projectId: 'test-project',
+        envId: 'test-env',
+      })
+    );
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc.local'),
+      JSON.stringify({
+        keys: ['API_KEY'],
+      })
+    );
+
+    // Write a .env with multiple variables
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+      pushedSecrets = data.secrets;
+      return {
+        status: 200,
+        data: { success: true },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+
+    assert.deepStrictEqual(pushedSecrets, {
+      API_KEY: 'secret-key',
+    });
+  });
+
+  it('should support whitelisting via syncKeys array in .pawthyrc in push command', async () => {
+    let pushedSecrets: Record<string, string> = {};
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    // Write a .pawthyrc containing syncKeys alias
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({
+        projectId: 'test-project',
+        envId: 'test-env',
+        syncKeys: ['DATABASE_URL'],
+      })
+    );
+
+    // Write a .env with multiple variables
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      ['DATABASE_URL=postgres://localhost/db', 'API_KEY=secret-key'].join('\n')
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+      pushedSecrets = data.secrets;
+      return {
+        status: 200,
+        data: { success: true },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+
+    assert.deepStrictEqual(pushedSecrets, {
+      DATABASE_URL: 'postgres://localhost/db',
+    });
+  });
 });

--- a/apps/pawthy/src/commands/push.ts
+++ b/apps/pawthy/src/commands/push.ts
@@ -7,136 +7,164 @@ import dotenv from 'dotenv';
 import { getToken, getApiUrl, getProjectConfig } from '../config.js';
 
 export const pushCommand = new Command('push')
-    .description('Push local .env secrets to Purrmission, updating existing values. This does not remove secrets.')
-    .option('-f, --file <path>', 'Path to .env file', '.env')
-    .option('--force', 'Push secrets without confirmation')
-    .option('-p, --project-id <id>', 'Project ID')
-    .option('-e, --env-id <id>', 'Environment ID')
-    .option('-k, --keys <list>', 'Comma-separated list of keys to push')
-    .action(async (options) => {
-        const token = getToken();
-        const apiUrl = getApiUrl();
-        if (!token) {
-            console.error(chalk.red('You must be logged in. Run `pawthy login` first.'));
-            process.exit(1);
-            return;
-        }
-
-        let projectId = options.projectId;
-        let envId = options.envId;
-        let config: { projectId?: string; envId?: string; keys?: string[]; syncKeys?: string[] } | null = null;
-
-        if (!projectId || !envId || !options.keys) {
-            config = await getProjectConfig();
-            projectId = projectId || config?.projectId || process.env.PAWTHY_PROJECT_ID;
-            envId = envId || config?.envId || process.env.PAWTHY_ENV_ID;
-        }
-
-        if (!projectId || !envId) {
-            console.error(
-                chalk.red(
-                    'Project ID and Environment ID must be specified (via CLI flags -p/-e, env vars PAWTHY_PROJECT_ID/PAWTHY_ENV_ID, or .pawthyrc config).'
-                )
-            );
-            process.exit(1);
-            return;
-        }
-
-        const envPath = path.resolve(process.cwd(), options.file);
-
-        try {
-            // 1. Read and Parse .env
-            const envContent = await fs.readFile(envPath, 'utf-8');
-            let secrets = dotenv.parse(envContent);
-
-            // Whitelisting / selective keys sync (Issue #80)
-            const keysWhitelist = getKeysWhitelist(options.keys, config);
-
-            if (keysWhitelist) {
-                const skippedKeys: string[] = [];
-                const filteredSecrets: Record<string, string> = {};
-                for (const [key, value] of Object.entries(secrets)) {
-                    if (keysWhitelist.has(key)) {
-                        filteredSecrets[key] = value;
-                    } else {
-                        skippedKeys.push(key);
-                    }
-                }
-                secrets = filteredSecrets;
-                if (skippedKeys.length > 0) {
-                    console.log(chalk.yellow(`\n⚠️  Skipped pushing keys not in whitelist: ${skippedKeys.join(', ')}`));
-                }
-            }
-
-            if (Object.keys(secrets).length === 0) {
-                console.log(chalk.yellow('No matching secrets found in the specified file.'));
-                return;
-            }
-
-            // 2. Confirmation Prompt
-            if (!options.force) {
-                const inquirer = (await import('inquirer')).default;
-                const { confirm } = await inquirer.prompt([{
-                    type: 'confirm',
-                    name: 'confirm',
-                    message: `You are about to push ${Object.keys(secrets).length} secrets to Purrmission. This may overwrite existing values. Continue?`,
-                    default: false,
-                }]);
-
-                if (!confirm) {
-                    console.log(chalk.yellow('Push cancelled.'));
-                    return;
-                }
-            }
-
-            console.log(chalk.dim(`Pushing ${Object.keys(secrets).length} secrets to Purrmission...`));
-
-            // 3. Push to API
-            await axios.put(`${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`, {
-                secrets
-            }, {
-                headers: { Authorization: `Bearer ${token}` },
-            });
-
-            console.log(chalk.green('\n✅ Secrets pushed successfully!'));
-
-        } catch (error) {
-            if (axios.isAxiosError(error)) {
-                if (error.response?.status === 401) {
-                    console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
-                } else if (error.response?.status === 403) {
-                    console.error(chalk.red('Access denied. You do not have permission to push secrets to this environment.'));
-                } else if (error.response?.status === 404) {
-                    console.error(chalk.red('Project or Environment not found. It may have been deleted.'));
-                } else {
-                    console.error(chalk.red(`Failed to push secrets: ${error.message}`));
-                }
-            } else if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
-                console.error(chalk.red(`File not found: ${envPath}`));
-            } else {
-                console.error(chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`));
-            }
-            process.exit(1);
-        }
-    });
-
-function getKeysWhitelist(optionsKeys?: string, config?: { keys?: string[]; syncKeys?: string[] } | null): Set<string> | null {
-    if (optionsKeys) {
-        const keys = optionsKeys.split(',')
-            .map(k => k.trim())
-            .filter(k => k.length > 0);
-        return keys.length > 0 ? new Set(keys) : null;
+  .description(
+    'Push local .env secrets to Purrmission, updating existing values. This does not remove secrets.'
+  )
+  .option('-f, --file <path>', 'Path to .env file', '.env')
+  .option('--force', 'Push secrets without confirmation')
+  .option('-p, --project-id <id>', 'Project ID')
+  .option('-e, --env-id <id>', 'Environment ID')
+  .option('-k, --keys <list>', 'Comma-separated list of keys to push')
+  .action(async (options) => {
+    const token = getToken();
+    const apiUrl = getApiUrl();
+    if (!token) {
+      console.error(chalk.red('You must be logged in. Run `pawthy login` first.'));
+      process.exit(1);
+      return;
     }
-    
-    if (config) {
-        const keys = config.keys || config.syncKeys;
-        if (Array.isArray(keys)) {
-            const normalized = keys
-                .map(k => typeof k === 'string' ? k.trim() : '')
-                .filter(k => k.length > 0);
-            return normalized.length > 0 ? new Set(normalized) : null;
-        }
+
+    let projectId = options.projectId;
+    let envId = options.envId;
+    let config: {
+      projectId?: string;
+      envId?: string;
+      keys?: string[];
+      syncKeys?: string[];
+    } | null = null;
+
+    if (!projectId || !envId || !options.keys) {
+      config = await getProjectConfig();
+      projectId = projectId || config?.projectId || process.env.PAWTHY_PROJECT_ID;
+      envId = envId || config?.envId || process.env.PAWTHY_ENV_ID;
     }
-    
-    return null;
+
+    if (!projectId || !envId) {
+      console.error(
+        chalk.red(
+          'Project ID and Environment ID must be specified (via CLI flags -p/-e, env vars PAWTHY_PROJECT_ID/PAWTHY_ENV_ID, or .pawthyrc config).'
+        )
+      );
+      process.exit(1);
+      return;
+    }
+
+    const envPath = path.resolve(process.cwd(), options.file);
+
+    try {
+      // 1. Read and Parse .env
+      const envContent = await fs.readFile(envPath, 'utf-8');
+      let secrets = dotenv.parse(envContent);
+
+      // Whitelisting / selective keys sync (Issue #80)
+      const keysWhitelist = getKeysWhitelist(options.keys, config);
+
+      if (keysWhitelist) {
+        const skippedKeys: string[] = [];
+        const filteredSecrets: Record<string, string> = {};
+        for (const [key, value] of Object.entries(secrets)) {
+          if (keysWhitelist.has(key)) {
+            filteredSecrets[key] = value;
+          } else {
+            skippedKeys.push(key);
+          }
+        }
+        secrets = filteredSecrets;
+        if (skippedKeys.length > 0) {
+          console.log(
+            chalk.yellow(`\n⚠️  Skipped pushing keys not in whitelist: ${skippedKeys.join(', ')}`)
+          );
+        }
+      }
+
+      if (Object.keys(secrets).length === 0) {
+        console.log(chalk.yellow('No matching secrets found in the specified file.'));
+        return;
+      }
+
+      // 2. Confirmation Prompt
+      if (!options.force) {
+        const inquirer = (await import('inquirer')).default;
+        const { confirm } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'confirm',
+            message: `You are about to push ${Object.keys(secrets).length} secrets to Purrmission. This may overwrite existing values. Continue?`,
+            default: false,
+          },
+        ]);
+
+        if (!confirm) {
+          console.log(chalk.yellow('Push cancelled.'));
+          return;
+        }
+      }
+
+      console.log(chalk.dim(`Pushing ${Object.keys(secrets).length} secrets to Purrmission...`));
+
+      // 3. Push to API
+      await axios.put(
+        `${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`,
+        {
+          secrets,
+        },
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+
+      console.log(chalk.green('\n✅ Secrets pushed successfully!'));
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) {
+          console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
+        } else if (error.response?.status === 403) {
+          console.error(
+            chalk.red(
+              'Access denied. You do not have permission to push secrets to this environment.'
+            )
+          );
+        } else if (error.response?.status === 404) {
+          console.error(chalk.red('Project or Environment not found. It may have been deleted.'));
+        } else {
+          console.error(chalk.red(`Failed to push secrets: ${error.message}`));
+        }
+      } else if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as NodeJS.ErrnoException).code === 'ENOENT'
+      ) {
+        console.error(chalk.red(`File not found: ${envPath}`));
+      } else {
+        console.error(
+          chalk.red(`An error occurred: ${error instanceof Error ? error.message : String(error)}`)
+        );
+      }
+      process.exit(1);
+    }
+  });
+
+function getKeysWhitelist(
+  optionsKeys?: string,
+  config?: { keys?: string[]; syncKeys?: string[] } | null
+): Set<string> | null {
+  if (optionsKeys) {
+    const keys = optionsKeys
+      .split(',')
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0);
+    return keys.length > 0 ? new Set(keys) : null;
+  }
+
+  if (config) {
+    const keys = config.keys || config.syncKeys;
+    if (Array.isArray(keys)) {
+      const normalized = keys
+        .map((k) => (typeof k === 'string' ? k.trim() : ''))
+        .filter((k) => k.length > 0);
+      return normalized.length > 0 ? new Set(normalized) : null;
+    }
+  }
+
+  return null;
 }

--- a/apps/pawthy/src/config.test.ts
+++ b/apps/pawthy/src/config.test.ts
@@ -1,4 +1,3 @@
-
 import { describe, it, mock, afterEach, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import os from 'os';
@@ -7,148 +6,146 @@ import path from 'path';
 import { getApiUrl, config, findProjectRoot, getProjectConfig } from './config.js';
 
 describe('Config', () => {
-    const originalEnv = process.env;
+  const originalEnv = process.env;
 
-    afterEach(() => {
-        process.env = originalEnv;
-        mock.restoreAll();
+  afterEach(() => {
+    process.env = originalEnv;
+    mock.restoreAll();
+  });
+
+  it('should prioritize PAWTHY_API_URL from shell environment', () => {
+    process.env = { ...originalEnv, PAWTHY_API_URL: 'https://shell.example.com' };
+    // We don't need to mock config here because env var takes precedence
+    assert.strictEqual(getApiUrl(), 'https://shell.example.com');
+  });
+
+  it('should prioritize config file over default if env var is missing', () => {
+    process.env = { ...originalEnv };
+    delete process.env.PAWTHY_API_URL;
+
+    // Mock config.get
+    mock.method(config, 'get', (key: string) => {
+      return key === 'apiUrl' ? 'https://config.example.com' : undefined;
     });
 
-    it('should prioritize PAWTHY_API_URL from shell environment', () => {
-        process.env = { ...originalEnv, PAWTHY_API_URL: 'https://shell.example.com' };
-        // We don't need to mock config here because env var takes precedence
-        assert.strictEqual(getApiUrl(), 'https://shell.example.com');
+    assert.strictEqual(getApiUrl(), 'https://config.example.com');
+  });
+
+  it('should use default production URL if no env var or config is set', () => {
+    process.env = { ...originalEnv };
+    delete process.env.PAWTHY_API_URL;
+
+    // Mock config.get to return default value
+    mock.method(config, 'get', (key: string) => {
+      return key === 'apiUrl' ? 'https://purrmission.infra.purrfecthq.com' : undefined;
     });
 
-    it('should prioritize config file over default if env var is missing', () => {
-        process.env = { ...originalEnv };
-        delete process.env.PAWTHY_API_URL;
+    assert.strictEqual(getApiUrl(), 'https://purrmission.infra.purrfecthq.com');
+  });
 
-        // Mock config.get
-        mock.method(config, 'get', (key: string) => {
-            return key === 'apiUrl' ? 'https://config.example.com' : undefined;
-        });
+  describe('findProjectRoot', () => {
+    let tempDir: string;
 
-        assert.strictEqual(getApiUrl(), 'https://config.example.com');
+    beforeEach(async () => {
+      tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pawthy-find-root-'));
     });
 
-    it('should use default production URL if no env var or config is set', () => {
-        process.env = { ...originalEnv };
-        delete process.env.PAWTHY_API_URL;
-
-
-        // Mock config.get to return default value
-        mock.method(config, 'get', (key: string) => {
-            return key === 'apiUrl' ? 'https://purrmission.infra.purrfecthq.com' : undefined;
-        });
-
-
-        assert.strictEqual(getApiUrl(), 'https://purrmission.infra.purrfecthq.com');
+    afterEach(async () => {
+      try {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore
+      }
     });
 
-    describe('findProjectRoot', () => {
-        let tempDir: string;
-
-        beforeEach(async () => {
-            tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pawthy-find-root-'));
-        });
-
-        afterEach(async () => {
-            try {
-                await fs.promises.rm(tempDir, { recursive: true, force: true });
-            } catch {
-                // Ignore
-            }
-        });
-
-        it('should return starting directory if .pawthyrc exists', async () => {
-            await fs.promises.writeFile(path.join(tempDir, '.pawthyrc'), '{}');
-            const root = findProjectRoot(tempDir);
-            assert.strictEqual(root, tempDir);
-        });
-
-        it('should walk up to find .pawthyrc in parent directory', async () => {
-            await fs.promises.writeFile(path.join(tempDir, '.pawthyrc'), '{}');
-            const subDir = path.join(tempDir, 'sub1', 'sub2');
-            await fs.promises.mkdir(subDir, { recursive: true });
-            const root = findProjectRoot(subDir);
-            assert.strictEqual(root, tempDir);
-        });
-
-        it('should walk up to find .git in parent directory', async () => {
-            await fs.promises.mkdir(path.join(tempDir, '.git'), { recursive: true });
-            const subDir = path.join(tempDir, 'sub1', 'sub2');
-            await fs.promises.mkdir(subDir, { recursive: true });
-            const root = findProjectRoot(subDir);
-            assert.strictEqual(root, tempDir);
-        });
-
-        it('should fallback to the resolved startDir if no project root indicators are found', () => {
-            const root = findProjectRoot(tempDir);
-            assert.strictEqual(root, path.resolve(tempDir));
-        });
-
-        it('should return starting directory if .pawthy directory exists', async () => {
-            await fs.promises.mkdir(path.join(tempDir, '.pawthy'), { recursive: true });
-            const root = findProjectRoot(tempDir);
-            assert.strictEqual(root, tempDir);
-        });
-
-        it('should not match .pawthy if it is a file, not a directory', async () => {
-            await fs.promises.writeFile(path.join(tempDir, '.pawthy'), 'fake file');
-            const root = findProjectRoot(tempDir);
-            assert.strictEqual(root, path.resolve(tempDir));
-        });
+    it('should return starting directory if .pawthyrc exists', async () => {
+      await fs.promises.writeFile(path.join(tempDir, '.pawthyrc'), '{}');
+      const root = findProjectRoot(tempDir);
+      assert.strictEqual(root, tempDir);
     });
 
-    describe('getProjectConfig', () => {
-        let tempDir: string;
-
-        beforeEach(async () => {
-            tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pawthy-get-config-'));
-            mock.method(process, 'cwd', () => tempDir);
-        });
-
-        afterEach(async () => {
-            try {
-                await fs.promises.rm(tempDir, { recursive: true, force: true });
-            } catch {
-                // Ignore
-            }
-        });
-
-        it('should return null if neither config file exists', async () => {
-            const result = await getProjectConfig();
-            assert.strictEqual(result, null);
-        });
-
-        it('should load .pawthyrc if it exists', async () => {
-            await fs.promises.writeFile(
-                path.join(tempDir, '.pawthyrc'),
-                JSON.stringify({ projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] })
-            );
-
-            const result = await getProjectConfig();
-            assert.deepStrictEqual(result, { projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] });
-        });
-
-        it('should load and merge both .pawthyrc and .pawthyrc.local', async () => {
-            await fs.promises.writeFile(
-                path.join(tempDir, '.pawthyrc'),
-                JSON.stringify({ projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] })
-            );
-            await fs.promises.writeFile(
-                path.join(tempDir, '.pawthyrc.local'),
-                JSON.stringify({ envId: 'env-override', keys: ['KEY_OVERRIDE'], syncKeys: ['SK_1'] })
-            );
-
-            const result = await getProjectConfig();
-            assert.deepStrictEqual(result, {
-                projectId: 'project-1',
-                envId: 'env-override',
-                keys: ['KEY_OVERRIDE'],
-                syncKeys: ['SK_1']
-            });
-        });
+    it('should walk up to find .pawthyrc in parent directory', async () => {
+      await fs.promises.writeFile(path.join(tempDir, '.pawthyrc'), '{}');
+      const subDir = path.join(tempDir, 'sub1', 'sub2');
+      await fs.promises.mkdir(subDir, { recursive: true });
+      const root = findProjectRoot(subDir);
+      assert.strictEqual(root, tempDir);
     });
+
+    it('should walk up to find .git in parent directory', async () => {
+      await fs.promises.mkdir(path.join(tempDir, '.git'), { recursive: true });
+      const subDir = path.join(tempDir, 'sub1', 'sub2');
+      await fs.promises.mkdir(subDir, { recursive: true });
+      const root = findProjectRoot(subDir);
+      assert.strictEqual(root, tempDir);
+    });
+
+    it('should fallback to the resolved startDir if no project root indicators are found', () => {
+      const root = findProjectRoot(tempDir);
+      assert.strictEqual(root, path.resolve(tempDir));
+    });
+
+    it('should return starting directory if .pawthy directory exists', async () => {
+      await fs.promises.mkdir(path.join(tempDir, '.pawthy'), { recursive: true });
+      const root = findProjectRoot(tempDir);
+      assert.strictEqual(root, tempDir);
+    });
+
+    it('should not match .pawthy if it is a file, not a directory', async () => {
+      await fs.promises.writeFile(path.join(tempDir, '.pawthy'), 'fake file');
+      const root = findProjectRoot(tempDir);
+      assert.strictEqual(root, path.resolve(tempDir));
+    });
+  });
+
+  describe('getProjectConfig', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pawthy-get-config-'));
+      mock.method(process, 'cwd', () => tempDir);
+    });
+
+    afterEach(async () => {
+      try {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore
+      }
+    });
+
+    it('should return null if neither config file exists', async () => {
+      const result = await getProjectConfig();
+      assert.strictEqual(result, null);
+    });
+
+    it('should load .pawthyrc if it exists', async () => {
+      await fs.promises.writeFile(
+        path.join(tempDir, '.pawthyrc'),
+        JSON.stringify({ projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] })
+      );
+
+      const result = await getProjectConfig();
+      assert.deepStrictEqual(result, { projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] });
+    });
+
+    it('should load and merge both .pawthyrc and .pawthyrc.local', async () => {
+      await fs.promises.writeFile(
+        path.join(tempDir, '.pawthyrc'),
+        JSON.stringify({ projectId: 'project-1', envId: 'env-1', keys: ['KEY_1'] })
+      );
+      await fs.promises.writeFile(
+        path.join(tempDir, '.pawthyrc.local'),
+        JSON.stringify({ envId: 'env-override', keys: ['KEY_OVERRIDE'], syncKeys: ['SK_1'] })
+      );
+
+      const result = await getProjectConfig();
+      assert.deepStrictEqual(result, {
+        projectId: 'project-1',
+        envId: 'env-override',
+        keys: ['KEY_OVERRIDE'],
+        syncKeys: ['SK_1'],
+      });
+    });
+  });
 });

--- a/apps/pawthy/src/config.ts
+++ b/apps/pawthy/src/config.ts
@@ -228,13 +228,18 @@ export function clearConfig(): void {
   config.clear();
 }
 
-export async function getProjectConfig(): Promise<{ projectId?: string; envId?: string; keys?: string[]; syncKeys?: string[] } | null> {
+export async function getProjectConfig(): Promise<{
+  projectId?: string;
+  envId?: string;
+  keys?: string[];
+  syncKeys?: string[];
+} | null> {
   const root = findProjectRoot();
   const configPath = path.join(root, '.pawthyrc');
   const localConfigPath = path.join(root, '.pawthyrc.local');
-  
+
   let configData: { projectId?: string; envId?: string; keys?: string[]; syncKeys?: string[] } = {};
-  
+
   // Try reading .pawthyrc
   try {
     const content = await fs.promises.readFile(configPath, 'utf-8');
@@ -247,12 +252,15 @@ export async function getProjectConfig(): Promise<{ projectId?: string; envId?: 
           `Error: Could not parse project configuration file at ${configPath}. It appears to be malformed.`
         );
       } else {
-        console.error(`Error: Failed to read project configuration from ${configPath}:`, err.message);
+        console.error(
+          `Error: Failed to read project configuration from ${configPath}:`,
+          err.message
+        );
       }
       process.exit(1);
     }
   }
-  
+
   // Try reading .pawthyrc.local
   try {
     const content = await fs.promises.readFile(localConfigPath, 'utf-8');
@@ -265,15 +273,18 @@ export async function getProjectConfig(): Promise<{ projectId?: string; envId?: 
           `Error: Could not parse local project configuration file at ${localConfigPath}. It appears to be malformed.`
         );
       } else {
-        console.error(`Error: Failed to read local project configuration from ${localConfigPath}:`, err.message);
+        console.error(
+          `Error: Failed to read local project configuration from ${localConfigPath}:`,
+          err.message
+        );
       }
       process.exit(1);
     }
   }
-  
+
   if (Object.keys(configData).length === 0) {
     return null;
   }
-  
+
   return configData;
 }

--- a/apps/pawthy/src/index.ts
+++ b/apps/pawthy/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import 'dotenv/config';
-import { Command } from "commander";
+import { Command } from 'commander';
 
 import packageJson from '../package.json' with { type: 'json' };
 import { loginCommand } from './commands/login.js';
@@ -12,9 +12,9 @@ import { pullCommand } from './commands/pull.js';
 const program = new Command();
 
 program
-    .name("pawthy")
-    .description("Official CLI for Purrmission Credential Sync")
-    .version(packageJson.version);
+  .name('pawthy')
+  .description('Official CLI for Purrmission Credential Sync')
+  .version(packageJson.version);
 
 program.addCommand(loginCommand);
 program.addCommand(initCommand);

--- a/apps/pawthy/tsconfig.json
+++ b/apps/pawthy/tsconfig.json
@@ -1,20 +1,13 @@
 {
-    "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "./dist",
-        "rootDir": "./src",
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
-        "target": "ES2022",
-        "types": [
-            "node"
-        ]
-    },
-    "include": [
-        "src/**/*"
-    ],
-    "exclude": [
-        "node_modules",
-        "dist"
-    ]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/apps/purrmission-bot/src/discord/commands/addGuardian.ts
+++ b/apps/purrmission-bot/src/discord/commands/addGuardian.ts
@@ -43,13 +43,15 @@ export async function handleAddGuardian(
   try {
     const result = await services.resource.addGuardian(resourceId, targetUser.id, callerId);
 
-    if (!result.success) {
+    if (!result.success || !result.guardian) {
       await interaction.reply({
-        content: `❌ ${result.error}`,
+        content: `❌ ${result.error ?? 'Failed to add guardian'}`,
         ephemeral: true,
       });
       return;
     }
+
+    const guardian = result.guardian;
 
     await interaction.reply({
       content: [
@@ -57,15 +59,15 @@ export async function handleAddGuardian(
         '',
         `**User:** <@${targetUser.id}>`,
         `**Resource ID:** \`${resourceId}\``,
-        `**Guardian ID:** \`${result.guardian!.id}\``,
-        `**Role:** ${result.guardian!.role}`,
+        `**Guardian ID:** \`${guardian.id}\``,
+        `**Role:** ${guardian.role}`,
       ].join('\n'),
       ephemeral: true,
     });
 
     logger.info('Guardian added successfully', {
       resourceId,
-      guardianId: result.guardian!.id,
+      guardianId: guardian.id,
       targetUserId: targetUser.id,
     });
   } catch (error) {

--- a/apps/purrmission-bot/src/discord/commands/approve.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/approve.test.ts
@@ -1,80 +1,90 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import type { Services } from '../../domain/services.js';
 import { execute } from './approve.js';
 
 describe('Approve Command', () => {
-    it('should approve a request when service returns success', async () => {
-        const mockReply = mock.fn();
-        const interaction = {
-            options: {
-                getString: mock.fn(() => 'req-123'),
-            },
-            user: { id: 'guardian-1' },
-            reply: mockReply,
-        } as any;
+  it('should approve a request when service returns success', async () => {
+    const mockReply = mock.fn();
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'req-123'),
+      },
+      user: { id: 'guardian-1' },
+      reply: mockReply,
+    } as unknown as ChatInputCommandInteraction;
 
-        const services = {
-            approval: {
-                recordDecision: mock.fn(async () => ({ success: true })),
-            },
-        } as any;
+    const services = {
+      approval: {
+        recordDecision: mock.fn(async () => ({ success: true })),
+      },
+    } as unknown as Services;
 
-        await execute(interaction, services);
+    await execute(interaction, services);
 
-        assert.strictEqual(interaction.options.getString.mock.calls.length, 1);
-        assert.strictEqual(services.approval.recordDecision.mock.calls.length, 1);
-        assert.deepStrictEqual(services.approval.recordDecision.mock.calls[0].arguments, [
-            'req-123',
-            'APPROVE',
-            'guardian-1',
-        ]);
-        assert.strictEqual(mockReply.mock.calls.length, 1);
-        assert.match(mockReply.mock.calls[0].arguments[0].content, /APPROVED/);
-    });
+    assert.strictEqual(
+      (interaction.options.getString as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      1
+    );
+    assert.strictEqual(
+      (services.approval.recordDecision as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      1
+    );
+    assert.deepStrictEqual(
+      (services.approval.recordDecision as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
+        .arguments,
+      ['req-123', 'APPROVE', 'guardian-1']
+    );
+    assert.strictEqual(mockReply.mock.calls.length, 1);
+    assert.match(mockReply.mock.calls[0].arguments[0].content, /APPROVED/);
+  });
 
-    it('should handle failure from service', async () => {
-        const mockReply = mock.fn();
-        const interaction = {
-            options: {
-                getString: mock.fn(() => 'req-123'),
-            },
-            user: { id: 'guardian-1' },
-            reply: mockReply,
-        } as any;
+  it('should handle failure from service', async () => {
+    const mockReply = mock.fn();
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'req-123'),
+      },
+      user: { id: 'guardian-1' },
+      reply: mockReply,
+    } as unknown as ChatInputCommandInteraction;
 
-        const services = {
-            approval: {
-                recordDecision: mock.fn(async () => ({ success: false, error: 'Not found' })),
-            },
-        } as any;
+    const services = {
+      approval: {
+        recordDecision: mock.fn(async () => ({ success: false, error: 'Not found' })),
+      },
+    } as unknown as Services;
 
-        await execute(interaction, services);
+    await execute(interaction, services);
 
-        assert.strictEqual(mockReply.mock.calls.length, 1);
-        assert.match(mockReply.mock.calls[0].arguments[0].content, /Failed to approve request/);
-    });
+    assert.strictEqual(mockReply.mock.calls.length, 1);
+    assert.match(mockReply.mock.calls[0].arguments[0].content, /Failed to approve request/);
+  });
 
-    it('should handle exceptions from service', async () => {
-        const mockReply = mock.fn();
-        const interaction = {
-            options: {
-                getString: mock.fn(() => 'req-123'),
-            },
-            user: { id: 'guardian-1' },
-            reply: mockReply,
-            replied: false,
-            deferred: false,
-        } as any;
+  it('should handle exceptions from service', async () => {
+    const mockReply = mock.fn();
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'req-123'),
+      },
+      user: { id: 'guardian-1' },
+      reply: mockReply,
+      replied: false,
+      deferred: false,
+    } as unknown as ChatInputCommandInteraction;
 
-        const services = {
-            approval: {
-                recordDecision: mock.fn(async () => { throw new Error('Database error'); }),
-            },
-        } as any;
+    const services = {
+      approval: {
+        recordDecision: mock.fn(async () => {
+          throw new Error('Database error');
+        }),
+      },
+    } as unknown as Services;
 
-        await execute(interaction, services);
+    await execute(interaction, services);
 
-        assert.strictEqual(mockReply.mock.calls.length, 1);
-        assert.match(mockReply.mock.calls[0].arguments[0].content, /An unexpected error occurred/);
-    });
+    assert.strictEqual(mockReply.mock.calls.length, 1);
+    assert.match(mockReply.mock.calls[0].arguments[0].content, /An unexpected error occurred/);
+  });
 });

--- a/apps/purrmission-bot/src/discord/commands/auth.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/auth.test.ts
@@ -1,67 +1,103 @@
-import { test, describe, beforeEach, mock } from 'node:test';
+import { test, describe, mock } from 'node:test';
 import assert from 'node:assert';
 import { handleAuthLogin } from './auth.js';
-import { ChatInputCommandInteraction } from 'discord.js';
-import { CommandContext } from './context.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import type { CommandContext } from './context.js';
 
 describe('Discord Command: handleAuthLogin', () => {
-    let mockInteraction: any;
-    let mockContext: any;
+  test('should reply with success when session is approved', async () => {
+    const mockReply = mock.fn();
+    const mockApproveSession = mock.fn(async () => true);
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'ABCD-1234'),
+      },
+      user: {
+        id: 'user-123',
+      },
+      reply: mockReply,
+    };
 
-    beforeEach(() => {
-        mockInteraction = {
-            options: {
-                getString: mock.fn(),
-            },
-            user: {
-                id: 'user-123',
-            },
-            reply: mock.fn(),
-        };
+    const context = {
+      services: {
+        auth: {
+          approveSession: mockApproveSession,
+        },
+      },
+    };
 
-        mockContext = {
-            services: {
-                auth: {
-                    approveSession: mock.fn(),
-                },
-            },
-        };
-    });
+    await handleAuthLogin(
+      interaction as unknown as ChatInputCommandInteraction,
+      context as unknown as CommandContext
+    );
 
-    test('should reply with success when session is approved', async () => {
-        // Redefine methods with implementations
-        mockInteraction.options.getString = mock.fn(() => 'ABCD-1234');
-        mockContext.services.auth.approveSession = mock.fn(async () => true);
+    assert.strictEqual(mockApproveSession.mock.callCount(), 1);
+    assert.deepStrictEqual(mockApproveSession.mock.calls[0].arguments, ['ABCD-1234', 'user-123']);
 
-        await handleAuthLogin(mockInteraction as ChatInputCommandInteraction, mockContext as CommandContext);
+    assert.strictEqual(mockReply.mock.callCount(), 1);
+    const replyArg = mockReply.mock.calls[0].arguments[0];
+    assert.ok(replyArg.content.includes('Successfully authenticated'));
+  });
 
-        assert.strictEqual(mockContext.services.auth.approveSession.mock.callCount(), 1);
-        assert.deepStrictEqual(mockContext.services.auth.approveSession.mock.calls[0].arguments, ['ABCD-1234', 'user-123']);
+  test('should reply with error when session is not approved', async () => {
+    const mockReply = mock.fn();
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'INVALID'),
+      },
+      user: {
+        id: 'user-123',
+      },
+      reply: mockReply,
+    };
 
-        assert.strictEqual(mockInteraction.reply.mock.callCount(), 1);
-        const replyArg = mockInteraction.reply.mock.calls[0].arguments[0];
-        assert.ok(replyArg.content.includes('Successfully authenticated'));
-    });
+    const context = {
+      services: {
+        auth: {
+          approveSession: mock.fn(async () => false),
+        },
+      },
+    };
 
-    test('should reply with error when session is not approved', async () => {
-        mockInteraction.options.getString = mock.fn(() => 'INVALID');
-        mockContext.services.auth.approveSession = mock.fn(async () => false);
+    await handleAuthLogin(
+      interaction as unknown as ChatInputCommandInteraction,
+      context as unknown as CommandContext
+    );
 
-        await handleAuthLogin(mockInteraction as ChatInputCommandInteraction, mockContext as CommandContext);
+    assert.strictEqual(mockReply.mock.callCount(), 1);
+    const replyArg = mockReply.mock.calls[0].arguments[0];
+    assert.ok(replyArg.content.includes('Failed to approve session'));
+  });
 
-        assert.strictEqual(mockInteraction.reply.mock.callCount(), 1);
-        const replyArg = mockInteraction.reply.mock.calls[0].arguments[0];
-        assert.ok(replyArg.content.includes('Failed to approve session'));
-    });
+  test('should handle internal errors gracefully', async () => {
+    const mockReply = mock.fn();
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'ERROR'),
+      },
+      user: {
+        id: 'user-123',
+      },
+      reply: mockReply,
+    };
 
-    test('should handle internal errors gracefully', async () => {
-        mockInteraction.options.getString = mock.fn(() => 'ERROR');
-        mockContext.services.auth.approveSession = mock.fn(async () => { throw new Error('Internal Boom'); });
+    const context = {
+      services: {
+        auth: {
+          approveSession: mock.fn(async () => {
+            throw new Error('Internal Boom');
+          }),
+        },
+      },
+    };
 
-        await handleAuthLogin(mockInteraction as ChatInputCommandInteraction, mockContext as CommandContext);
+    await handleAuthLogin(
+      interaction as unknown as ChatInputCommandInteraction,
+      context as unknown as CommandContext
+    );
 
-        assert.strictEqual(mockInteraction.reply.mock.callCount(), 1);
-        const replyArg = mockInteraction.reply.mock.calls[0].arguments[0];
-        assert.ok(replyArg.content.includes('internal error occurred'));
-    });
+    assert.strictEqual(mockReply.mock.callCount(), 1);
+    const replyArg = mockReply.mock.calls[0].arguments[0];
+    assert.ok(replyArg.content.includes('internal error occurred'));
+  });
 });

--- a/apps/purrmission-bot/src/discord/commands/checkDmConnectivity.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/checkDmConnectivity.test.ts
@@ -4,7 +4,7 @@ import { handleCheckDmConnectivityCommand } from './checkDmConnectivity.js';
 import type { ChatInputCommandInteraction } from 'discord.js';
 
 describe('handleCheckDmConnectivityCommand', () => {
-  let mockInteraction: any;
+  let mockInteraction: ChatInputCommandInteraction;
   let replyCalls: unknown[] = [];
   let editReplyCalls: unknown[] = [];
   let sendCalls: unknown[] = [];

--- a/apps/purrmission-bot/src/discord/commands/deny.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/deny.test.ts
@@ -1,80 +1,90 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import type { Services } from '../../domain/services.js';
 import { execute } from './deny.js';
 
 describe('Deny Command', () => {
-    it('should deny a request when service returns success', async () => {
-        const mockReply = mock.fn();
-        const interaction = {
-            options: {
-                getString: mock.fn(() => 'req-123'),
-            },
-            user: { id: 'guardian-1' },
-            reply: mockReply,
-        } as any;
+  it('should deny a request when service returns success', async () => {
+    const mockReply = mock.fn();
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'req-123'),
+      },
+      user: { id: 'guardian-1' },
+      reply: mockReply,
+    } as unknown as ChatInputCommandInteraction;
 
-        const services = {
-            approval: {
-                recordDecision: mock.fn(async () => ({ success: true })),
-            },
-        } as any;
+    const services = {
+      approval: {
+        recordDecision: mock.fn(async () => ({ success: true })),
+      },
+    } as unknown as Services;
 
-        await execute(interaction, services);
+    await execute(interaction, services);
 
-        assert.strictEqual(interaction.options.getString.mock.calls.length, 1);
-        assert.strictEqual(services.approval.recordDecision.mock.calls.length, 1);
-        assert.deepStrictEqual(services.approval.recordDecision.mock.calls[0].arguments, [
-            'req-123',
-            'DENY',
-            'guardian-1',
-        ]);
-        assert.strictEqual(mockReply.mock.calls.length, 1);
-        assert.match(mockReply.mock.calls[0].arguments[0].content, /DENIED/);
-    });
+    assert.strictEqual(
+      (interaction.options.getString as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      1
+    );
+    assert.strictEqual(
+      (services.approval.recordDecision as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      1
+    );
+    assert.deepStrictEqual(
+      (services.approval.recordDecision as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
+        .arguments,
+      ['req-123', 'DENY', 'guardian-1']
+    );
+    assert.strictEqual(mockReply.mock.calls.length, 1);
+    assert.match(mockReply.mock.calls[0].arguments[0].content, /DENIED/);
+  });
 
-    it('should handle failure from service', async () => {
-        const mockReply = mock.fn();
-        const interaction = {
-            options: {
-                getString: mock.fn(() => 'req-123'),
-            },
-            user: { id: 'guardian-1' },
-            reply: mockReply,
-        } as any;
+  it('should handle failure from service', async () => {
+    const mockReply = mock.fn();
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'req-123'),
+      },
+      user: { id: 'guardian-1' },
+      reply: mockReply,
+    } as unknown as ChatInputCommandInteraction;
 
-        const services = {
-            approval: {
-                recordDecision: mock.fn(async () => ({ success: false, error: 'Not found' })),
-            },
-        } as any;
+    const services = {
+      approval: {
+        recordDecision: mock.fn(async () => ({ success: false, error: 'Not found' })),
+      },
+    } as unknown as Services;
 
-        await execute(interaction, services);
+    await execute(interaction, services);
 
-        assert.strictEqual(mockReply.mock.calls.length, 1);
-        assert.match(mockReply.mock.calls[0].arguments[0].content, /Failed to deny request/);
-    });
+    assert.strictEqual(mockReply.mock.calls.length, 1);
+    assert.match(mockReply.mock.calls[0].arguments[0].content, /Failed to deny request/);
+  });
 
-    it('should handle exceptions from service', async () => {
-        const mockReply = mock.fn();
-        const interaction = {
-            options: {
-                getString: mock.fn(() => 'req-123'),
-            },
-            user: { id: 'guardian-1' },
-            reply: mockReply,
-            replied: false,
-            deferred: false,
-        } as any;
+  it('should handle exceptions from service', async () => {
+    const mockReply = mock.fn();
+    const interaction = {
+      options: {
+        getString: mock.fn(() => 'req-123'),
+      },
+      user: { id: 'guardian-1' },
+      reply: mockReply,
+      replied: false,
+      deferred: false,
+    } as unknown as ChatInputCommandInteraction;
 
-        const services = {
-            approval: {
-                recordDecision: mock.fn(async () => { throw new Error('Database error'); }),
-            },
-        } as any;
+    const services = {
+      approval: {
+        recordDecision: mock.fn(async () => {
+          throw new Error('Database error');
+        }),
+      },
+    } as unknown as Services;
 
-        await execute(interaction, services);
+    await execute(interaction, services);
 
-        assert.strictEqual(mockReply.mock.calls.length, 1);
-        assert.match(mockReply.mock.calls[0].arguments[0].content, /An unexpected error occurred/);
-    });
+    assert.strictEqual(mockReply.mock.calls.length, 1);
+    assert.match(mockReply.mock.calls[0].arguments[0].content, /An unexpected error occurred/);
+  });
 });

--- a/apps/purrmission-bot/src/discord/interactions/approvalButtons.ts
+++ b/apps/purrmission-bot/src/discord/interactions/approvalButtons.ts
@@ -220,7 +220,10 @@ async function revealAccessToRequester(
 
     if (context.type === 'FIELD_ACCESS' && context.fieldName) {
       // Reveal field value
-      const field = await repositories.resourceFields.findByResourceAndName(resourceId, context.fieldName);
+      const field = await repositories.resourceFields.findByResourceAndName(
+        resourceId,
+        context.fieldName
+      );
       if (field) {
         await dm.send(
           [
@@ -239,7 +242,9 @@ async function revealAccessToRequester(
           fieldName: context.fieldName,
         });
       } else {
-        await dm.send(`✅ Your access request for field **${context.fieldName}** on **${resourceName}** was approved, but the field could not be found. It may have been deleted.`);
+        await dm.send(
+          `✅ Your access request for field **${context.fieldName}** on **${resourceName}** was approved, but the field could not be found. It may have been deleted.`
+        );
         logger.warn('Approved field access request for a non-existent field', {
           requesterId: context.requesterId,
           resourceId,
@@ -269,7 +274,9 @@ async function revealAccessToRequester(
           totpAccountId: linkedAccount.id,
         });
       } else {
-        await dm.send(`✅ Your access request for 2FA on **${resourceName}** was approved, but no 2FA account is linked to it. It may have been unlinked.`);
+        await dm.send(
+          `✅ Your access request for 2FA on **${resourceName}** was approved, but no 2FA account is linked to it. It may have been unlinked.`
+        );
         logger.warn('Approved 2FA access request for a resource with no linked account', {
           requesterId: context.requesterId,
           resourceId,
@@ -401,4 +408,3 @@ export function createAccessRequestEmbed(
 
   return embed;
 }
-

--- a/apps/purrmission-bot/src/discord/types/command.ts
+++ b/apps/purrmission-bot/src/discord/types/command.ts
@@ -1,12 +1,12 @@
 import {
-    SlashCommandBuilder,
-    ChatInputCommandInteraction,
-    SlashCommandSubcommandsOnlyBuilder,
-    SlashCommandOptionsOnlyBuilder
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  SlashCommandSubcommandsOnlyBuilder,
+  SlashCommandOptionsOnlyBuilder,
 } from 'discord.js';
 import type { Services } from '../../domain/services.js';
 
 export interface Command {
-    data: SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder | SlashCommandOptionsOnlyBuilder;
-    execute: (interaction: ChatInputCommandInteraction, services: Services) => Promise<void>;
+  data: SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder | SlashCommandOptionsOnlyBuilder;
+  execute: (interaction: ChatInputCommandInteraction, services: Services) => Promise<void>;
 }

--- a/apps/purrmission-bot/src/domain/audit.test.ts
+++ b/apps/purrmission-bot/src/domain/audit.test.ts
@@ -2,64 +2,72 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { AuditService } from './audit.js';
 import { InMemoryAuditRepository } from './repositories.mock.js';
+import type { ServiceDependencies } from './services.js';
+import type { AuditRepository } from './repositories.js';
 
 describe('AuditService', () => {
-    it('should log an event successfully', async () => {
-        const repo = new InMemoryAuditRepository();
-        const service = new AuditService({ repositories: { audit: repo } } as any);
+  it('should log an event successfully', async () => {
+    const repo = new InMemoryAuditRepository();
+    const service = new AuditService({
+      repositories: { audit: repo },
+    } as unknown as ServiceDependencies);
 
-        await service.log({
-            action: 'TEST_ACTION',
-            resourceId: 'res-1',
-            actorId: 'user-1',
-            status: 'SUCCESS',
-            context: '{"foo":"bar"}',
-        });
-
-        const logs = await service.getLogsForResource('res-1');
-        assert.equal(logs.length, 1);
-        assert.equal(logs[0].action, 'TEST_ACTION');
-        assert.equal(logs[0].resourceId, 'res-1');
-        assert.equal(logs[0].actorId, 'user-1');
-        assert.equal(logs[0].status, 'SUCCESS');
-        assert.equal(logs[0].context, '{"foo":"bar"}');
-        assert.ok(logs[0].id);
-        assert.ok(logs[0].createdAt);
+    await service.log({
+      action: 'TEST_ACTION',
+      resourceId: 'res-1',
+      actorId: 'user-1',
+      status: 'SUCCESS',
+      context: '{"foo":"bar"}',
     });
 
-    it('should swallow errors and not throw if logging fails', async () => {
-        const brokenRepo = {
-            create: async () => {
-                throw new Error('Database connection failed');
-            },
-        };
-        const service = new AuditService({ repositories: { audit: brokenRepo } } as any);
+    const logs = await service.getLogsForResource('res-1');
+    assert.equal(logs.length, 1);
+    assert.equal(logs[0].action, 'TEST_ACTION');
+    assert.equal(logs[0].resourceId, 'res-1');
+    assert.equal(logs[0].actorId, 'user-1');
+    assert.equal(logs[0].status, 'SUCCESS');
+    assert.equal(logs[0].context, '{"foo":"bar"}');
+    assert.ok(logs[0].id);
+    assert.ok(logs[0].createdAt);
+  });
 
-        // This should NOT throw despite the repo throwing
-        await assert.doesNotReject(async () => {
-            await service.log({
-                action: 'FAIL_ACTION',
-                resourceId: 'res-broken',
-                status: 'ATTEMPT',
-            });
-        });
+  it('should swallow errors and not throw if logging fails', async () => {
+    const brokenRepo = {
+      create: async () => {
+        throw new Error('Database connection failed');
+      },
+    };
+    const service = new AuditService({
+      repositories: { audit: brokenRepo as unknown as AuditRepository },
+    } as unknown as ServiceDependencies);
+
+    // This should NOT throw despite the repo throwing
+    await assert.doesNotReject(async () => {
+      await service.log({
+        action: 'FAIL_ACTION',
+        resourceId: 'res-broken',
+        status: 'ATTEMPT',
+      });
     });
+  });
 
-    it('should retrieve logs for a specific resource', async () => {
-        const repo = new InMemoryAuditRepository();
-        const service = new AuditService({ repositories: { audit: repo } } as any);
+  it('should retrieve logs for a specific resource', async () => {
+    const repo = new InMemoryAuditRepository();
+    const service = new AuditService({
+      repositories: { audit: repo },
+    } as unknown as ServiceDependencies);
 
-        await service.log({ action: 'A', resourceId: 'res-1', status: 'S' });
-        await service.log({ action: 'B', resourceId: 'res-2', status: 'S' });
-        await service.log({ action: 'C', resourceId: 'res-1', status: 'S' });
+    await service.log({ action: 'A', resourceId: 'res-1', status: 'S' });
+    await service.log({ action: 'B', resourceId: 'res-2', status: 'S' });
+    await service.log({ action: 'C', resourceId: 'res-1', status: 'S' });
 
-        const logsRes1 = await service.getLogsForResource('res-1');
-        const logsRes2 = await service.getLogsForResource('res-2');
+    const logsRes1 = await service.getLogsForResource('res-1');
+    const logsRes2 = await service.getLogsForResource('res-2');
 
-        assert.equal(logsRes1.length, 2);
-        assert.equal(logsRes1[0].action, 'A');
-        assert.equal(logsRes1[1].action, 'C');
-        assert.equal(logsRes2.length, 1);
-        assert.equal(logsRes2[0].action, 'B');
-    });
+    assert.equal(logsRes1.length, 2);
+    assert.equal(logsRes1[0].action, 'A');
+    assert.equal(logsRes1[1].action, 'C');
+    assert.equal(logsRes2.length, 1);
+    assert.equal(logsRes2[0].action, 'B');
+  });
 });

--- a/apps/purrmission-bot/src/domain/audit.ts
+++ b/apps/purrmission-bot/src/domain/audit.ts
@@ -3,38 +3,38 @@ import { AuditLog, CreateAuditLogInput } from './models.js';
 import { logger } from '../logging/logger.js';
 
 export class AuditService {
-    private deps: ServiceDependencies;
+  private deps: ServiceDependencies;
 
-    constructor(deps: ServiceDependencies) {
-        this.deps = deps;
-    }
+  constructor(deps: ServiceDependencies) {
+    this.deps = deps;
+  }
 
-    /**
-     * Log a security or compliance event.
-     * Does NOT throw if logging fails, to prevent blocking business logic.
-     * Logs error to console instead.
-     */
-    async log(event: Omit<CreateAuditLogInput, 'id' | 'createdAt'>): Promise<void> {
-        try {
-            await this.deps.repositories.audit.create(event);
-            logger.debug(`Audit event logged: ${event.action}`, {
-                resourceId: event.resourceId,
-                actorId: event.actorId,
-                status: event.status,
-            });
-        } catch (error) {
-            logger.error('Failed to write audit log', {
-                event,
-                error: error instanceof Error ? error.message : String(error),
-            });
-            // Swallow error - audit failure should not crash the request
-        }
+  /**
+   * Log a security or compliance event.
+   * Does NOT throw if logging fails, to prevent blocking business logic.
+   * Logs error to console instead.
+   */
+  async log(event: Omit<CreateAuditLogInput, 'id' | 'createdAt'>): Promise<void> {
+    try {
+      await this.deps.repositories.audit.create(event);
+      logger.debug(`Audit event logged: ${event.action}`, {
+        resourceId: event.resourceId,
+        actorId: event.actorId,
+        status: event.status,
+      });
+    } catch (error) {
+      logger.error('Failed to write audit log', {
+        event,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      // Swallow error - audit failure should not crash the request
     }
+  }
 
-    /**
-     * Retrieve audit logs for a resource.
-     */
-    async getLogsForResource(resourceId: string): Promise<AuditLog[]> {
-        return this.deps.repositories.audit.findByResourceId(resourceId);
-    }
+  /**
+   * Retrieve audit logs for a resource.
+   */
+  async getLogsForResource(resourceId: string): Promise<AuditLog[]> {
+    return this.deps.repositories.audit.findByResourceId(resourceId);
+  }
 }

--- a/apps/purrmission-bot/src/domain/errors.ts
+++ b/apps/purrmission-bot/src/domain/errors.ts
@@ -1,20 +1,19 @@
-
 export class DomainError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = this.constructor.name;
-        Error.captureStackTrace(this, this.constructor);
-    }
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
 }
 
 export class DuplicateError extends DomainError {
-    constructor(message: string) {
-        super(message);
-    }
+  constructor(message: string) {
+    super(message);
+  }
 }
 
 export class ResourceNotFoundError extends DomainError {
-    constructor(message: string) {
-        super(message);
-    }
+  constructor(message: string) {
+    super(message);
+  }
 }

--- a/apps/purrmission-bot/src/domain/models.ts
+++ b/apps/purrmission-bot/src/domain/models.ts
@@ -43,7 +43,6 @@ export interface Resource {
   createdAt: Date;
 }
 
-
 /**
  * Role of a guardian for a resource.
  * - OWNER: Can add/remove other guardians, full control
@@ -262,7 +261,6 @@ export interface AuditLog {
 }
 
 export type CreateAuditLogInput = Omit<AuditLog, 'id' | 'createdAt'>;
-
 
 /**
  * Represents a device login session (OAuth Device Flow).

--- a/apps/purrmission-bot/src/domain/project.test.ts
+++ b/apps/purrmission-bot/src/domain/project.test.ts
@@ -37,7 +37,10 @@ describe('ProjectService', () => {
       createResource: createResourceMock,
     };
 
-    projectService = new ProjectService(projectRepo as any, resourceService);
+    projectService = new ProjectService(
+      projectRepo as unknown as ProjectRepository,
+      resourceService
+    );
   });
 
   it('should create a project', async () => {

--- a/apps/purrmission-bot/src/domain/project.ts
+++ b/apps/purrmission-bot/src/domain/project.ts
@@ -1,71 +1,85 @@
-
 import { ProjectRepository } from './repositories.js';
-import { Project, Environment, CreateProjectInput, CreateEnvironmentInput, ResourceNotFoundError, ProjectMember, ProjectMemberRole } from './models.js';
+import {
+  Project,
+  Environment,
+  CreateProjectInput,
+  CreateEnvironmentInput,
+  ResourceNotFoundError,
+  ProjectMember,
+  ProjectMemberRole,
+} from './models.js';
 
 export class ProjectService {
-    constructor(
-        private readonly projectRepo: ProjectRepository,
-        private readonly resourceService: { createResource: (name: string, ownerId: string) => Promise<{ resource: { id: string } }> }
-    ) { }
-
-    async createProject(input: CreateProjectInput): Promise<Project> {
-        return this.projectRepo.createProject(input);
+  constructor(
+    private readonly projectRepo: ProjectRepository,
+    private readonly resourceService: {
+      createResource: (name: string, ownerId: string) => Promise<{ resource: { id: string } }>;
     }
+  ) {}
 
-    async listProjects(userId: string): Promise<Project[]> {
-        return this.projectRepo.listProjectsByOwner(userId);
-    }
+  async createProject(input: CreateProjectInput): Promise<Project> {
+    return this.projectRepo.createProject(input);
+  }
 
-    async getProject(id: string): Promise<Project | null> {
-        return this.projectRepo.findById(id);
-    }
+  async listProjects(userId: string): Promise<Project[]> {
+    return this.projectRepo.listProjectsByOwner(userId);
+  }
 
-    async createEnvironment(input: CreateEnvironmentInput): Promise<Environment> {
-        // 1. Get Project to find owner
-        const project = await this.getProject(input.projectId);
-        if (!project) throw new ResourceNotFoundError('Project not found');
+  async getProject(id: string): Promise<Project | null> {
+    return this.projectRepo.findById(id);
+  }
 
-        // 2. Create Resource for this environment
-        const resourceName = `${project.name}:${input.name}`; // e.g., web-app:dev
-        const { resource } = await this.resourceService.createResource(resourceName, project.ownerId);
+  async createEnvironment(input: CreateEnvironmentInput): Promise<Environment> {
+    // 1. Get Project to find owner
+    const project = await this.getProject(input.projectId);
+    if (!project) throw new ResourceNotFoundError('Project not found');
 
-        // 3. Create Environment linked to Resource
-        return this.projectRepo.createEnvironment({
-            ...input,
-            resourceId: resource.id
-        });
-    }
+    // 2. Create Resource for this environment
+    const resourceName = `${project.name}:${input.name}`; // e.g., web-app:dev
+    const { resource } = await this.resourceService.createResource(resourceName, project.ownerId);
 
-    async listEnvironments(projectId: string): Promise<Environment[]> {
-        return this.projectRepo.listEnvironments(projectId);
-    }
+    // 3. Create Environment linked to Resource
+    return this.projectRepo.createEnvironment({
+      ...input,
+      resourceId: resource.id,
+    });
+  }
 
-    async getEnvironment(projectId: string, slug: string): Promise<Environment | null> {
-        return this.projectRepo.findEnvironment(projectId, slug);
-    }
+  async listEnvironments(projectId: string): Promise<Environment[]> {
+    return this.projectRepo.listEnvironments(projectId);
+  }
 
-    async getEnvironmentById(projectId: string, envId: string): Promise<Environment | null> {
-        return this.projectRepo.getEnvironmentById(projectId, envId);
-    }
+  async getEnvironment(projectId: string, slug: string): Promise<Environment | null> {
+    return this.projectRepo.findEnvironment(projectId, slug);
+  }
 
-    async addMember(projectId: string, userId: string, role: ProjectMemberRole, addedBy: string): Promise<ProjectMember> {
-        return this.projectRepo.addMember({
-            projectId,
-            userId,
-            role,
-            addedBy
-        });
-    }
+  async getEnvironmentById(projectId: string, envId: string): Promise<Environment | null> {
+    return this.projectRepo.getEnvironmentById(projectId, envId);
+  }
 
-    async removeMember(projectId: string, userId: string): Promise<void> {
-        return this.projectRepo.removeMember(projectId, userId);
-    }
+  async addMember(
+    projectId: string,
+    userId: string,
+    role: ProjectMemberRole,
+    addedBy: string
+  ): Promise<ProjectMember> {
+    return this.projectRepo.addMember({
+      projectId,
+      userId,
+      role,
+      addedBy,
+    });
+  }
 
-    async getMemberRole(projectId: string, userId: string): Promise<ProjectMemberRole | null> {
-        return this.projectRepo.getMemberRole(projectId, userId);
-    }
+  async removeMember(projectId: string, userId: string): Promise<void> {
+    return this.projectRepo.removeMember(projectId, userId);
+  }
 
-    async listMembers(projectId: string): Promise<ProjectMember[]> {
-        return this.projectRepo.listMembers(projectId);
-    }
+  async getMemberRole(projectId: string, userId: string): Promise<ProjectMemberRole | null> {
+    return this.projectRepo.getMemberRole(projectId, userId);
+  }
+
+  async listMembers(projectId: string): Promise<ProjectMember[]> {
+    return this.projectRepo.listMembers(projectId);
+  }
 }

--- a/apps/purrmission-bot/src/domain/services.test.ts
+++ b/apps/purrmission-bot/src/domain/services.test.ts
@@ -9,6 +9,13 @@ import {
 } from './repositories.js';
 import type { Guardian } from './models.js';
 
+type MockedFn = {
+  mock: {
+    calls: Array<{ arguments: unknown[] }>;
+    mockImplementation: (fn: (...args: unknown[]) => unknown) => void;
+  };
+};
+
 describe('ResourceService', () => {
   let resourceService: ResourceService;
   let mockRepositories: Repositories;
@@ -22,14 +29,14 @@ describe('ResourceService', () => {
 
   beforeEach(() => {
     mockGuardianRepo = {
-      findByResourceAndUser: mock.fn() as any,
-      findByResourceId: mock.fn() as any,
-      remove: mock.fn() as any,
-      add: mock.fn() as any,
+      findByResourceAndUser: mock.fn() as unknown as GuardianRepository['findByResourceAndUser'],
+      findByResourceId: mock.fn() as unknown as GuardianRepository['findByResourceId'],
+      remove: mock.fn() as unknown as GuardianRepository['remove'],
+      add: mock.fn() as unknown as GuardianRepository['add'],
     };
 
     mockResourceRepo = {
-      findById: mock.fn() as any,
+      findById: mock.fn() as unknown as ResourceRepository['findById'],
     };
 
     mockRepositories = {
@@ -47,8 +54,8 @@ describe('ResourceService', () => {
   describe('removeGuardian', () => {
     it('should remove guardian if actor is owner', async () => {
       // Mock Actor is Owner
-      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
-        async (_rid: string, uid: string) => {
+      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
+        async (_rid: unknown, uid: unknown) => {
           if (uid === ownerId)
             return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
           if (uid === guardianId)
@@ -60,17 +67,17 @@ describe('ResourceService', () => {
       const result = await resourceService.removeGuardian(resourceId, ownerId, guardianId);
 
       assert.strictEqual(result.success, true);
-      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 1);
-      assert.deepStrictEqual((mockGuardianRepo.remove as any).mock.calls[0].arguments, [
-        resourceId,
-        guardianId,
-      ]);
+      assert.strictEqual((mockGuardianRepo.remove as unknown as MockedFn).mock.calls.length, 1);
+      assert.deepStrictEqual(
+        (mockGuardianRepo.remove as unknown as MockedFn).mock.calls[0].arguments,
+        [resourceId, guardianId]
+      );
     });
 
     it('should fail if actor is not owner', async () => {
       // Mock Actor is Guardian (not Owner)
-      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
-        async (_rid: string, uid: string) => {
+      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
+        async (_rid: unknown, uid: unknown) => {
           if (uid === guardianId)
             return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
           return null;
@@ -80,14 +87,14 @@ describe('ResourceService', () => {
       const result = await resourceService.removeGuardian(resourceId, guardianId, otherId);
 
       assert.strictEqual(result.success, false);
-      assert.match(result.error!, /Only the resource owner/);
-      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
+      assert.match(result.error ?? '', /Only the resource owner/);
+      assert.strictEqual((mockGuardianRepo.remove as unknown as MockedFn).mock.calls.length, 0);
     });
 
     it('should fail if target is not a guardian', async () => {
       // Mock Actor is Owner, Target not found
-      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
-        async (_rid: string, uid: string) => {
+      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
+        async (_rid: unknown, uid: unknown) => {
           if (uid === ownerId)
             return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
           return null;
@@ -97,8 +104,8 @@ describe('ResourceService', () => {
       const result = await resourceService.removeGuardian(resourceId, ownerId, otherId);
 
       assert.strictEqual(result.success, false);
-      assert.match(result.error!, /not a guardian/);
-      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
+      assert.match(result.error ?? '', /not a guardian/);
+      assert.strictEqual((mockGuardianRepo.remove as unknown as MockedFn).mock.calls.length, 0);
     });
 
     it('should fail with custom error if target is a dynamic guardian', async () => {
@@ -134,8 +141,8 @@ describe('ResourceService', () => {
 
     it('should fail if target is owner', async () => {
       // Mock Actor is Owner, Target is Owner
-      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
-        async (_rid: string, uid: string) => {
+      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
+        async (_rid: unknown, uid: unknown) => {
           if (uid === ownerId)
             return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
           if (uid === guardianId)
@@ -147,16 +154,33 @@ describe('ResourceService', () => {
       const result = await resourceService.removeGuardian(resourceId, ownerId, guardianId);
 
       assert.strictEqual(result.success, false);
-      assert.match(result.error!, /Cannot remove the resource owner/);
-      assert.strictEqual((mockGuardianRepo.remove as any).mock.calls.length, 0);
+      assert.match(result.error ?? '', /Cannot remove the resource owner/);
+      assert.strictEqual((mockGuardianRepo.remove as unknown as MockedFn).mock.calls.length, 0);
+    });
+
+    it('should support remove alias method', async () => {
+      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
+        async (_rid: unknown, uid: unknown) => {
+          if (uid === ownerId)
+            return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
+          if (uid === guardianId)
+            return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
+          return null;
+        }
+      );
+
+      const result = await resourceService.remove(resourceId, ownerId, guardianId);
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual((mockGuardianRepo.remove as unknown as MockedFn).mock.calls.length, 1);
     });
   });
 
   describe('listGuardians', () => {
     it('should list guardians if actor is authorized', async () => {
       // Mock Actor is Guardian
-      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(
-        async (_rid: string, uid: string) => {
+      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
+        async (_rid: unknown, uid: unknown) => {
           if (uid === guardianId)
             return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
           return null;
@@ -164,25 +188,51 @@ describe('ResourceService', () => {
       );
 
       // Mock List return
-      (mockGuardianRepo.findByResourceId as any).mock.mockImplementation(async () => [
-        { id: 'g1', role: 'OWNER', discordUserId: 'owner-id' },
-        { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId },
-      ]);
+      (mockGuardianRepo.findByResourceId as unknown as MockedFn).mock.mockImplementation(
+        async () => [
+          { id: 'g1', role: 'OWNER', discordUserId: 'owner-id' } as Guardian,
+          { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian,
+        ]
+      );
 
       const result = await resourceService.listGuardians(resourceId, guardianId);
 
       assert.strictEqual(result.success, true);
-      assert.strictEqual(result.guardians!.length, 2);
+      assert.strictEqual(result.guardians?.length, 2);
     });
 
     it('should fail if actor is unauthorized', async () => {
       // Mock Actor not found
-      (mockGuardianRepo.findByResourceAndUser as any).mock.mockImplementation(async () => null);
+      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
+        async () => null
+      );
 
       const result = await resourceService.listGuardians(resourceId, otherId);
 
       assert.strictEqual(result.success, false);
-      assert.match(result.error!, /Access denied/);
+      assert.match(result.error ?? '', /Access denied/);
+    });
+
+    it('should support list alias method', async () => {
+      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
+        async (_rid: unknown, uid: unknown) => {
+          if (uid === guardianId)
+            return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
+          return null;
+        }
+      );
+
+      (mockGuardianRepo.findByResourceId as unknown as MockedFn).mock.mockImplementation(
+        async () => [
+          { id: 'g1', role: 'OWNER' },
+          { id: 'g2', role: 'GUARDIAN' },
+        ]
+      );
+
+      const result = await resourceService.list(resourceId, guardianId);
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.guardians?.length, 2);
     });
   });
 
@@ -193,8 +243,12 @@ describe('ResourceService', () => {
       const mockTotpRepo = {
         findById: mock.fn(async () => mockTotpAccount),
       };
-      mockResourceRepo.findById = mock.fn(async () => mockResource) as any;
-      mockResourceRepo.update = mock.fn(async () => mockResource) as any;
+      mockResourceRepo.findById = mock.fn(
+        async () => mockResource
+      ) as unknown as ResourceRepository['findById'];
+      mockResourceRepo.update = mock.fn(
+        async () => mockResource
+      ) as unknown as ResourceRepository['update'];
 
       const failingAuditService = {
         log: mock.fn(async () => {
@@ -205,16 +259,16 @@ describe('ResourceService', () => {
       const deps: ServiceDependencies = {
         repositories: {
           ...mockRepositories,
-          totp: mockTotpRepo as any,
+          totp: mockTotpRepo as unknown as Repositories['totp'],
         },
-        audit: failingAuditService as any,
+        audit: failingAuditService as unknown as ServiceDependencies['audit'],
       };
       const svc = new ResourceService(deps);
 
       // Should complete successfully without throwing
       await svc.linkTOTPAccount(resourceId, 'totp-1', ownerId);
 
-      assert.strictEqual((mockResourceRepo.update as any).mock.calls.length, 1);
+      assert.strictEqual((mockResourceRepo.update as unknown as MockedFn).mock.calls.length, 1);
       assert.strictEqual(failingAuditService.log.mock.calls.length, 1);
     });
   });
@@ -229,16 +283,17 @@ describe('ApprovalService', () => {
 
   beforeEach(() => {
     mockApprovalRepo = {
-      create: mock.fn() as any,
-      findById: mock.fn() as any,
-      updateStatus: mock.fn() as any,
-      findActiveByRequester: mock.fn() as any,
+      create: mock.fn() as unknown as ApprovalRequestRepository['create'],
+      findById: mock.fn() as unknown as ApprovalRequestRepository['findById'],
+      updateStatus: mock.fn() as unknown as ApprovalRequestRepository['updateStatus'],
+      findActiveByRequester:
+        mock.fn() as unknown as ApprovalRequestRepository['findActiveByRequester'],
     };
     mockResourceRepo = {
-      findById: mock.fn() as any,
+      findById: mock.fn() as unknown as ResourceRepository['findById'],
     };
     mockGuardianRepo = {
-      findByResourceId: mock.fn() as any,
+      findByResourceId: mock.fn() as unknown as GuardianRepository['findByResourceId'],
     };
 
     mockRepositories = {
@@ -260,16 +315,19 @@ describe('ApprovalService', () => {
       const requesterId = 'user-1';
       const mockRequest = { id: 'req-1', status: 'PENDING' };
 
-      (mockApprovalRepo.findActiveByRequester as any).mock.mockImplementation(
+      (mockApprovalRepo.findActiveByRequester as unknown as MockedFn).mock.mockImplementation(
         async () => mockRequest
       );
 
       const result = await approvalService.findActiveApproval(resourceId, requesterId);
 
       assert.strictEqual(result, mockRequest);
-      assert.strictEqual((mockApprovalRepo.findActiveByRequester as any).mock.calls.length, 1);
+      assert.strictEqual(
+        (mockApprovalRepo.findActiveByRequester as unknown as MockedFn).mock.calls.length,
+        1
+      );
       assert.deepStrictEqual(
-        (mockApprovalRepo.findActiveByRequester as any).mock.calls[0].arguments,
+        (mockApprovalRepo.findActiveByRequester as unknown as MockedFn).mock.calls[0].arguments,
         [resourceId, requesterId]
       );
     });
@@ -283,12 +341,16 @@ describe('ApprovalService', () => {
         resourceId: 'res-1',
         context: { requesterId: 'requester-1' },
       };
-      mockApprovalRepo.findById = mock.fn(async () => mockRequest) as any;
-      mockApprovalRepo.updateStatus = mock.fn(async () => {}) as any;
+      mockApprovalRepo.findById = mock.fn(
+        async () => mockRequest
+      ) as unknown as ApprovalRequestRepository['findById'];
+      mockApprovalRepo.updateStatus = mock.fn(
+        async () => {}
+      ) as unknown as ApprovalRequestRepository['updateStatus'];
       mockGuardianRepo.findByResourceAndUser = mock.fn(async () => ({
         id: 'g-1',
         role: 'OWNER',
-      })) as any;
+      })) as unknown as GuardianRepository['findByResourceAndUser'];
 
       const failingAuditService = {
         log: mock.fn(async () => {
@@ -298,14 +360,17 @@ describe('ApprovalService', () => {
 
       const deps: ServiceDependencies = {
         repositories: mockRepositories,
-        audit: failingAuditService as any,
+        audit: failingAuditService as unknown as ServiceDependencies['audit'],
       };
       const svc = new ApprovalService(deps);
 
       const result = await svc.recordDecision('req-1', 'APPROVE', 'guardian-1');
 
       assert.strictEqual(result.success, true);
-      assert.strictEqual((mockApprovalRepo.updateStatus as any).mock.calls.length, 1);
+      assert.strictEqual(
+        (mockApprovalRepo.updateStatus as unknown as MockedFn).mock.calls.length,
+        1
+      );
       assert.strictEqual(failingAuditService.log.mock.calls.length, 1);
     });
   });

--- a/apps/purrmission-bot/src/domain/services.test.ts
+++ b/apps/purrmission-bot/src/domain/services.test.ts
@@ -157,23 +157,6 @@ describe('ResourceService', () => {
       assert.match(result.error ?? '', /Cannot remove the resource owner/);
       assert.strictEqual((mockGuardianRepo.remove as unknown as MockedFn).mock.calls.length, 0);
     });
-
-    it('should support remove alias method', async () => {
-      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
-        async (_rid: unknown, uid: unknown) => {
-          if (uid === ownerId)
-            return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
-          if (uid === guardianId)
-            return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
-          return null;
-        }
-      );
-
-      const result = await resourceService.remove(resourceId, ownerId, guardianId);
-
-      assert.strictEqual(result.success, true);
-      assert.strictEqual((mockGuardianRepo.remove as unknown as MockedFn).mock.calls.length, 1);
-    });
   });
 
   describe('listGuardians', () => {
@@ -211,28 +194,6 @@ describe('ResourceService', () => {
 
       assert.strictEqual(result.success, false);
       assert.match(result.error ?? '', /Access denied/);
-    });
-
-    it('should support list alias method', async () => {
-      (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
-        async (_rid: unknown, uid: unknown) => {
-          if (uid === guardianId)
-            return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
-          return null;
-        }
-      );
-
-      (mockGuardianRepo.findByResourceId as unknown as MockedFn).mock.mockImplementation(
-        async () => [
-          { id: 'g1', role: 'OWNER' },
-          { id: 'g2', role: 'GUARDIAN' },
-        ]
-      );
-
-      const result = await resourceService.list(resourceId, guardianId);
-
-      assert.strictEqual(result.success, true);
-      assert.strictEqual(result.guardians?.length, 2);
     });
   });
 

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -464,6 +464,27 @@ export class ResourceService {
   }
 
   /**
+   * Remove a guardian from a resource (alias for removeGuardian).
+   */
+  async remove(
+    resourceId: string,
+    actorId: string,
+    targetUserId: string
+  ): Promise<{ success: boolean; error?: string }> {
+    return this.removeGuardian(resourceId, actorId, targetUserId);
+  }
+
+  /**
+   * List confirmed guardians for a resource (alias for listGuardians).
+   */
+  async list(
+    resourceId: string,
+    actorId: string
+  ): Promise<{ success: boolean; guardians?: Guardian[]; error?: string }> {
+    return this.listGuardians(resourceId, actorId);
+  }
+
+  /**
    * Verify an API key and return the resource.
    */
   async verifyApiKey(apiKey: string): Promise<Resource | null> {

--- a/apps/purrmission-bot/src/domain/totp.test.ts
+++ b/apps/purrmission-bot/src/domain/totp.test.ts
@@ -3,74 +3,74 @@ import assert from 'node:assert';
 import { createTOTPAccountFromSecret } from './totp.js';
 
 describe('Bypassing spaces in TOTP secrets', () => {
-    const accountBase = {
-        ownerDiscordUserId: 'user-123',
-        accountName: 'Test Account',
-        issuer: undefined,
-        shared: false,
-    };
+  const accountBase = {
+    ownerDiscordUserId: 'user-123',
+    accountName: 'Test Account',
+    issuer: undefined,
+    shared: false,
+  };
 
-    test('should accept a valid Base32 secret without spaces', () => {
-        const validSecret = 'JBSWY3DPEHPK3PXP'; // Base32 for 'Hello!'
-        const account = createTOTPAccountFromSecret(
-            accountBase.ownerDiscordUserId,
-            accountBase.accountName,
-            validSecret,
-            accountBase.issuer,
-            accountBase.shared
-        );
-        assert.strictEqual(account.secret, validSecret);
-    });
+  test('should accept a valid Base32 secret without spaces', () => {
+    const validSecret = 'JBSWY3DPEHPK3PXP'; // Base32 for 'Hello!'
+    const account = createTOTPAccountFromSecret(
+      accountBase.ownerDiscordUserId,
+      accountBase.accountName,
+      validSecret,
+      accountBase.issuer,
+      accountBase.shared
+    );
+    assert.strictEqual(account.secret, validSecret);
+  });
 
-    test('should accept a valid Base32 secret with spaces', () => {
-        const secretWithSpaces = 'JBSWY 3DPEH PK3PX P';
-        const expectedSecret = 'JBSWY3DPEHPK3PXP';
-        const account = createTOTPAccountFromSecret(
-            accountBase.ownerDiscordUserId,
-            accountBase.accountName,
-            secretWithSpaces,
-            accountBase.issuer,
-            accountBase.shared
-        );
-        assert.strictEqual(account.secret, expectedSecret);
-    });
+  test('should accept a valid Base32 secret with spaces', () => {
+    const secretWithSpaces = 'JBSWY 3DPEH PK3PX P';
+    const expectedSecret = 'JBSWY3DPEHPK3PXP';
+    const account = createTOTPAccountFromSecret(
+      accountBase.ownerDiscordUserId,
+      accountBase.accountName,
+      secretWithSpaces,
+      accountBase.issuer,
+      accountBase.shared
+    );
+    assert.strictEqual(account.secret, expectedSecret);
+  });
 
-    test('should accept a valid Base32 secret with multiple spaces', () => {
-        const secretWithSpaces = '  JBSWY   3DPEH   PK3PX   P  ';
-        const expectedSecret = 'JBSWY3DPEHPK3PXP';
-        const account = createTOTPAccountFromSecret(
-            accountBase.ownerDiscordUserId,
-            accountBase.accountName,
-            secretWithSpaces,
-            accountBase.issuer,
-            accountBase.shared
-        );
-        assert.strictEqual(account.secret, expectedSecret);
-    });
+  test('should accept a valid Base32 secret with multiple spaces', () => {
+    const secretWithSpaces = '  JBSWY   3DPEH   PK3PX   P  ';
+    const expectedSecret = 'JBSWY3DPEHPK3PXP';
+    const account = createTOTPAccountFromSecret(
+      accountBase.ownerDiscordUserId,
+      accountBase.accountName,
+      secretWithSpaces,
+      accountBase.issuer,
+      accountBase.shared
+    );
+    assert.strictEqual(account.secret, expectedSecret);
+  });
 
-    test('should throw error for invalid Base32 characters even with spaces', () => {
-        const invalidSecret = 'JBSWY 3DPEH PK3PX 1'; // '1' is not valid Base32
-        assert.throws(() => {
-            createTOTPAccountFromSecret(
-                accountBase.ownerDiscordUserId,
-                accountBase.accountName,
-                invalidSecret,
-                accountBase.issuer,
-                accountBase.shared
-            );
-        }, /Invalid TOTP secret format \(Base32 expected\)/);
-    });
+  test('should throw error for invalid Base32 characters even with spaces', () => {
+    const invalidSecret = 'JBSWY 3DPEH PK3PX 1'; // '1' is not valid Base32
+    assert.throws(() => {
+      createTOTPAccountFromSecret(
+        accountBase.ownerDiscordUserId,
+        accountBase.accountName,
+        invalidSecret,
+        accountBase.issuer,
+        accountBase.shared
+      );
+    }, /Invalid TOTP secret format \(Base32 expected\)/);
+  });
 
-    test('should accept mixed whitespace characters', () => {
-        const secretWithMixedWhitespace = 'JBSWY\n3DPEH\tPK3PX\r\n P';
-        const expectedSecret = 'JBSWY3DPEHPK3PXP';
-        const account = createTOTPAccountFromSecret(
-            accountBase.ownerDiscordUserId,
-            accountBase.accountName,
-            secretWithMixedWhitespace,
-            accountBase.issuer,
-            accountBase.shared
-        );
-        assert.strictEqual(account.secret, expectedSecret);
-    });
+  test('should accept mixed whitespace characters', () => {
+    const secretWithMixedWhitespace = 'JBSWY\n3DPEH\tPK3PX\r\n P';
+    const expectedSecret = 'JBSWY3DPEHPK3PXP';
+    const account = createTOTPAccountFromSecret(
+      accountBase.ownerDiscordUserId,
+      accountBase.accountName,
+      secretWithMixedWhitespace,
+      accountBase.issuer,
+      accountBase.shared
+    );
+    assert.strictEqual(account.secret, expectedSecret);
+  });
 });

--- a/apps/purrmission-bot/src/domain/totp.ts
+++ b/apps/purrmission-bot/src/domain/totp.ts
@@ -66,7 +66,6 @@ export function createTOTPAccountFromUri(
 ): Omit<TOTPAccount, 'id' | 'createdAt' | 'updatedAt'> {
   const { accountName, issuer, secret } = parseOtpauthUri(uri);
 
-
   return {
     ownerDiscordUserId,
     accountName,
@@ -86,7 +85,6 @@ export function createTOTPAccountFromSecret(
   issuer: string | undefined,
   shared: boolean
 ): Omit<TOTPAccount, 'id' | 'createdAt' | 'updatedAt'> {
-
   if (!secret || secret.trim().length === 0) {
     throw new Error('Secret cannot be empty');
   }

--- a/apps/purrmission-bot/src/infra/crypto.test.ts
+++ b/apps/purrmission-bot/src/infra/crypto.test.ts
@@ -3,39 +3,41 @@ import assert from 'node:assert';
 import { encryptValue, decryptValue, validateEncryptionConfig } from './crypto.js';
 
 describe('Crypto Infra', () => {
-    it('should encrypt and decrypt a value correctly (v1)', () => {
-        const secret = 'super-secret-value';
-        const encrypted = encryptValue(secret);
-        assert.ok(encrypted.startsWith('v1:'), 'Ciphertext should start with v1:');
+  it('should encrypt and decrypt a value correctly (v1)', () => {
+    const secret = 'super-secret-value';
+    const encrypted = encryptValue(secret);
+    assert.ok(encrypted.startsWith('v1:'), 'Ciphertext should start with v1:');
 
-        const decrypted = decryptValue(encrypted);
-        assert.strictEqual(decrypted, secret);
-    });
+    const decrypted = decryptValue(encrypted);
+    assert.strictEqual(decrypted, secret);
+  });
 
-    it('should decrypt legacy format correctly', () => {
-        // We simulate a legacy failure (invalid format) vs a crypto failure
+  it('should decrypt legacy format correctly', () => {
+    // We simulate a legacy failure (invalid format) vs a crypto failure
 
-        const invalidLegacy = 'not-enough-parts';
-        try {
-            decryptValue(invalidLegacy);
-            assert.fail('Should have thrown');
-        } catch (e: any) {
-            assert.match(e.message, /Decryption failed: invalid legacy data format/);
-        }
+    const invalidLegacy = 'not-enough-parts';
+    try {
+      decryptValue(invalidLegacy);
+      assert.fail('Should have thrown');
+    } catch (e: unknown) {
+      const err = e as Error;
+      assert.match(err.message, /Decryption failed: invalid legacy data format/);
+    }
 
-        const validStructureWrongKey = 'a:b:c';
-        try {
-            decryptValue(validStructureWrongKey);
-            // This might fail base64 decode or auth tag check
-            assert.fail('Should have thrown');
-        } catch (e: any) {
-            // It passed the "parts check" for legacy, so it failed deeper
-            assert.match(e.message, /Decryption failed: invalid data/);
-        }
-    });
+    const validStructureWrongKey = 'a:b:c';
+    try {
+      decryptValue(validStructureWrongKey);
+      // This might fail base64 decode or auth tag check
+      assert.fail('Should have thrown');
+    } catch (e: unknown) {
+      // It passed the "parts check" for legacy, so it failed deeper
+      const err = e as Error;
+      assert.match(err.message, /Decryption failed: invalid data/);
+    }
+  });
 
-    it('should validate encryption config successfully', () => {
-        // Should not throw
-        validateEncryptionConfig();
-    });
+  it('should validate encryption config successfully', () => {
+    // Should not throw
+    validateEncryptionConfig();
+  });
 });

--- a/apps/purrmission-bot/src/infra/crypto.ts
+++ b/apps/purrmission-bot/src/infra/crypto.ts
@@ -20,16 +20,18 @@ const V1_PREFIX = 'v1:';
  * @throws Error if ENCRYPTION_KEY is not set or invalid
  */
 function getEncryptionKey(): Buffer {
-    const keyHex = env.ENCRYPTION_KEY;
-    if (!keyHex) {
-        throw new Error('ENCRYPTION_KEY environment variable is not set');
-    }
+  const keyHex = env.ENCRYPTION_KEY;
+  if (!keyHex) {
+    throw new Error('ENCRYPTION_KEY environment variable is not set');
+  }
 
-    if (!HEX_REGEX.test(keyHex)) {
-        throw new Error('ENCRYPTION_KEY must be a valid 32-byte hex string (64 hexadecimal characters)');
-    }
+  if (!HEX_REGEX.test(keyHex)) {
+    throw new Error(
+      'ENCRYPTION_KEY must be a valid 32-byte hex string (64 hexadecimal characters)'
+    );
+  }
 
-    return Buffer.from(keyHex, 'hex');
+  return Buffer.from(keyHex, 'hex');
 }
 
 /**
@@ -38,24 +40,24 @@ function getEncryptionKey(): Buffer {
  * @throws Error if configuration is invalid or crypto operations fail
  */
 export function validateEncryptionConfig(): void {
-    try {
-        const key = getEncryptionKey();
-        if (key.length !== 32) {
-            throw new Error(`Invalid key length: expected 32 bytes, got ${key.length}`);
-        }
-
-        // Test cycle
-        const testPayload = 'purrmission-startup-check-' + Date.now();
-        const encrypted = encryptValue(testPayload);
-        const decrypted = decryptValue(encrypted);
-
-        if (decrypted !== testPayload) {
-            throw new Error('Encryption round-trip failed: decrypted value does not match original');
-        }
-    } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        throw new Error(`Encryption configuration validation failed: ${msg}`);
+  try {
+    const key = getEncryptionKey();
+    if (key.length !== 32) {
+      throw new Error(`Invalid key length: expected 32 bytes, got ${key.length}`);
     }
+
+    // Test cycle
+    const testPayload = 'purrmission-startup-check-' + Date.now();
+    const encrypted = encryptValue(testPayload);
+    const decrypted = decryptValue(encrypted);
+
+    if (decrypted !== testPayload) {
+      throw new Error('Encryption round-trip failed: decrypted value does not match original');
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`Encryption configuration validation failed: ${msg}`);
+  }
 }
 
 /**
@@ -66,16 +68,16 @@ export function validateEncryptionConfig(): void {
  * @returns Versioned ciphertext string (e.g., "v1:iv:authTag:ciphertext")
  */
 export function encryptWithKey(plaintext: string, keyBuffer: Buffer): string {
-    const iv = crypto.randomBytes(IV_LENGTH);
-    const cipher = crypto.createCipheriv(ALGORITHM, keyBuffer, iv, {
-        authTagLength: AUTH_TAG_LENGTH,
-    });
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, keyBuffer, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
 
-    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-    const authTag = cipher.getAuthTag();
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
 
-    // Format: v1:base64(iv):base64(authTag):base64(ciphertext)
-    return `${V1_PREFIX}${iv.toString('base64')}:${authTag.toString('base64')}:${encrypted.toString('base64')}`;
+  // Format: v1:base64(iv):base64(authTag):base64(ciphertext)
+  return `${V1_PREFIX}${iv.toString('base64')}:${authTag.toString('base64')}:${encrypted.toString('base64')}`;
 }
 
 /**
@@ -86,8 +88,8 @@ export function encryptWithKey(plaintext: string, keyBuffer: Buffer): string {
  * @returns Versioned ciphertext string (e.g., "v1:iv:authTag:ciphertext")
  */
 export function encryptValue(plaintext: string, keyBuffer?: Buffer): string {
-    const key = keyBuffer || getEncryptionKey();
-    return encryptWithKey(plaintext, key);
+  const key = keyBuffer || getEncryptionKey();
+  return encryptWithKey(plaintext, key);
 }
 
 /**
@@ -100,40 +102,39 @@ export function encryptValue(plaintext: string, keyBuffer?: Buffer): string {
  * @throws Error if decryption fails
  */
 export function decryptValue(ciphertext: string, keyBuffer?: Buffer): string {
-    const key = keyBuffer || getEncryptionKey();
-    let ivStr, tagStr, dataStr;
+  const key = keyBuffer || getEncryptionKey();
+  let ivStr, tagStr, dataStr;
 
-    if (ciphertext.startsWith(V1_PREFIX)) {
-        // v1 format: v1:iv:tag:data
-        const parts = ciphertext.slice(V1_PREFIX.length).split(':');
-        if (parts.length !== 3) {
-            throw new Error('Decryption failed: invalid v1 data format');
-        }
-        [ivStr, tagStr, dataStr] = parts;
-    } else {
-        // Legacy format: iv:tag:data
-        const parts = ciphertext.split(':');
-        if (parts.length !== 3) {
-            throw new Error('Decryption failed: invalid legacy data format');
-        }
-        [ivStr, tagStr, dataStr] = parts;
+  if (ciphertext.startsWith(V1_PREFIX)) {
+    // v1 format: v1:iv:tag:data
+    const parts = ciphertext.slice(V1_PREFIX.length).split(':');
+    if (parts.length !== 3) {
+      throw new Error('Decryption failed: invalid v1 data format');
     }
-
-    try {
-        const iv = Buffer.from(ivStr, 'base64');
-        const authTag = Buffer.from(tagStr, 'base64');
-        const encrypted = Buffer.from(dataStr, 'base64');
-
-        const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, {
-            authTagLength: AUTH_TAG_LENGTH,
-        });
-        decipher.setAuthTag(authTag);
-
-        const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-        return decrypted.toString('utf8');
-    } catch {
-        // Generic error to avoid leaking cryptographic details
-        throw new Error('Decryption failed: invalid data or wrong key');
+    [ivStr, tagStr, dataStr] = parts;
+  } else {
+    // Legacy format: iv:tag:data
+    const parts = ciphertext.split(':');
+    if (parts.length !== 3) {
+      throw new Error('Decryption failed: invalid legacy data format');
     }
+    [ivStr, tagStr, dataStr] = parts;
+  }
+
+  try {
+    const iv = Buffer.from(ivStr, 'base64');
+    const authTag = Buffer.from(tagStr, 'base64');
+    const encrypted = Buffer.from(dataStr, 'base64');
+
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, {
+      authTagLength: AUTH_TAG_LENGTH,
+    });
+    decipher.setAuthTag(authTag);
+
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString('utf8');
+  } catch {
+    // Generic error to avoid leaking cryptographic details
+    throw new Error('Decryption failed: invalid data or wrong key');
+  }
 }
-

--- a/apps/purrmission-bot/src/infra/rateLimit.test.ts
+++ b/apps/purrmission-bot/src/infra/rateLimit.test.ts
@@ -3,50 +3,50 @@ import assert from 'node:assert/strict';
 import { RateLimiter } from './rateLimit.js';
 
 describe('RateLimiter', () => {
-    it('should allow requests within limit', () => {
-        const limiter = new RateLimiter(1000, 2);
-        assert.equal(limiter.check('user-1'), true);
-        assert.equal(limiter.check('user-1'), true);
-        assert.equal(limiter.check('user-1'), false);
-    });
+  it('should allow requests within limit', () => {
+    const limiter = new RateLimiter(1000, 2);
+    assert.equal(limiter.check('user-1'), true);
+    assert.equal(limiter.check('user-1'), true);
+    assert.equal(limiter.check('user-1'), false);
+  });
 
-    it('should use separate buckets for different keys', () => {
-        const limiter = new RateLimiter(1000, 1);
-        assert.equal(limiter.check('user-1'), true);
-        assert.equal(limiter.check('user-1'), false);
-        assert.equal(limiter.check('user-2'), true);
-        assert.equal(limiter.check('user-2'), false);
-    });
+  it('should use separate buckets for different keys', () => {
+    const limiter = new RateLimiter(1000, 1);
+    assert.equal(limiter.check('user-1'), true);
+    assert.equal(limiter.check('user-1'), false);
+    assert.equal(limiter.check('user-2'), true);
+    assert.equal(limiter.check('user-2'), false);
+  });
 
-    it('should reset bucket after window expires', async () => {
-        const limiter = new RateLimiter(100, 1);
-        assert.equal(limiter.check('user-1'), true);
-        assert.equal(limiter.check('user-1'), false);
+  it('should reset bucket after window expires', async () => {
+    const limiter = new RateLimiter(100, 1);
+    assert.equal(limiter.check('user-1'), true);
+    assert.equal(limiter.check('user-1'), false);
 
-        await new Promise(resolve => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
-        assert.equal(limiter.check('user-1'), true);
-    });
+    assert.equal(limiter.check('user-1'), true);
+  });
 
-    it('should clean up stale buckets', async () => {
-        // Use a tiny window for testing cleanup
-        const limiter = new RateLimiter(50, 1);
-        limiter.check('user-1');
+  it('should clean up stale buckets', async () => {
+    // Use a tiny window for testing cleanup
+    const limiter = new RateLimiter(50, 1);
+    limiter.check('user-1');
 
-        // Buckets internal Map is private, but we can indirectly test it
-        // by waiting for cleanup and checking if it refills correctly.
-        // Actually, cleanup just deletes the entry from the map.
+    // Buckets internal Map is private, but we can indirectly test it
+    // by waiting for cleanup and checking if it refills correctly.
+    // Actually, cleanup just deletes the entry from the map.
 
-        // @ts-expect-error - testing cleanup - accessing private member for testing
-        assert.equal(limiter.buckets.size, 1);
+    // @ts-expect-error - testing cleanup - accessing private member for testing
+    assert.equal(limiter.buckets.size, 1);
 
-        await new Promise(resolve => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
-        // Manual trigger cleanup since the interval is 5 mins
-        // @ts-expect-error - testing cleanup
-        limiter.cleanup();
+    // Manual trigger cleanup since the interval is 5 mins
+    // @ts-expect-error - testing cleanup
+    limiter.cleanup();
 
-        // @ts-expect-error - testing cleanup
-        assert.equal(limiter.buckets.size, 0);
-    });
+    // @ts-expect-error - testing cleanup
+    assert.equal(limiter.buckets.size, 0);
+  });
 });

--- a/apps/purrmission-bot/src/infra/rateLimit.ts
+++ b/apps/purrmission-bot/src/infra/rateLimit.ts
@@ -1,13 +1,13 @@
 import { logger } from '../logging/logger.js';
 
 interface RateLimitConfig {
-    windowMs: number;
-    maxRequests: number;
+  windowMs: number;
+  maxRequests: number;
 }
 
 interface TokenBucket {
-    tokens: number;
-    lastRefill: number;
+  tokens: number;
+  lastRefill: number;
 }
 
 /**
@@ -17,66 +17,66 @@ interface TokenBucket {
 type RateLimitKey = string;
 
 export class RateLimiter {
-    private buckets: Map<RateLimitKey, TokenBucket> = new Map();
-    private config: RateLimitConfig;
+  private buckets: Map<RateLimitKey, TokenBucket> = new Map();
+  private config: RateLimitConfig;
 
-    /**
-     * @param windowMs - Time window in milliseconds
-     * @param maxRequests - Max requests allowed in the window
-     */
-    constructor(windowMs: number = 60000, maxRequests: number = 10) {
-        this.config = { windowMs, maxRequests };
+  /**
+   * @param windowMs - Time window in milliseconds
+   * @param maxRequests - Max requests allowed in the window
+   */
+  constructor(windowMs: number = 60000, maxRequests: number = 10) {
+    this.config = { windowMs, maxRequests };
 
-        // Cleanup interval to remove stale buckets
-        const interval = setInterval(() => this.cleanup(), 60000 * 5); // Every 5 min
-        interval.unref(); // Allow process to exit if only the interval is active
+    // Cleanup interval to remove stale buckets
+    const interval = setInterval(() => this.cleanup(), 60000 * 5); // Every 5 min
+    interval.unref(); // Allow process to exit if only the interval is active
+  }
+
+  /**
+   * Check if a request should be rate limited.
+   * Returns true if request is allowed, false if limited.
+   * Consumes a token if allowed.
+   */
+  check(key: RateLimitKey): boolean {
+    const now = Date.now();
+    let bucket = this.buckets.get(key);
+
+    if (!bucket) {
+      bucket = {
+        tokens: this.config.maxRequests,
+        lastRefill: now,
+      };
+      this.buckets.set(key, bucket);
     }
 
-    /**
-     * Check if a request should be rate limited.
-     * Returns true if request is allowed, false if limited.
-     * Consumes a token if allowed.
-     */
-    check(key: RateLimitKey): boolean {
-        const now = Date.now();
-        let bucket = this.buckets.get(key);
+    this.refill(bucket, now);
 
-        if (!bucket) {
-            bucket = {
-                tokens: this.config.maxRequests,
-                lastRefill: now,
-            };
-            this.buckets.set(key, bucket);
-        }
-
-        this.refill(bucket, now);
-
-        if (bucket.tokens >= 1) {
-            bucket.tokens -= 1;
-            return true;
-        }
-
-        logger.warn(`Rate limit exceeded for key: ${key}`);
-        return false;
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return true;
     }
 
-    private refill(bucket: TokenBucket, now: number): void {
-        const elapsed = now - bucket.lastRefill;
-        if (elapsed > this.config.windowMs) {
-            // Full refill after window passes (simple fixed window reset)
-            bucket.tokens = this.config.maxRequests;
-            bucket.lastRefill = now;
-        }
-    }
+    logger.warn(`Rate limit exceeded for key: ${key}`);
+    return false;
+  }
 
-    private cleanup(): void {
-        const now = Date.now();
-        for (const [key, bucket] of this.buckets.entries()) {
-            if (now - bucket.lastRefill > this.config.windowMs * 2) {
-                this.buckets.delete(key);
-            }
-        }
+  private refill(bucket: TokenBucket, now: number): void {
+    const elapsed = now - bucket.lastRefill;
+    if (elapsed > this.config.windowMs) {
+      // Full refill after window passes (simple fixed window reset)
+      bucket.tokens = this.config.maxRequests;
+      bucket.lastRefill = now;
     }
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [key, bucket] of this.buckets.entries()) {
+      if (now - bucket.lastRefill > this.config.windowMs * 2) {
+        this.buckets.delete(key);
+      }
+    }
+  }
 }
 
 // Singleton instance for global rate limiting

--- a/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
+++ b/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
@@ -395,7 +395,8 @@ describe('Credential Sync Logic Smoke Test', () => {
       slug: 'dev',
       projectId: project.id,
     });
-    const resourceId = env.resourceId!;
+    assert.ok(env.resourceId, 'env.resourceId must be defined');
+    const resourceId = env.resourceId;
 
     // Create approval request with default expiration (24h)
     const result = await services.approval.createApprovalRequest({
@@ -420,7 +421,8 @@ describe('Credential Sync Logic Smoke Test', () => {
     assert.strictEqual(active.id, result.request.id);
 
     // Now, let's manually modify the request in the repo to be expired (expiresAt in the past)
-    const rawReq = approvalRepo.requests.find((r) => r.id === result.request!.id);
+    const requestId = result.request.id;
+    const rawReq = approvalRepo.requests.find((r) => r.id === requestId);
     assert.ok(rawReq);
     rawReq.expiresAt = new Date(Date.now() - 60000); // 1 minute ago
 

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -21,26 +21,26 @@ describe('System API E2E Tests', () => {
   let server: FastifyInstance;
 
   // Shared mock implementations that tests can override
-  const mockVerifyApiKey = { fn: async (_apiKey: string): Promise<any> => null };
+  const mockVerifyApiKey = { fn: async (_apiKey: string): Promise<unknown> => null };
   const mockCreateApprovalRequest = {
-    fn: async (_input: any): Promise<any> => ({ success: false }),
+    fn: async (_input: unknown): Promise<unknown> => ({ success: false }),
   };
-  const mockGetApprovalRequest = { fn: async (_id: string): Promise<any> => null };
+  const mockGetApprovalRequest = { fn: async (_id: string): Promise<unknown> => null };
   const mockFindActiveApproval = {
-    fn: async (_resourceId: string, _userId: string): Promise<any> => null,
+    fn: async (_resourceId: string, _userId: string): Promise<unknown> => null,
   };
-  const mockValidateToken = { fn: async (_token: string): Promise<any> => null };
-  const mockGetProject = { fn: async (_projectId: string): Promise<any> => null };
+  const mockValidateToken = { fn: async (_token: string): Promise<unknown> => null };
+  const mockGetProject = { fn: async (_projectId: string): Promise<unknown> => null };
   const mockGetEnvironmentById = {
-    fn: async (_projectId: string, _envId: string): Promise<any> => null,
+    fn: async (_projectId: string, _envId: string): Promise<unknown> => null,
   };
   const mockGetMemberRole = {
-    fn: async (_projectId: string, _userId: string): Promise<any> => null,
+    fn: async (_projectId: string, _userId: string): Promise<unknown> => null,
   };
   const mockIsGuardian = {
     fn: async (_resourceId: string, _userId: string): Promise<boolean> => false,
   };
-  const mockListFields = { fn: async (_resourceId: string): Promise<any[]> => [] };
+  const mockListFields = { fn: async (_resourceId: string): Promise<unknown[]> => [] };
   const mockUpsertField = {
     fn: async (_resourceId: string, _key: string, _value: string): Promise<void> => {},
   };
@@ -54,7 +54,7 @@ describe('System API E2E Tests', () => {
         mockUpsertField.fn(resourceId, key, value),
     },
     approval: {
-      createApprovalRequest: (input: any) => mockCreateApprovalRequest.fn(input),
+      createApprovalRequest: (input: unknown) => mockCreateApprovalRequest.fn(input),
       getApprovalRequest: (id: string) => mockGetApprovalRequest.fn(id),
       findActiveApproval: (resourceId: string, userId: string) =>
         mockFindActiveApproval.fn(resourceId, userId),
@@ -289,9 +289,9 @@ describe('System API E2E Tests', () => {
       mockFindActiveApproval.fn = async () => null; // none exists yet
 
       let createdRequest = false;
-      mockCreateApprovalRequest.fn = async (input: any) => {
+      mockCreateApprovalRequest.fn = async (input: unknown) => {
         createdRequest = true;
-        assert.strictEqual(input.resourceId, 'res-1');
+        assert.strictEqual((input as { resourceId: string }).resourceId, 'res-1');
         return {
           success: true,
           request: {

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -3,37 +3,37 @@
 ## Pre-Deployment Verification
 
 - [ ] **Environment Variables**:
-    - [ ] `DATABASE_URL` is set in `.env`.
-        - *Critical*: For SQLite, verify the path points to a persistent volume/location outside the ephemeral build directories.
-        - **Example**: 
-            - BAD: `file:./dev.db` (Relative to app, deleted on deploy)
-            - GOOD: `file:/home/user/purrmission_data/prod.db` (Absolute path, outside deploy folder)
-    - [ ] `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID` are set.
-    - [ ] `PORT` is set (default 3000).
+  - [ ] `DATABASE_URL` is set in `.env`.
+    - _Critical_: For SQLite, verify the path points to a persistent volume/location outside the ephemeral build directories.
+    - **Example**:
+      - BAD: `file:./dev.db` (Relative to app, deleted on deploy)
+      - GOOD: `file:/home/user/purrmission_data/prod.db` (Absolute path, outside deploy folder)
+  - [ ] `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID` are set.
+  - [ ] `PORT` is set (default 3000).
 
 - [ ] **Database & Migrations**:
-    - [ ] **Artifact Check**: Ensure `prisma/` directory (containing `schema.prisma`) is included in the deployment artifact.
-        - *Current Status*: **MISSING** in `deploy.yml`. Application execution might work, but migrations will fail.
-    - [ ] **Migration Check**: Run `npx prisma migrate deploy` on the server after deployment.
-    - [ ] **Persistence Check**: Verify SQLite database file is not overwritten/deleted during deployment cleanup.
+  - [ ] **Artifact Check**: Ensure `prisma/` directory (containing `schema.prisma`) is included in the deployment artifact.
+    - _Current Status_: **MISSING** in `deploy.yml`. Application execution might work, but migrations will fail.
+  - [ ] **Migration Check**: Run `npx prisma migrate deploy` on the server after deployment.
+  - [ ] **Persistence Check**: Verify SQLite database file is not overwritten/deleted during deployment cleanup.
 
 - [ ] **Dependencies**:
-    - [ ] Verify `pnpm install --immutable` runs successfully.
-    - [ ] Ensure `openssl` is installed on the server (required for Prisma Engine).
+  - [ ] Verify `pnpm install --immutable` runs successfully.
+  - [ ] Ensure `openssl` is installed on the server (required for Prisma Engine).
 
 ## Deployment Steps
 
 1.  **Merge to `deploy` branch**: Triggers GitHub Action.
 2.  **Monitor Action**: Watch for build and deploy job success.
 3.  **Post-Deployment Server Checks**:
-    -   SSH into server.
-    -   Navigate to deployment directory.
-    -   Run Migrations: `npx prisma migrate deploy` (Requires fixing artifact export first).
-    -   Check PM2 status: `pm2 status`.
-    -   View Logs: `pm2 logs Purrmission`.
+    - SSH into server.
+    - Navigate to deployment directory.
+    - Run Migrations: `npx prisma migrate deploy` (Requires fixing artifact export first).
+    - Check PM2 status: `pm2 status`.
+    - View Logs: `pm2 logs Purrmission`.
 
 ## Troubleshooting
 
--   **"Schema not found"**: The `prisma` directory was not uploaded. Copy it manually or update `deploy.yml`.
--   **"Database is locked"**: Common with SQLite if multiple processes access it. Restart PM2.
--   **Missing Dependencies**: If `npx` or `prisma` not found, ensure they are in `dependencies` or `pnpm install` installs dev deps (default for Yarn Berry).
+- **"Schema not found"**: The `prisma` directory was not uploaded. Copy it manually or update `deploy.yml`.
+- **"Database is locked"**: Common with SQLite if multiple processes access it. Restart PM2.
+- **Missing Dependencies**: If `npx` or `prisma` not found, ensure they are in `dependencies` or `pnpm install` installs dev deps (default for Yarn Berry).

--- a/docs/deployment-testing.md
+++ b/docs/deployment-testing.md
@@ -22,15 +22,18 @@ Use the helper script to run the workflow locally:
 ```
 
 This will:
+
 1. Load secrets from `.github/act/deploy.secrets`
 2. Load env from `.github/act/deploy.env`
 3. Execute the `deploy` workflow in dry-run mode
 4. Run the simulation step
 
 To run a "real" (simulated) deploy inside Act:
+
 ```bash
 ./scripts/ci/act-deploy.sh false
 ```
+
 **Note:** This will attempt to SSH/SCP if you provide valid credentials in `.secrets`. If you use the default dummy secrets, it will fail connection, which is expected.
 
 ## Distrobox Verification
@@ -44,6 +47,7 @@ To test the deployment logic against a realistic OS environment (simulating a fr
 ```
 
 This script will:
+
 1. Build the project (`pnpm build`).
 2. Create two containers: `purrmission-srv-fresh` and `purrmission-srv-existing` (defined in `distrobox.ini`).
 3. **Fresh Server Test**:
@@ -62,6 +66,7 @@ distrobox enter purrmission-srv-fresh
 ```
 
 Then run the simulation manually:
+
 ```bash
 ./scripts/ci/simulate-deploy.sh "apps/purrmission-bot/dist"
 ```

--- a/docs/reports/2026-01-18-credential-sync-analysis.md
+++ b/docs/reports/2026-01-18-credential-sync-analysis.md
@@ -1,22 +1,25 @@
 # Credential Sync Analysis & Smoke Test Report
 
 ## Executive Summary
+
 The "Credential Sync" feature (Epic #14) is **Functionally Complete** and adheres to the design document. A logic-based smoke test verified the critical path: Project Creation -> Secret Management -> Guardian Access -> Approval Workflow -> Secret Retrieval. Security requirements (at-rest encryption for secrets and tokens) are met.
 
 ## Verification Activity
+
 - **Code Analysis**: Reviewed `apps/pawthy` (CLI), `apps/purrmission-bot` (Server/Discord), and Domain models.
 - **Design Check**: Verified alignment with `docs/design/credential-sync.md`.
 - **Smoke Testing**: Implemented and ran `src/test/credential_sync_logic.test.ts` (Logic Interaction Test).
-    - **Result**: ✅ PASSED.
+  - **Result**: ✅ PASSED.
 
 ## Implementation Details
+
 1.  **Architecture**:
     - **CLI**: Implements `init`, `login`, `push`, `pull` consistent with API.
     - **API**: Endpoints for Project/Env/Secret management fully implemented.
     - **Security**:
-        - **Secrets**: Encrypted at rest (`ResourceField` value).
-        - **Tokens**: Hashed at rest (SHA-256).
-        - **Transport**: Relies on HTTPS (standard).
+      - **Secrets**: Encrypted at rest (`ResourceField` value).
+      - **Tokens**: Hashed at rest (SHA-256).
+      - **Transport**: Relies on HTTPS (standard).
 2.  **Data Flow**:
     - Project Service correctly links Environments to Resources.
     - Approval Service correctly gates access to secrets for non-owners.
@@ -24,26 +27,33 @@ The "Credential Sync" feature (Epic #14) is **Functionally Complete** and adhere
 ## Found Gaps & Recommendations
 
 ### 1. Robustness of Audit Logging (Minor)
+
 **Observation**: In `ApprovalService` and other services, audit logging is awaited (`await this.deps.audit?.log(...)`).
 **Risk**: If the Audit Service fails (system issue), the primary business operation might fail or throw an exception _after_ the DB state change (or prevent it), potentially leading to inconsistent state or user error.
 **Recommendation**: Wrap audit logging in `try/catch` block to ensure business continuity even if auditing fails (unless auditing is a hard requirement for compliance, then use transaction).
 
 ### 2. End-to-End Testing
+
 **Observation**: No full automated E2E test exists connecting CLI -> API -> Discord.
 **Recommendation**: Create a "System Test" that spins up the Fastify server and mocks Discord interactions to test the HTTP contract.
 
 ### 3. CLI Distribution
+
 **Observation**: CLI code exists but no clear packaging/distribution strategy (e.g. `npm publish` workflow) was observed in Epic.
 **Recommendation**: Add a task to define CLI versioning and release pipeline.
 
 ## Conclusion
+
 The feature is ready for **Beta Testing** or internal dogfooding. The implementation is solid.
 
 ## Verification Artifacts
+
 - Smoke Test Logic: `apps/purrmission-bot/src/test/credential_sync_logic.test.ts`
 
 ## Post-Analysis Updates (2026-01-18)
+
 **Connected Issues:**
+
 - #30 Enhance Audit Log Robustness
 - #31 Implement End-to-End API System Test
 - #32 Define CLI Distribution Pipeline

--- a/docs/user/cli-setup.md
+++ b/docs/user/cli-setup.md
@@ -20,6 +20,7 @@ npx @psl-oss/pawthy pull
 ## Installation
 
 ### Global Installation
+
 For frequent use, install globally:
 
 ```bash
@@ -27,11 +28,13 @@ npm install -g @psl-oss/pawthy
 ```
 
 Then run commands directly:
+
 ```bash
 pawthy push
 ```
 
 ### Project Installation
+
 To pin a specific version for your project:
 
 ```bash
@@ -39,6 +42,7 @@ npm install -D @psl-oss/pawthy
 ```
 
 Run via npm scripts or `npx`:
+
 ```bash
 npx pawthy pull
 ```
@@ -46,4 +50,5 @@ npx pawthy pull
 ## Troubleshooting
 
 ### "Package not found"
+
 Ensure you are using the correct scope `@psl-oss`.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,12 +1,12 @@
 module.exports = {
-    apps: [
-        {
-            name: "Purrmission",
-            script: "./apps/purrmission-bot/dist/index.js",
-            cwd: "./", // .env file must be in this directory (project root)
-            env: {
-                NODE_ENV: "production",
-            },
-        },
-    ],
+  apps: [
+    {
+      name: 'Purrmission',
+      script: './apps/purrmission-bot/dist/index.js',
+      cwd: './', // .env file must be in this directory (project root)
+      env: {
+        NODE_ENV: 'production',
+      },
+    },
+  ],
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,18 +3,18 @@ import prettier from 'eslint-config-prettier';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-    {
-        ignores: ['**/dist/**', '**/node_modules/**', '**/.turbo/**', '**/coverage/**'],
+  {
+    ignores: ['**/dist/**', '**/node_modules/**', '**/.turbo/**', '**/coverage/**'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  prettier,
+  {
+    rules: {
+      //'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
     },
-    js.configs.recommended,
-    ...tseslint.configs.recommended,
-    prettier,
-    {
-        rules: {
-            //'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
-            '@typescript-eslint/explicit-function-return-type': 'off',
-            '@typescript-eslint/no-explicit-any': 'warn',
-            '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-        },
-    },
+  }
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     dependencies:
       '@prisma/client':
@@ -136,375 +135,614 @@ importers:
         version: 5.9.3
 
 packages:
-
   '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==,
+      }
+    engines: { node: '>=6.0.0' }
     hasBin: true
 
   '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@commitlint/cli@20.4.1':
-    resolution: {integrity: sha512-uuFKKpc7OtQM+6SRqT+a4kV818o1pS+uvv/gsRhyX7g4x495jg+Q7P0+O9VNGyLXBYP0syksS7gMRDJKcekr6A==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-uuFKKpc7OtQM+6SRqT+a4kV818o1pS+uvv/gsRhyX7g4x495jg+Q7P0+O9VNGyLXBYP0syksS7gMRDJKcekr6A==,
+      }
+    engines: { node: '>=v18' }
     hasBin: true
 
   '@commitlint/config-conventional@20.4.1':
-    resolution: {integrity: sha512-0YUvIeBtpi86XriqrR+TCULVFiyYTIOEPjK7tTRMxjcBm1qlzb+kz7IF2WxL6Fq5DaundG8VO37BNgMkMTBwqA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-0YUvIeBtpi86XriqrR+TCULVFiyYTIOEPjK7tTRMxjcBm1qlzb+kz7IF2WxL6Fq5DaundG8VO37BNgMkMTBwqA==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/config-validator@20.4.0':
-    resolution: {integrity: sha512-zShmKTF+sqyNOfAE0vKcqnpvVpG0YX8F9G/ZIQHI2CoKyK+PSdladXMSns400aZ5/QZs+0fN75B//3Q5CHw++w==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-zShmKTF+sqyNOfAE0vKcqnpvVpG0YX8F9G/ZIQHI2CoKyK+PSdladXMSns400aZ5/QZs+0fN75B//3Q5CHw++w==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/ensure@20.4.1':
-    resolution: {integrity: sha512-WLQqaFx1pBooiVvBrA1YfJNFqZF8wS/YGOtr5RzApDbV9tQ52qT5VkTsY65hFTnXhW8PcDfZLaknfJTmPejmlw==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-WLQqaFx1pBooiVvBrA1YfJNFqZF8wS/YGOtr5RzApDbV9tQ52qT5VkTsY65hFTnXhW8PcDfZLaknfJTmPejmlw==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/execute-rule@20.0.0':
-    resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/format@20.4.0':
-    resolution: {integrity: sha512-i3ki3WR0rgolFVX6r64poBHXM1t8qlFel1G1eCBvVgntE3fCJitmzSvH5JD/KVJN/snz6TfaX2CLdON7+s4WVQ==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-i3ki3WR0rgolFVX6r64poBHXM1t8qlFel1G1eCBvVgntE3fCJitmzSvH5JD/KVJN/snz6TfaX2CLdON7+s4WVQ==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/is-ignored@20.4.1':
-    resolution: {integrity: sha512-In5EO4JR1lNsAv1oOBBO24V9ND1IqdAJDKZiEpdfjDl2HMasAcT7oA+5BKONv1pRoLG380DGPE2W2RIcUwdgLA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-In5EO4JR1lNsAv1oOBBO24V9ND1IqdAJDKZiEpdfjDl2HMasAcT7oA+5BKONv1pRoLG380DGPE2W2RIcUwdgLA==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/lint@20.4.1':
-    resolution: {integrity: sha512-g94LrGl/c6UhuhDQqNqU232aslLEN2vzc7MPfQTHzwzM4GHNnEAwVWWnh0zX8S5YXecuLXDwbCsoGwmpAgPWKA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-g94LrGl/c6UhuhDQqNqU232aslLEN2vzc7MPfQTHzwzM4GHNnEAwVWWnh0zX8S5YXecuLXDwbCsoGwmpAgPWKA==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/load@20.4.0':
-    resolution: {integrity: sha512-Dauup/GfjwffBXRJUdlX/YRKfSVXsXZLnINXKz0VZkXdKDcaEILAi9oflHGbfydonJnJAbXEbF3nXPm9rm3G6A==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-Dauup/GfjwffBXRJUdlX/YRKfSVXsXZLnINXKz0VZkXdKDcaEILAi9oflHGbfydonJnJAbXEbF3nXPm9rm3G6A==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/message@20.4.0':
-    resolution: {integrity: sha512-B5lGtvHgiLAIsK5nLINzVW0bN5hXv+EW35sKhYHE8F7V9Uz1fR4tx3wt7mobA5UNhZKUNgB/+ldVMQE6IHZRyA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-B5lGtvHgiLAIsK5nLINzVW0bN5hXv+EW35sKhYHE8F7V9Uz1fR4tx3wt7mobA5UNhZKUNgB/+ldVMQE6IHZRyA==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/parse@20.4.1':
-    resolution: {integrity: sha512-XNtZjeRcFuAfUnhYrCY02+mpxwY4OmnvD3ETbVPs25xJFFz1nRo/25nHj+5eM+zTeRFvWFwD4GXWU2JEtoK1/w==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-XNtZjeRcFuAfUnhYrCY02+mpxwY4OmnvD3ETbVPs25xJFFz1nRo/25nHj+5eM+zTeRFvWFwD4GXWU2JEtoK1/w==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/read@20.4.0':
-    resolution: {integrity: sha512-QfpFn6/I240ySEGv7YWqho4vxqtPpx40FS7kZZDjUJ+eHxu3azfhy7fFb5XzfTqVNp1hNoI3tEmiEPbDB44+cg==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-QfpFn6/I240ySEGv7YWqho4vxqtPpx40FS7kZZDjUJ+eHxu3azfhy7fFb5XzfTqVNp1hNoI3tEmiEPbDB44+cg==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/resolve-extends@20.4.0':
-    resolution: {integrity: sha512-ay1KM8q0t+/OnlpqXJ+7gEFQNlUtSU5Gxr8GEwnVf2TPN3+ywc5DzL3JCxmpucqxfHBTFwfRMXxPRRnR5Ki20g==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-ay1KM8q0t+/OnlpqXJ+7gEFQNlUtSU5Gxr8GEwnVf2TPN3+ywc5DzL3JCxmpucqxfHBTFwfRMXxPRRnR5Ki20g==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/rules@20.4.1':
-    resolution: {integrity: sha512-WtqypKEPbQEuJwJS4aKs0OoJRBKz1HXPBC9wRtzVNH68FLhPWzxXlF09hpUXM9zdYTpm4vAdoTGkWiBgQ/vL0g==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-WtqypKEPbQEuJwJS4aKs0OoJRBKz1HXPBC9wRtzVNH68FLhPWzxXlF09hpUXM9zdYTpm4vAdoTGkWiBgQ/vL0g==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/to-lines@20.0.0':
-    resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/top-level@20.4.0':
-    resolution: {integrity: sha512-NDzq8Q6jmFaIIBC/GG6n1OQEaHdmaAAYdrZRlMgW6glYWGZ+IeuXmiymDvQNXPc82mVxq2KiE3RVpcs+1OeDeA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-NDzq8Q6jmFaIIBC/GG6n1OQEaHdmaAAYdrZRlMgW6glYWGZ+IeuXmiymDvQNXPc82mVxq2KiE3RVpcs+1OeDeA==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/types@20.4.0':
-    resolution: {integrity: sha512-aO5l99BQJ0X34ft8b0h7QFkQlqxC6e7ZPVmBKz13xM9O8obDaM1Cld4sQlJDXXU/VFuUzQ30mVtHjVz74TuStw==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-aO5l99BQJ0X34ft8b0h7QFkQlqxC6e7ZPVmBKz13xM9O8obDaM1Cld4sQlJDXXU/VFuUzQ30mVtHjVz74TuStw==,
+      }
+    engines: { node: '>=v18' }
 
   '@discordjs/builders@1.13.1':
-    resolution: {integrity: sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==}
-    engines: {node: '>=16.11.0'}
+    resolution:
+      {
+        integrity: sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==,
+      }
+    engines: { node: '>=16.11.0' }
 
   '@discordjs/collection@1.5.3':
-    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
-    engines: {node: '>=16.11.0'}
+    resolution:
+      {
+        integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==,
+      }
+    engines: { node: '>=16.11.0' }
 
   '@discordjs/collection@2.1.1':
-    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==,
+      }
+    engines: { node: '>=18' }
 
   '@discordjs/formatters@0.6.2':
-    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
-    engines: {node: '>=16.11.0'}
+    resolution:
+      {
+        integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==,
+      }
+    engines: { node: '>=16.11.0' }
 
   '@discordjs/rest@2.6.0':
-    resolution: {integrity: sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==,
+      }
+    engines: { node: '>=18' }
 
   '@discordjs/util@1.2.0':
-    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==,
+      }
+    engines: { node: '>=18' }
 
   '@discordjs/ws@1.2.3':
-    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
-    engines: {node: '>=16.11.0'}
+    resolution:
+      {
+        integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==,
+      }
+    engines: { node: '>=16.11.0' }
 
   '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==,
+      }
+    engines: { node: '>=18' }
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==,
+      }
+    engines: { node: '>=18' }
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==,
+      }
+    engines: { node: '>=18' }
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==,
+      }
+    engines: { node: '>=18' }
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==,
+      }
+    engines: { node: '>=18' }
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==,
+      }
+    engines: { node: '>=18' }
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==,
+      }
+    engines: { node: '>=18' }
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [openharmony]
 
   '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==,
+      }
+    engines: { node: '>=18' }
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
   '@eslint-community/regexpp@4.12.2':
-    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==,
+      }
+    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
   '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/config-helpers@0.4.2':
-    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/core@0.17.0':
-    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/eslintrc@3.3.3':
-    resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/js@9.39.2':
-    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/object-schema@2.1.7':
-    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@fastify/ajv-compiler@4.0.5':
-    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+    resolution:
+      {
+        integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==,
+      }
 
   '@fastify/error@4.2.0':
-    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+    resolution:
+      {
+        integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==,
+      }
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
-    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+    resolution:
+      {
+        integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==,
+      }
 
   '@fastify/formbody@8.0.2':
-    resolution: {integrity: sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==}
+    resolution:
+      {
+        integrity: sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==,
+      }
 
   '@fastify/forwarded@3.0.1':
-    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+    resolution:
+      {
+        integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==,
+      }
 
   '@fastify/merge-json-schemas@0.2.1':
-    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+    resolution:
+      {
+        integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==,
+      }
 
   '@fastify/proxy-addr@5.1.0':
-    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+    resolution:
+      {
+        integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==,
+      }
 
   '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
-    engines: {node: '>=18.18.0'}
+    resolution:
+      {
+        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+      }
+    engines: { node: '>=18.18.0' }
 
   '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
-    engines: {node: '>=18.18.0'}
+    resolution:
+      {
+        integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
+      }
+    engines: { node: '>=18.18.0' }
 
   '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
+    resolution:
+      {
+        integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
+      }
+    engines: { node: '>=12.22' }
 
   '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
+    resolution:
+      {
+        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
+      }
+    engines: { node: '>=18.18' }
 
   '@inquirer/external-editor@1.0.3':
-    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==,
+      }
+    engines: { node: '>=18' }
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -512,46 +750,82 @@ packages:
         optional: true
 
   '@inquirer/figures@1.0.15':
-    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==,
+      }
+    engines: { node: '>=18' }
 
   '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+    resolution:
+      {
+        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+      }
 
   '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: '>=6.0.0' }
 
   '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
 
   '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+      }
 
   '@otplib/core@12.0.1':
-    resolution: {integrity: sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==}
+    resolution:
+      {
+        integrity: sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==,
+      }
 
   '@otplib/plugin-crypto@12.0.1':
-    resolution: {integrity: sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==}
+    resolution:
+      {
+        integrity: sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==,
+      }
     deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
 
   '@otplib/plugin-thirty-two@12.0.1':
-    resolution: {integrity: sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==}
+    resolution:
+      {
+        integrity: sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==,
+      }
     deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
 
   '@otplib/preset-default@12.0.1':
-    resolution: {integrity: sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==}
+    resolution:
+      {
+        integrity: sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==,
+      }
     deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
 
   '@otplib/preset-v11@12.0.1':
-    resolution: {integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==}
+    resolution:
+      {
+        integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==,
+      }
 
   '@pinojs/redact@0.4.0':
-    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+    resolution:
+      {
+        integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==,
+      }
 
   '@prisma/client@6.19.1':
-    resolution: {integrity: sha512-4SXj4Oo6HyQkLUWT8Ke5R0PTAfVOKip5Roo+6+b2EDTkFg5be0FnBWiuRJc0BC0sRQIWGMLKW1XguhVfW/z3/A==}
-    engines: {node: '>=18.18'}
+    resolution:
+      {
+        integrity: sha512-4SXj4Oo6HyQkLUWT8Ke5R0PTAfVOKip5Roo+6+b2EDTkFg5be0FnBWiuRJc0BC0sRQIWGMLKW1XguhVfW/z3/A==,
+      }
+    engines: { node: '>=18.18' }
     peerDependencies:
       prisma: '*'
       typescript: '>=5.1.0'
@@ -562,151 +836,250 @@ packages:
         optional: true
 
   '@prisma/config@6.19.1':
-    resolution: {integrity: sha512-bUL/aYkGXLwxVGhJmQMtslLT7KPEfUqmRa919fKI4wQFX4bIFUKiY8Jmio/2waAjjPYrtuDHa7EsNCnJTXxiOw==}
+    resolution:
+      {
+        integrity: sha512-bUL/aYkGXLwxVGhJmQMtslLT7KPEfUqmRa919fKI4wQFX4bIFUKiY8Jmio/2waAjjPYrtuDHa7EsNCnJTXxiOw==,
+      }
 
   '@prisma/debug@6.19.1':
-    resolution: {integrity: sha512-h1JImhlAd/s5nhY/e9qkAzausWldbeT+e4nZF7A4zjDYBF4BZmKDt4y0jK7EZapqOm1kW7V0e9agV/iFDy3fWw==}
+    resolution:
+      {
+        integrity: sha512-h1JImhlAd/s5nhY/e9qkAzausWldbeT+e4nZF7A4zjDYBF4BZmKDt4y0jK7EZapqOm1kW7V0e9agV/iFDy3fWw==,
+      }
 
   '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
-    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
+    resolution:
+      {
+        integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==,
+      }
 
   '@prisma/engines@6.19.1':
-    resolution: {integrity: sha512-xy95dNJ7DiPf9IJ3oaVfX785nbFl7oNDzclUF+DIiJw6WdWCvPl0LPU0YqQLsrwv8N64uOQkH391ujo3wSo+Nw==}
+    resolution:
+      {
+        integrity: sha512-xy95dNJ7DiPf9IJ3oaVfX785nbFl7oNDzclUF+DIiJw6WdWCvPl0LPU0YqQLsrwv8N64uOQkH391ujo3wSo+Nw==,
+      }
 
   '@prisma/fetch-engine@6.19.1':
-    resolution: {integrity: sha512-mmgcotdaq4VtAHO6keov3db+hqlBzQS6X7tR7dFCbvXjLVTxBYdSJFRWz+dq7F9p6dvWyy1X0v8BlfRixyQK6g==}
+    resolution:
+      {
+        integrity: sha512-mmgcotdaq4VtAHO6keov3db+hqlBzQS6X7tR7dFCbvXjLVTxBYdSJFRWz+dq7F9p6dvWyy1X0v8BlfRixyQK6g==,
+      }
 
   '@prisma/get-platform@6.19.1':
-    resolution: {integrity: sha512-zsg44QUiQAnFUyh6Fbt7c9HjMXHwFTqtrgcX7DAZmRgnkPyYT7Sh8Mn8D5PuuDYNtMOYcpLGg576MLfIORsBYw==}
+    resolution:
+      {
+        integrity: sha512-zsg44QUiQAnFUyh6Fbt7c9HjMXHwFTqtrgcX7DAZmRgnkPyYT7Sh8Mn8D5PuuDYNtMOYcpLGg576MLfIORsBYw==,
+      }
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
-    resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
+    resolution:
+      {
+        integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==,
+      }
     cpu: [arm]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.54.0':
-    resolution: {integrity: sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==}
+    resolution:
+      {
+        integrity: sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==,
+      }
     cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.54.0':
-    resolution: {integrity: sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==}
+    resolution:
+      {
+        integrity: sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==,
+      }
     cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.54.0':
-    resolution: {integrity: sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==}
+    resolution:
+      {
+        integrity: sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==,
+      }
     cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.54.0':
-    resolution: {integrity: sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==}
+    resolution:
+      {
+        integrity: sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==,
+      }
     cpu: [arm64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.54.0':
-    resolution: {integrity: sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==}
+    resolution:
+      {
+        integrity: sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==,
+      }
     cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.54.0':
-    resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
+    resolution:
+      {
+        integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==,
+      }
     cpu: [arm]
     os: [linux]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
-    resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
+    resolution:
+      {
+        integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==,
+      }
     cpu: [arm]
     os: [linux]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
-    resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
+    resolution:
+      {
+        integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==,
+      }
     cpu: [arm64]
     os: [linux]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
-    resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
+    resolution:
+      {
+        integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==,
+      }
     cpu: [arm64]
     os: [linux]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
-    resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
+    resolution:
+      {
+        integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==,
+      }
     cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
-    resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
+    resolution:
+      {
+        integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==,
+      }
     cpu: [ppc64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
-    resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
+    resolution:
+      {
+        integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==,
+      }
     cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
-    resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
+    resolution:
+      {
+        integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==,
+      }
     cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
-    resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
+    resolution:
+      {
+        integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==,
+      }
     cpu: [s390x]
     os: [linux]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
-    resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
+    resolution:
+      {
+        integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==,
+      }
     cpu: [x64]
     os: [linux]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
-    resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
+    resolution:
+      {
+        integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==,
+      }
     cpu: [x64]
     os: [linux]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
-    resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
+    resolution:
+      {
+        integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==,
+      }
     cpu: [arm64]
     os: [openharmony]
 
   '@rollup/rollup-win32-arm64-msvc@4.54.0':
-    resolution: {integrity: sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==}
+    resolution:
+      {
+        integrity: sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==,
+      }
     cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.54.0':
-    resolution: {integrity: sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==}
+    resolution:
+      {
+        integrity: sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==,
+      }
     cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-gnu@4.54.0':
-    resolution: {integrity: sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==}
+    resolution:
+      {
+        integrity: sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==,
+      }
     cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.54.0':
-    resolution: {integrity: sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==}
+    resolution:
+      {
+        integrity: sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==,
+      }
     cpu: [x64]
     os: [win32]
 
   '@sapphire/async-queue@1.5.5':
-    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==,
+      }
+    engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
 
   '@sapphire/shapeshift@4.0.0':
-    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
-    engines: {node: '>=v16'}
+    resolution:
+      {
+        integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==,
+      }
+    engines: { node: '>=v16' }
 
   '@sapphire/snowflake@3.5.3':
-    resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==,
+      }
+    engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
 
   '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
 
   '@trivago/prettier-plugin-sort-imports@6.0.2':
-    resolution: {integrity: sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==}
-    engines: {node: '>= 20'}
+    resolution:
+      {
+        integrity: sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==,
+      }
+    engines: { node: '>= 20' }
     peerDependencies:
       '@vue/compiler-sfc': 3.x
       prettier: 2.x - 3.x
@@ -724,104 +1097,170 @@ packages:
         optional: true
 
   '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
 
   '@types/inquirer@9.0.9':
-    resolution: {integrity: sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw==}
+    resolution:
+      {
+        integrity: sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw==,
+      }
 
   '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+    resolution:
+      {
+        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
 
   '@types/node@20.19.30':
-    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
+    resolution:
+      {
+        integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==,
+      }
 
   '@types/node@22.19.3':
-    resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
+    resolution:
+      {
+        integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==,
+      }
 
   '@types/through@0.0.33':
-    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
+    resolution:
+      {
+        integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==,
+      }
 
   '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+    resolution:
+      {
+        integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
+      }
 
   '@typescript-eslint/eslint-plugin@8.50.0':
-    resolution: {integrity: sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       '@typescript-eslint/parser': ^8.50.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/parser@8.50.0':
-    resolution: {integrity: sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/project-service@8.50.0':
-    resolution: {integrity: sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/scope-manager@8.50.0':
-    resolution: {integrity: sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@typescript-eslint/tsconfig-utils@8.50.0':
-    resolution: {integrity: sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/type-utils@8.50.0':
-    resolution: {integrity: sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/types@8.50.0':
-    resolution: {integrity: sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@typescript-eslint/typescript-estree@8.50.0':
-    resolution: {integrity: sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/utils@8.50.0':
-    resolution: {integrity: sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/visitor-keys@8.50.0':
-    resolution: {integrity: sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@vladfrangu/async_event_emitter@2.4.7':
-    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==,
+      }
+    engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
 
   abstract-logging@2.0.1:
-    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+    resolution:
+      {
+        integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==,
+      }
 
   acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    resolution:
+      {
+        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+      }
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
+      }
+    engines: { node: '>=0.4.0' }
     hasBin: true
 
   ajv-formats@2.1.1:
-    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    resolution:
+      {
+        integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==,
+      }
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -829,7 +1268,10 @@ packages:
         optional: true
 
   ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    resolution:
+      {
+        integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==,
+      }
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -837,97 +1279,178 @@ packages:
         optional: true
 
   ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    resolution:
+      {
+        integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+      }
 
   ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+    resolution:
+      {
+        integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==,
+      }
 
   ansi-align@3.0.1:
-    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+    resolution:
+      {
+        integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
+      }
 
   ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==,
+      }
+    engines: { node: '>=8' }
 
   ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==,
+      }
+    engines: { node: '>=18' }
 
   ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+      }
+    engines: { node: '>=8' }
 
   ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
+      }
+    engines: { node: '>=12' }
 
   ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+      }
+    engines: { node: '>=8' }
 
   ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
+      }
+    engines: { node: '>=12' }
 
   any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+    resolution:
+      {
+        integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
+      }
 
   argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
 
   array-ify@1.0.0:
-    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+    resolution:
+      {
+        integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==,
+      }
 
   asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    resolution:
+      {
+        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
+      }
 
   atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==,
+      }
+    engines: { node: '>=8.0.0' }
 
   atomically@2.1.0:
-    resolution: {integrity: sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==}
+    resolution:
+      {
+        integrity: sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==,
+      }
 
   avvio@9.1.0:
-    resolution: {integrity: sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==}
+    resolution:
+      {
+        integrity: sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==,
+      }
 
   axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+    resolution:
+      {
+        integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==,
+      }
 
   balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    resolution:
+      {
+        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+      }
 
   base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    resolution:
+      {
+        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+      }
 
   bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    resolution:
+      {
+        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
+      }
 
   boxen@7.1.1:
-    resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
-    engines: {node: '>=14.16'}
+    resolution:
+      {
+        integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==,
+      }
+    engines: { node: '>=14.16' }
 
   brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+    resolution:
+      {
+        integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
+      }
 
   brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+    resolution:
+      {
+        integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
+      }
 
   braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+      }
+    engines: { node: '>=8' }
 
   buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    resolution:
+      {
+        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
 
   bundle-require@5.1.0:
-    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     peerDependencies:
       esbuild: '>=0.18'
 
   c12@3.1.0:
-    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    resolution:
+      {
+        integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==,
+      }
     peerDependencies:
       magicast: ^0.3.5
     peerDependenciesMeta:
@@ -935,145 +1458,253 @@ packages:
         optional: true
 
   cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
+      }
+    engines: { node: '>=8' }
 
   call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
+      }
+    engines: { node: '>=6' }
 
   camelcase@7.0.1:
-    resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
-    engines: {node: '>=14.16'}
+    resolution:
+      {
+        integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==,
+      }
+    engines: { node: '>=14.16' }
 
   chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
+      }
+    engines: { node: '>=10' }
 
   chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
+      }
+    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
 
   chardet@2.1.1:
-    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+    resolution:
+      {
+        integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==,
+      }
 
   chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
+    resolution:
+      {
+        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
+      }
+    engines: { node: '>= 14.16.0' }
 
   citty@0.1.6:
-    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+    resolution:
+      {
+        integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==,
+      }
 
   cli-boxes@3.0.0:
-    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
+      }
+    engines: { node: '>=10' }
 
   cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==,
+      }
+    engines: { node: '>=8' }
 
   cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==,
+      }
+    engines: { node: '>=18' }
 
   cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==,
+      }
+    engines: { node: '>=6' }
 
   cli-truncate@5.1.1:
-    resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==,
+      }
+    engines: { node: '>=20' }
 
   cli-width@4.1.0:
-    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
-    engines: {node: '>= 12'}
+    resolution:
+      {
+        integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==,
+      }
+    engines: { node: '>= 12' }
 
   cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
+      }
+    engines: { node: '>=12' }
 
   clone@1.0.4:
-    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==,
+      }
+    engines: { node: '>=0.8' }
 
   color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: '>=7.0.0' }
 
   color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
 
   colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+    resolution:
+      {
+        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
+      }
 
   combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
+      }
+    engines: { node: '>= 0.8' }
 
   commander@11.1.0:
-    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==,
+      }
+    engines: { node: '>=16' }
 
   commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
+      }
+    engines: { node: '>=20' }
 
   commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
+      }
+    engines: { node: '>= 6' }
 
   compare-func@2.0.0:
-    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+    resolution:
+      {
+        integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==,
+      }
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution:
+      {
+        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+      }
 
   conf@12.0.0:
-    resolution: {integrity: sha512-fIWyWUXrJ45cHCIQX+Ck1hrZDIf/9DR0P0Zewn3uNht28hbt5OfGUq8rRWsxi96pZWPyBEd0eY9ama01JTaknA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-fIWyWUXrJ45cHCIQX+Ck1hrZDIf/9DR0P0Zewn3uNht28hbt5OfGUq8rRWsxi96pZWPyBEd0eY9ama01JTaknA==,
+      }
+    engines: { node: '>=18' }
 
   confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    resolution:
+      {
+        integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
+      }
 
   confbox@0.2.2:
-    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+    resolution:
+      {
+        integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==,
+      }
 
   consola@3.4.2:
-    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
-    engines: {node: ^14.18.0 || >=16.10.0}
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
 
   conventional-changelog-angular@8.1.0:
-    resolution: {integrity: sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==,
+      }
+    engines: { node: '>=18' }
 
   conventional-changelog-conventionalcommits@9.1.0:
-    resolution: {integrity: sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==,
+      }
+    engines: { node: '>=18' }
 
   conventional-commits-parser@6.2.1:
-    resolution: {integrity: sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==,
+      }
+    engines: { node: '>=18' }
     hasBin: true
 
   cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==,
+      }
+    engines: { node: '>=18' }
 
   cosmiconfig-typescript-loader@6.2.0:
-    resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==,
+      }
+    engines: { node: '>=v18' }
     peerDependencies:
       '@types/node': '*'
       cosmiconfig: '>=9'
       typescript: '>=5'
 
   cosmiconfig@9.0.0:
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==,
+      }
+    engines: { node: '>=14' }
     peerDependencies:
       typescript: '>=4.9.5'
     peerDependenciesMeta:
@@ -1081,20 +1712,32 @@ packages:
         optional: true
 
   cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+      }
+    engines: { node: '>= 8' }
 
   dargs@8.1.0:
-    resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==,
+      }
+    engines: { node: '>=12' }
 
   debounce-fn@5.1.2:
-    resolution: {integrity: sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==,
+      }
+    engines: { node: '>=12' }
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: '>=6.0' }
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -1102,134 +1745,239 @@ packages:
         optional: true
 
   deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    resolution:
+      {
+        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
+      }
 
   deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==,
+      }
+    engines: { node: '>=16.0.0' }
 
   defaults@1.0.4:
-    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+    resolution:
+      {
+        integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==,
+      }
 
   defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+    resolution:
+      {
+        integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==,
+      }
 
   delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
+      }
+    engines: { node: '>=0.4.0' }
 
   dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
+      }
+    engines: { node: '>=6' }
 
   destr@2.0.5:
-    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+    resolution:
+      {
+        integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==,
+      }
 
   discord-api-types@0.38.37:
-    resolution: {integrity: sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==}
+    resolution:
+      {
+        integrity: sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==,
+      }
 
   discord.js@14.25.1:
-    resolution: {integrity: sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==,
+      }
+    engines: { node: '>=18' }
 
   dot-prop@5.3.0:
-    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==,
+      }
+    engines: { node: '>=8' }
 
   dot-prop@8.0.2:
-    resolution: {integrity: sha512-xaBe6ZT4DHPkg0k4Ytbvn5xoxgpG0jOS1dYxSOwAHPuNLjP3/OzN0gH55SrLqpx8cBfSaVt91lXYkApjb+nYdQ==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-xaBe6ZT4DHPkg0k4Ytbvn5xoxgpG0jOS1dYxSOwAHPuNLjP3/OzN0gH55SrLqpx8cBfSaVt91lXYkApjb+nYdQ==,
+      }
+    engines: { node: '>=16' }
 
   dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==,
+      }
+    engines: { node: '>=12' }
 
   dotenv@17.2.3:
-    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==,
+      }
+    engines: { node: '>=12' }
 
   dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+      }
+    engines: { node: '>= 0.4' }
 
   eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    resolution:
+      {
+        integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
+      }
 
   effect@3.18.4:
-    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+    resolution:
+      {
+        integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==,
+      }
 
   emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+    resolution:
+      {
+        integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
+      }
 
   emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    resolution:
+      {
+        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+      }
 
   emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    resolution:
+      {
+        integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
+      }
 
   empathic@2.0.0:
-    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==,
+      }
+    engines: { node: '>=14' }
 
   env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==,
+      }
+    engines: { node: '>=6' }
 
   env-paths@3.0.0:
-    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
+      }
+    engines: { node: '>=18' }
 
   error-ex@1.3.4:
-    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+    resolution:
+      {
+        integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==,
+      }
 
   es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+      }
+    engines: { node: '>= 0.4' }
 
   es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: '>= 0.4' }
 
   es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
+      }
+    engines: { node: '>= 0.4' }
 
   es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: '>= 0.4' }
 
   esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==,
+      }
+    engines: { node: '>=18' }
     hasBin: true
 
   escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+      }
+    engines: { node: '>=6' }
 
   escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
+      }
+    engines: { node: '>=10' }
 
   eslint-scope@8.4.0:
-    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
   eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint@9.39.2:
-    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -1238,68 +1986,125 @@ packages:
         optional: true
 
   espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==,
+      }
+    engines: { node: '>=0.10' }
 
   esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+      }
+    engines: { node: '>=4.0' }
 
   estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+      }
+    engines: { node: '>=4.0' }
 
   esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+      }
+    engines: { node: '>=0.10.0' }
 
   eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+    resolution:
+      {
+        integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
+      }
 
   exsolve@1.0.8:
-    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+    resolution:
+      {
+        integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==,
+      }
 
   fast-check@3.23.2:
-    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==,
+      }
+    engines: { node: '>=8.0.0' }
 
   fast-decode-uri-component@1.0.1:
-    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+    resolution:
+      {
+        integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==,
+      }
 
   fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    resolution:
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+      }
 
   fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    resolution:
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+      }
 
   fast-json-stringify@6.1.1:
-    resolution: {integrity: sha512-DbgptncYEXZqDUOEl4krff4mUiVrTZZVI7BBrQR/T3BqMj/eM1flTC1Uk2uUoLcWCxjT95xKulV/Lc6hhOZsBQ==}
+    resolution:
+      {
+        integrity: sha512-DbgptncYEXZqDUOEl4krff4mUiVrTZZVI7BBrQR/T3BqMj/eM1flTC1Uk2uUoLcWCxjT95xKulV/Lc6hhOZsBQ==,
+      }
 
   fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    resolution:
+      {
+        integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
 
   fast-querystring@1.1.2:
-    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+    resolution:
+      {
+        integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==,
+      }
 
   fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+    resolution:
+      {
+        integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+      }
 
   fastify-plugin@5.1.0:
-    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+    resolution:
+      {
+        integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==,
+      }
 
   fastify@5.6.2:
-    resolution: {integrity: sha512-dPugdGnsvYkBlENLhCgX8yhyGCsCPrpA8lFWbTNU428l+YOnLgYHR69hzV8HWPC79n536EqzqQtvhtdaCE0dKg==}
+    resolution:
+      {
+        integrity: sha512-dPugdGnsvYkBlENLhCgX8yhyGCsCPrpA8lFWbTNU428l+YOnLgYHR69hzV8HWPC79n536EqzqQtvhtdaCE0dKg==,
+      }
 
   fastq@1.19.1:
-    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+    resolution:
+      {
+        integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==,
+      }
 
   fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: '>=12.0.0' }
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1307,34 +2112,58 @@ packages:
         optional: true
 
   file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
+      }
+    engines: { node: '>=16.0.0' }
 
   fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
+      }
+    engines: { node: '>=8' }
 
   find-my-way@9.3.0:
-    resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==,
+      }
+    engines: { node: '>=20' }
 
   find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+      }
+    engines: { node: '>=10' }
 
   fix-dts-default-cjs-exports@1.0.1:
-    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+    resolution:
+      {
+        integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==,
+      }
 
   flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
+      }
+    engines: { node: '>=16' }
 
   flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+    resolution:
+      {
+        integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==,
+      }
 
   follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==,
+      }
+    engines: { node: '>=4.0' }
     peerDependencies:
       debug: '*'
     peerDependenciesMeta:
@@ -1342,463 +2171,838 @@ packages:
         optional: true
 
   form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==,
+      }
+    engines: { node: '>= 6' }
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    resolution:
+      {
+        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+      }
 
   get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+    resolution:
+      {
+        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
 
   get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==,
+      }
+    engines: { node: '>=18' }
 
   get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: '>= 0.4' }
 
   get-tsconfig@4.13.0:
-    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+    resolution:
+      {
+        integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==,
+      }
 
   giget@2.0.0:
-    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    resolution:
+      {
+        integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==,
+      }
     hasBin: true
 
   git-raw-commits@4.0.0:
-    resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==,
+      }
+    engines: { node: '>=16' }
     hasBin: true
 
   glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
+      }
+    engines: { node: '>=10.13.0' }
 
   global-directory@4.0.1:
-    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==,
+      }
+    engines: { node: '>=18' }
 
   globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
+      }
+    engines: { node: '>=18' }
 
   gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+      }
+    engines: { node: '>= 0.4' }
 
   has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: '>=8' }
 
   has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: '>= 0.4' }
 
   hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==,
+      }
+    engines: { node: '>=18' }
     hasBin: true
 
   iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
+      }
+    engines: { node: '>=0.10.0' }
 
   ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    resolution:
+      {
+        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+      }
 
   ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+      }
+    engines: { node: '>= 4' }
 
   ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+      }
+    engines: { node: '>= 4' }
 
   import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
+      }
+    engines: { node: '>=6' }
 
   import-meta-resolve@4.2.0:
-    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+    resolution:
+      {
+        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
+      }
 
   imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
+    resolution:
+      {
+        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+      }
+    engines: { node: '>=0.8.19' }
 
   inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
 
   ini@4.1.1:
-    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    resolution:
+      {
+        integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==,
+      }
+    engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
 
   inquirer@9.3.8:
-    resolution: {integrity: sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==,
+      }
+    engines: { node: '>=18' }
 
   ipaddr.js@2.3.0:
-    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==,
+      }
+    engines: { node: '>= 10' }
 
   is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    resolution:
+      {
+        integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
+      }
 
   is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+      }
+    engines: { node: '>=0.10.0' }
 
   is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+      }
+    engines: { node: '>=8' }
 
   is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==,
+      }
+    engines: { node: '>=18' }
 
   is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+      }
+    engines: { node: '>=0.10.0' }
 
   is-interactive@1.0.0:
-    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==,
+      }
+    engines: { node: '>=8' }
 
   is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+      }
+    engines: { node: '>=0.12.0' }
 
   is-obj@2.0.0:
-    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==,
+      }
+    engines: { node: '>=8' }
 
   is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
+      }
+    engines: { node: '>=12' }
 
   is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==,
+      }
+    engines: { node: '>=10' }
 
   isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    resolution:
+      {
+        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
 
   javascript-natural-sort@0.7.1:
-    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+    resolution:
+      {
+        integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==,
+      }
 
   jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    resolution:
+      {
+        integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
+      }
     hasBin: true
 
   joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
+      }
+    engines: { node: '>=10' }
 
   js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    resolution:
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+      }
 
   js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    resolution:
+      {
+        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+      }
     hasBin: true
 
   jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
+      }
+    engines: { node: '>=6' }
     hasBin: true
 
   json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    resolution:
+      {
+        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+      }
 
   json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    resolution:
+      {
+        integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
+      }
 
   json-schema-ref-resolver@3.0.0:
-    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+    resolution:
+      {
+        integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==,
+      }
 
   json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    resolution:
+      {
+        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
 
   json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    resolution:
+      {
+        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+      }
 
   json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+    resolution:
+      {
+        integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==,
+      }
 
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    resolution:
+      {
+        integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+      }
 
   keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    resolution:
+      {
+        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+      }
 
   levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+      }
+    engines: { node: '>= 0.8.0' }
 
   light-my-request@6.6.0:
-    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
+    resolution:
+      {
+        integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==,
+      }
 
   lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
+      }
+    engines: { node: '>=14' }
 
   lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    resolution:
+      {
+        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
+      }
 
   lint-staged@16.2.7:
-    resolution: {integrity: sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==}
-    engines: {node: '>=20.17'}
+    resolution:
+      {
+        integrity: sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==,
+      }
+    engines: { node: '>=20.17' }
     hasBin: true
 
   listr2@9.0.5:
-    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==,
+      }
+    engines: { node: '>=20.0.0' }
 
   load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+      }
+    engines: { node: '>=10' }
 
   lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+    resolution:
+      {
+        integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==,
+      }
 
   lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+    resolution:
+      {
+        integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==,
+      }
 
   lodash.kebabcase@4.1.1:
-    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+    resolution:
+      {
+        integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==,
+      }
 
   lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    resolution:
+      {
+        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
 
   lodash.mergewith@4.6.2:
-    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+    resolution:
+      {
+        integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==,
+      }
 
   lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+    resolution:
+      {
+        integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==,
+      }
 
   lodash.startcase@4.4.0:
-    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+    resolution:
+      {
+        integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
+      }
 
   lodash.upperfirst@4.3.1:
-    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+    resolution:
+      {
+        integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==,
+      }
 
   lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    resolution:
+      {
+        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
+      }
 
   log-symbols@4.1.0:
-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==,
+      }
+    engines: { node: '>=10' }
 
   log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==,
+      }
+    engines: { node: '>=18' }
 
   magic-bytes.js@1.12.1:
-    resolution: {integrity: sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==}
+    resolution:
+      {
+        integrity: sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==,
+      }
 
   magic-string@0.30.21:
-    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
 
   math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+      }
+    engines: { node: '>= 0.4' }
 
   meow@12.1.1:
-    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
-    engines: {node: '>=16.10'}
+    resolution:
+      {
+        integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==,
+      }
+    engines: { node: '>=16.10' }
 
   meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==,
+      }
+    engines: { node: '>=18' }
 
   micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
+      }
+    engines: { node: '>=8.6' }
 
   mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+      }
+    engines: { node: '>= 0.6' }
 
   mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+      }
+    engines: { node: '>= 0.6' }
 
   mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
+      }
+    engines: { node: '>=6' }
 
   mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==,
+      }
+    engines: { node: '>=12' }
 
   mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
+      }
+    engines: { node: '>=18' }
 
   minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    resolution:
+      {
+        integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
+      }
 
   minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==,
+      }
+    engines: { node: '>=16 || 14 >=14.17' }
 
   minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    resolution:
+      {
+        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+      }
 
   mlly@1.8.0:
-    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+    resolution:
+      {
+        integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==,
+      }
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
 
   mute-stream@1.0.0:
-    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    resolution:
+      {
+        integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==,
+      }
+    engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
 
   mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+    resolution:
+      {
+        integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
+      }
 
   nano-spawn@2.0.0:
-    resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
-    engines: {node: '>=20.17'}
+    resolution:
+      {
+        integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==,
+      }
+    engines: { node: '>=20.17' }
 
   natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    resolution:
+      {
+        integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
+      }
 
   node-fetch-native@1.6.7:
-    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+    resolution:
+      {
+        integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==,
+      }
 
   nypm@0.6.2:
-    resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
-    engines: {node: ^14.16.0 || >=16.10.0}
+    resolution:
+      {
+        integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==,
+      }
+    engines: { node: ^14.16.0 || >=16.10.0 }
     hasBin: true
 
   object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+      }
+    engines: { node: '>=0.10.0' }
 
   ohash@2.0.11:
-    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+    resolution:
+      {
+        integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==,
+      }
 
   on-exit-leak-free@2.1.2:
-    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==,
+      }
+    engines: { node: '>=14.0.0' }
 
   onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
+      }
+    engines: { node: '>=6' }
 
   onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==,
+      }
+    engines: { node: '>=18' }
 
   optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
+      }
+    engines: { node: '>= 0.8.0' }
 
   ora@5.4.1:
-    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==,
+      }
+    engines: { node: '>=10' }
 
   otplib@12.0.1:
-    resolution: {integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==}
+    resolution:
+      {
+        integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==,
+      }
 
   p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+      }
+    engines: { node: '>=10' }
 
   p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+      }
+    engines: { node: '>=10' }
 
   parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
+      }
+    engines: { node: '>=6' }
 
   parse-imports-exports@0.2.4:
-    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+    resolution:
+      {
+        integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==,
+      }
 
   parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==,
+      }
+    engines: { node: '>=8' }
 
   parse-statements@1.0.11:
-    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
+    resolution:
+      {
+        integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==,
+      }
 
   path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+      }
+    engines: { node: '>=8' }
 
   path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: '>=8' }
 
   pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
 
   perfect-debounce@1.0.0:
-    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+    resolution:
+      {
+        integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==,
+      }
 
   picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
 
   picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+      }
+    engines: { node: '>=8.6' }
 
   picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+      }
+    engines: { node: '>=12' }
 
   pidtree@0.6.0:
-    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==,
+      }
+    engines: { node: '>=0.10' }
     hasBin: true
 
   pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+    resolution:
+      {
+        integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==,
+      }
 
   pino-std-serializers@7.0.0:
-    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+    resolution:
+      {
+        integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==,
+      }
 
   pino@10.1.0:
-    resolution: {integrity: sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==}
+    resolution:
+      {
+        integrity: sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==,
+      }
     hasBin: true
 
   pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
+      }
+    engines: { node: '>= 6' }
 
   pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+    resolution:
+      {
+        integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
+      }
 
   pkg-types@2.3.0:
-    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+    resolution:
+      {
+        integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==,
+      }
 
   postcss-load-config@6.0.1:
-    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
+      }
+    engines: { node: '>= 18' }
     peerDependencies:
       jiti: '>=1.21.0'
       postcss: '>=8.0.9'
@@ -1815,12 +3019,18 @@ packages:
         optional: true
 
   prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+      }
+    engines: { node: '>= 0.8.0' }
 
   prettier-plugin-tailwindcss@0.7.2:
-    resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
-    engines: {node: '>=20.19'}
+    resolution:
+      {
+        integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==,
+      }
+    engines: { node: '>=20.19' }
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
       '@prettier/plugin-hermes': '*'
@@ -1874,13 +3084,19 @@ packages:
         optional: true
 
   prettier@3.7.4:
-    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==,
+      }
+    engines: { node: '>=14' }
     hasBin: true
 
   prisma@6.19.1:
-    resolution: {integrity: sha512-XRfmGzh6gtkc/Vq3LqZJcS2884dQQW3UhPo6jNRoiTW95FFQkXFg8vkYEy6og+Pyv0aY7zRQ7Wn1Cvr56XjhQQ==}
-    engines: {node: '>=18.18'}
+    resolution:
+      {
+        integrity: sha512-XRfmGzh6gtkc/Vq3LqZJcS2884dQQW3UhPo6jNRoiTW95FFQkXFg8vkYEy6og+Pyv0aY7zRQ7Wn1Cvr56XjhQQ==,
+      }
+    engines: { node: '>=18.18' }
     hasBin: true
     peerDependencies:
       typescript: '>=5.1.0'
@@ -1889,248 +3105,446 @@ packages:
         optional: true
 
   process-warning@4.0.1:
-    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+    resolution:
+      {
+        integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==,
+      }
 
   process-warning@5.0.0:
-    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+    resolution:
+      {
+        integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
+      }
 
   proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    resolution:
+      {
+        integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==,
+      }
 
   punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+      }
+    engines: { node: '>=6' }
 
   pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+    resolution:
+      {
+        integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==,
+      }
 
   quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+    resolution:
+      {
+        integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
+      }
 
   rc9@2.1.2:
-    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+    resolution:
+      {
+        integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==,
+      }
 
   readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
+      }
+    engines: { node: '>= 6' }
 
   readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
+    resolution:
+      {
+        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
+      }
+    engines: { node: '>= 14.18.0' }
 
   real-require@0.2.0:
-    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
-    engines: {node: '>= 12.13.0'}
+    resolution:
+      {
+        integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==,
+      }
+    engines: { node: '>= 12.13.0' }
 
   require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
+      }
+    engines: { node: '>=0.10.0' }
 
   require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
+      }
+    engines: { node: '>=0.10.0' }
 
   resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
+      }
+    engines: { node: '>=4' }
 
   resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+      }
+    engines: { node: '>=8' }
 
   resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
 
   restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==,
+      }
+    engines: { node: '>=8' }
 
   restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==,
+      }
+    engines: { node: '>=18' }
 
   ret@0.5.0:
-    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==,
+      }
+    engines: { node: '>=10' }
 
   reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
+      }
+    engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
 
   rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+    resolution:
+      {
+        integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
+      }
 
   rollup@4.54.0:
-    resolution: {integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==,
+      }
+    engines: { node: '>=18.0.0', npm: '>=8.0.0' }
     hasBin: true
 
   run-async@3.0.0:
-    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==,
+      }
+    engines: { node: '>=0.12.0' }
 
   rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+    resolution:
+      {
+        integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
+      }
 
   safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
 
   safe-regex2@5.0.0:
-    resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
+    resolution:
+      {
+        integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==,
+      }
 
   safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==,
+      }
+    engines: { node: '>=10' }
 
   safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
 
   secure-json-parse@4.1.0:
-    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+    resolution:
+      {
+        integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==,
+      }
 
   semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==,
+      }
+    engines: { node: '>=10' }
     hasBin: true
 
   set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+    resolution:
+      {
+        integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==,
+      }
 
   shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: '>=8' }
 
   shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: '>=8' }
 
   signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    resolution:
+      {
+        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
+      }
 
   signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+      }
+    engines: { node: '>=14' }
 
   slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==,
+      }
+    engines: { node: '>=18' }
 
   sonic-boom@4.2.0:
-    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+    resolution:
+      {
+        integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==,
+      }
 
   source-map@0.7.6:
-    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
-    engines: {node: '>= 12'}
+    resolution:
+      {
+        integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
+      }
+    engines: { node: '>= 12' }
 
   split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
+    resolution:
+      {
+        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+      }
+    engines: { node: '>= 10.x' }
 
   string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
-    engines: {node: '>=0.6.19'}
+    resolution:
+      {
+        integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==,
+      }
+    engines: { node: '>=0.6.19' }
 
   string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+      }
+    engines: { node: '>=8' }
 
   string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
+      }
+    engines: { node: '>=12' }
 
   string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
+      }
+    engines: { node: '>=18' }
 
   string-width@8.1.1:
-    resolution: {integrity: sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==,
+      }
+    engines: { node: '>=20' }
 
   string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+      }
 
   strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+      }
+    engines: { node: '>=8' }
 
   strip-ansi@7.1.2:
-    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==,
+      }
+    engines: { node: '>=12' }
 
   strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
+      }
+    engines: { node: '>=8' }
 
   stubborn-fs@2.0.0:
-    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+    resolution:
+      {
+        integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==,
+      }
 
   stubborn-utils@1.0.2:
-    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+    resolution:
+      {
+        integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==,
+      }
 
   sucrase@3.35.1:
-    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
+      }
+    engines: { node: '>=16 || 14 >=14.17' }
     hasBin: true
 
   supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+      }
+    engines: { node: '>=8' }
 
   thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
+      }
+    engines: { node: '>=0.8' }
 
   thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+    resolution:
+      {
+        integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
+      }
 
   thirty-two@1.0.2:
-    resolution: {integrity: sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==}
-    engines: {node: '>=0.2.6'}
+    resolution:
+      {
+        integrity: sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==,
+      }
+    engines: { node: '>=0.2.6' }
 
   thread-stream@3.1.0:
-    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+    resolution:
+      {
+        integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==,
+      }
 
   tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    resolution:
+      {
+        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
+      }
 
   tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==,
+      }
+    engines: { node: '>=18' }
 
   tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+      }
+    engines: { node: '>=12.0.0' }
 
   to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+    resolution:
+      {
+        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+      }
+    engines: { node: '>=8.0' }
 
   toad-cache@3.7.0:
-    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==,
+      }
+    engines: { node: '>=12' }
 
   tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    resolution:
+      {
+        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+      }
     hasBin: true
 
   ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
-    engines: {node: '>=18.12'}
+    resolution:
+      {
+        integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==,
+      }
+    engines: { node: '>=18.12' }
     peerDependencies:
       typescript: '>=4.8.4'
 
   ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    resolution:
+      {
+        integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
+      }
 
   ts-mixer@6.0.4:
-    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+    resolution:
+      {
+        integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==,
+      }
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   tsup@8.5.1:
-    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==,
+      }
+    engines: { node: '>=18' }
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
@@ -2148,130 +3562,220 @@ packages:
         optional: true
 
   tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
+      }
+    engines: { node: '>=18.0.0' }
     hasBin: true
 
   turbo-darwin-64@2.7.1:
-    resolution: {integrity: sha512-EaA7UfYujbY9/Ku0WqPpvfctxm91h9LF7zo8vjielz+omfAPB54Si+ADmUoBczBDC6RoLgbURC3GmUW2alnjJg==}
+    resolution:
+      {
+        integrity: sha512-EaA7UfYujbY9/Ku0WqPpvfctxm91h9LF7zo8vjielz+omfAPB54Si+ADmUoBczBDC6RoLgbURC3GmUW2alnjJg==,
+      }
     cpu: [x64]
     os: [darwin]
 
   turbo-darwin-arm64@2.7.1:
-    resolution: {integrity: sha512-/pWGSygtBugd7sKQOeMm+jKY3qN1vyB0RiHBM6bN/6qUOo2VHo8IQwBTIaSgINN4Ue6fzEU+WfePNvonSU9yXw==}
+    resolution:
+      {
+        integrity: sha512-/pWGSygtBugd7sKQOeMm+jKY3qN1vyB0RiHBM6bN/6qUOo2VHo8IQwBTIaSgINN4Ue6fzEU+WfePNvonSU9yXw==,
+      }
     cpu: [arm64]
     os: [darwin]
 
   turbo-linux-64@2.7.1:
-    resolution: {integrity: sha512-Y5H11mdhASw/dJuRFyGtTCDFX5/MPT73EKsVEiHbw5MkFc77lx3nMc5L/Q7bKEhef/vYJAsAb61QuHsB6qdP8Q==}
+    resolution:
+      {
+        integrity: sha512-Y5H11mdhASw/dJuRFyGtTCDFX5/MPT73EKsVEiHbw5MkFc77lx3nMc5L/Q7bKEhef/vYJAsAb61QuHsB6qdP8Q==,
+      }
     cpu: [x64]
     os: [linux]
 
   turbo-linux-arm64@2.7.1:
-    resolution: {integrity: sha512-L/r77jD7cqIEXoyu2LGBUrTY5GJSi/XcGLsQ2nZ/fefk6x3MpljTvwsXUVG1BUkiBPc4zaKRj6yGyWMo5MbLxQ==}
+    resolution:
+      {
+        integrity: sha512-L/r77jD7cqIEXoyu2LGBUrTY5GJSi/XcGLsQ2nZ/fefk6x3MpljTvwsXUVG1BUkiBPc4zaKRj6yGyWMo5MbLxQ==,
+      }
     cpu: [arm64]
     os: [linux]
 
   turbo-windows-64@2.7.1:
-    resolution: {integrity: sha512-rkeuviXZ/1F7lCare7TNKvYtT/SH9dZR55FAMrxrFRh88b+ZKwlXEBfq5/1OctEzRUo/VLIm+s5LJMOEy+QshA==}
+    resolution:
+      {
+        integrity: sha512-rkeuviXZ/1F7lCare7TNKvYtT/SH9dZR55FAMrxrFRh88b+ZKwlXEBfq5/1OctEzRUo/VLIm+s5LJMOEy+QshA==,
+      }
     cpu: [x64]
     os: [win32]
 
   turbo-windows-arm64@2.7.1:
-    resolution: {integrity: sha512-1rZk9htm3+iP/rWCf/h4/DFQey9sMs2TJPC4T5QQfwqAdMWsphgrxBuFqHdxczlbBCgbWNhVw0CH2bTxe1/GFg==}
+    resolution:
+      {
+        integrity: sha512-1rZk9htm3+iP/rWCf/h4/DFQey9sMs2TJPC4T5QQfwqAdMWsphgrxBuFqHdxczlbBCgbWNhVw0CH2bTxe1/GFg==,
+      }
     cpu: [arm64]
     os: [win32]
 
   turbo@2.7.1:
-    resolution: {integrity: sha512-zAj9jGc7VDvuAo/5Jbos4QTtWz9uUpkMhMKGyTjDJkx//hdL2bM31qQoJSAbU+7JyK5vb0LPzpwf6DUt3zayqg==}
+    resolution:
+      {
+        integrity: sha512-zAj9jGc7VDvuAo/5Jbos4QTtWz9uUpkMhMKGyTjDJkx//hdL2bM31qQoJSAbU+7JyK5vb0LPzpwf6DUt3zayqg==,
+      }
     hasBin: true
 
   type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+      }
+    engines: { node: '>= 0.8.0' }
 
   type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==,
+      }
+    engines: { node: '>=10' }
 
   type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
+    resolution:
+      {
+        integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==,
+      }
+    engines: { node: '>=12.20' }
 
   type-fest@3.13.1:
-    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
-    engines: {node: '>=14.16'}
+    resolution:
+      {
+        integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==,
+      }
+    engines: { node: '>=14.16' }
 
   typescript-eslint@8.50.0:
-    resolution: {integrity: sha512-Q1/6yNUmCpH94fbgMUMg2/BSAr/6U7GBk61kZTv1/asghQOWOjTlp9K8mixS5NcJmm2creY+UFfGeW/+OcA64A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Q1/6yNUmCpH94fbgMUMg2/BSAr/6U7GBk61kZTv1/asghQOWOjTlp9K8mixS5NcJmm2creY+UFfGeW/+OcA64A==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: '>=14.17' }
     hasBin: true
 
   ufo@1.6.1:
-    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+    resolution:
+      {
+        integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==,
+      }
 
   uint8array-extras@0.3.0:
-    resolution: {integrity: sha512-erJsJwQ0tKdwuqI0359U8ijkFmfiTcq25JvvzRVc1VP+2son1NJRXhxcAKJmAW3ajM8JSGAfsAXye8g4s+znxA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-erJsJwQ0tKdwuqI0359U8ijkFmfiTcq25JvvzRVc1VP+2son1NJRXhxcAKJmAW3ajM8JSGAfsAXye8g4s+znxA==,
+      }
+    engines: { node: '>=18' }
 
   undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
 
   undici@6.21.3:
-    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
-    engines: {node: '>=18.17'}
+    resolution:
+      {
+        integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==,
+      }
+    engines: { node: '>=18.17' }
 
   uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    resolution:
+      {
+        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+      }
 
   util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
 
   wcwidth@1.0.1:
-    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+    resolution:
+      {
+        integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==,
+      }
 
   when-exit@2.1.5:
-    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+    resolution:
+      {
+        integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==,
+      }
 
   which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: '>= 8' }
     hasBin: true
 
   widest-line@4.0.1:
-    resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==,
+      }
+    engines: { node: '>=12' }
 
   word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
+      }
+    engines: { node: '>=0.10.0' }
 
   wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==,
+      }
+    engines: { node: '>=8' }
 
   wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+      }
+    engines: { node: '>=10' }
 
   wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
+      }
+    engines: { node: '>=12' }
 
   wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
+      }
+    engines: { node: '>=18' }
 
   ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==,
+      }
+    engines: { node: '>=10.0.0' }
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: '>=5.0.2'
@@ -2282,35 +3786,55 @@ packages:
         optional: true
 
   y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
+      }
+    engines: { node: '>=10' }
 
   yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
-    engines: {node: '>= 14.6'}
+    resolution:
+      {
+        integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==,
+      }
+    engines: { node: '>= 14.6' }
     hasBin: true
 
   yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+      }
+    engines: { node: '>=12' }
 
   yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
+      }
+    engines: { node: '>=12' }
 
   yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+      }
+    engines: { node: '>=10' }
 
   yoctocolors-cjs@2.1.3:
-    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==,
+      }
+    engines: { node: '>=18' }
 
   zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+    resolution:
+      {
+        integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
+      }
 
 snapshots:
-
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5

--- a/pr_final_feedback.md
+++ b/pr_final_feedback.md
@@ -20,7 +20,10 @@ Code context:
 +describe('handleResourceAutocomplete', () => {
 
 
-------------------------------------------------------------
+---
+
+---
+
 Comment #2640363669 by gemini-code-assist[bot] on apps/purrmission-bot/src/discord/commands/resource.ts:N/A
 State: null | Created: 2025-12-22T15:54:10Z
 
@@ -34,18 +37,20 @@ To avoid an unnecessary database query when the user has no guardianships (and t
 
 Code context:
 @@ -201,9 +201,27 @@ export async function handleResourceAutocomplete(
-     const focusedOption = interaction.options.getFocused(true);
- 
+const focusedOption = interaction.options.getFocused(true);
+
      if (focusedOption.name === 'resource-id') {
+
 -        // TODO: Implement resource autocomplete
 -        // For now, just return empty (user needs to paste resource ID)
 -        await interaction.respond([]);
-+        const userId = interaction.user.id;
-+        const { guardians, resources } = context.repositories;
-+
-+        // Find all resources where the user is a guardian
-+        const userGuardianships = await guardians.findByUserId(userId);
-+        const resourceIds = userGuardianships.map((g) => g.resourceId);
-+
-+        // Fetch resource details optimized
-+        const validResources = await resources.findManyByIds(resourceIds);
+
+*        const userId = interaction.user.id;
+*        const { guardians, resources } = context.repositories;
+*
+*        // Find all resources where the user is a guardian
+*        const userGuardianships = await guardians.findByUserId(userId);
+*        const resourceIds = userGuardianships.map((g) => g.resourceId);
+*
+*        // Fetch resource details optimized
+*        const validResources = await resources.findManyByIds(resourceIds);

--- a/review_comments_chatgpt.md
+++ b/review_comments_chatgpt.md
@@ -1,8 +1,9 @@
-------------------------------------------------------------
+---
+
 Comment #2693233839 by chatgpt-codex-connector[bot] on apps/purrmission-bot/src/domain/services.ts:N/A
 State: N/A | Created: 2026-01-15T07:11:33Z
 
-**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Prevent removing the sole OWNER guardian**
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Prevent removing the sole OWNER guardian**
 
 The new `removeGuardian` flow allows deleting any guardian without checking `targetGuardian.role`. Because the only OWNER is created in `createResource` and `addGuardian` only adds `GUARDIAN` roles, this means an owner can remove themselves (or another OWNER if added externally), leaving the resource with no OWNER. At that point no one can add/remove guardians, effectively orphaning the resource. Consider blocking removal when `targetGuardian.role === 'OWNER'` or ensuring another OWNER remains.
 
@@ -10,30 +11,29 @@ Useful? React with 👍 / 👎.
 
 Code context:
 @@ -359,6 +359,56 @@ export class ResourceService {
-     return { success: true, guardian };
-   }
- 
-+  /**
-+   * Remove a guardian from a resource.
-+   */
-+  async removeGuardian(
-+    resourceId: string,
-+    actorId: string,
-+    targetUserId: string
-+  ): Promise<{ success: boolean; error?: string }> {
-+    const { repositories } = this.deps;
-+
-+    // Verify Actor is Owner
-+    const actorGuardian = await repositories.guardians.findByResourceAndUser(resourceId, actorId);
-+    if (!actorGuardian || actorGuardian.role !== 'OWNER') {
-+      return { success: false, error: 'Only the resource owner can remove guardians.' };
-+    }
-+
-+    // Verify Target is a Guardian
-+    const targetGuardian = await repositories.guardians.findByResourceAndUser(resourceId, targetUserId);
-+    if (!targetGuardian) {
-+      return { success: false, error: 'User is not a guardian of this resource.' };
-+    }
-+
-+    await repositories.guardians.remove(resourceId, targetUserId);
+return { success: true, guardian };
+}
 
+- /\*\*
+- - Remove a guardian from a resource.
+- \*/
+- async removeGuardian(
+- resourceId: string,
+- actorId: string,
+- targetUserId: string
+- ): Promise<{ success: boolean; error?: string }> {
+- const { repositories } = this.deps;
+-
+- // Verify Actor is Owner
+- const actorGuardian = await repositories.guardians.findByResourceAndUser(resourceId, actorId);
+- if (!actorGuardian || actorGuardian.role !== 'OWNER') {
+-      return { success: false, error: 'Only the resource owner can remove guardians.' };
+- }
+-
+- // Verify Target is a Guardian
+- const targetGuardian = await repositories.guardians.findByResourceAndUser(resourceId, targetUserId);
+- if (!targetGuardian) {
+-      return { success: false, error: 'User is not a guardian of this resource.' };
+- }
+-
+- await repositories.guardians.remove(resourceId, targetUserId);

--- a/review_comments_gemini.md
+++ b/review_comments_gemini.md
@@ -44,7 +44,10 @@ Code context:
 +      return { success: false, error: 'User is not a guardian of this resource.' };
 +    }
 
-------------------------------------------------------------
+---
+
+---
+
 Comment #2693231044 by gemini-code-assist[bot] on apps/purrmission-bot/src/discord/commands/guardian.test.ts:N/A
 State: N/A | Created: 2026-01-15T07:10:15Z
 
@@ -58,21 +61,24 @@ There's a type mismatch in the `removeGuardianCalls` array definition. The type 
 
 Code context:
 @@ -12,17 +12,23 @@ import type {
- interface MockServices {
-     resource: {
-         addGuardian: (resourceId: string, userId: string) => Promise<{ success: boolean; guardian?: { id: string; role: string } }>;
-+        removeGuardian: (resourceId: string, actorId: string, targetUserId: string) => Promise<{ success: boolean; error?: string }>;
-+        listGuardians: (resourceId: string, actorId: string) => Promise<{ success: boolean; guardians?: { discordUserId: string; role: string }[]; error?: string }>;
-     }
- }
- 
- describe('handlePurrmissionCommand - Guardian Routing', () => {
-     let mockInteraction: Partial<ChatInputCommandInteraction>;
-     let mockContext: CommandContext;
-     let addGuardianCalls: { resourceId: string; userId: string }[] = [];
-+    let removeGuardianCalls: { resourceId: string; userId: string; actorId: string }[] = [];
+interface MockServices {
+resource: {
+addGuardian: (resourceId: string, userId: string) => Promise<{ success: boolean; guardian?: { id: string; role: string } }>;
 
-------------------------------------------------------------
+-        removeGuardian: (resourceId: string, actorId: string, targetUserId: string) => Promise<{ success: boolean; error?: string }>;
+-        listGuardians: (resourceId: string, actorId: string) => Promise<{ success: boolean; guardians?: { discordUserId: string; role: string }[]; error?: string }>;
+      }
+  }
+
+describe('handlePurrmissionCommand - Guardian Routing', () => {
+let mockInteraction: Partial<ChatInputCommandInteraction>;
+let mockContext: CommandContext;
+let addGuardianCalls: { resourceId: string; userId: string }[] = [];
+
+- let removeGuardianCalls: { resourceId: string; userId: string; actorId: string }[] = [];
+
+---
+
 Comment #2693231054 by gemini-code-assist[bot] on apps/purrmission-bot/src/discord/commands/listGuardians.ts:N/A
 State: N/A | Created: 2026-01-15T07:10:15Z
 
@@ -92,33 +98,33 @@ The condition `!result.guardians` is redundant. The `listGuardians` service meth
 
 Code context:
 @@ -0,0 +1,55 @@
-+/**
-+ * Handler for /purrmission guardian list command.
-+ */
-+
-+import type { ChatInputCommandInteraction } from 'discord.js';
-+import type { Services } from '../../domain/services.js';
-+import { logger } from '../../logging/logger.js';
-+
-+export async function handleListGuardians(
-+    interaction: ChatInputCommandInteraction,
-+    services: Services
-+): Promise<void> {
-+    const resourceId = interaction.options.getString('resource-id', true);
-+    const callerId = interaction.user.id;
-+
-+    try {
-+        const result = await services.resource.listGuardians(resourceId, callerId);
-+
-+        if (!result.success || !result.guardians) {
-+            await interaction.reply({
-+                content: `❌ ${result.error || 'Failed to list guardians'}`,
-+                ephemeral: true,
-+            });
-+            return;
-+        }
++/\*\*
 
-------------------------------------------------------------
+- - Handler for /purrmission guardian list command.
+- \*/
+- +import type { ChatInputCommandInteraction } from 'discord.js';
+  +import type { Services } from '../../domain/services.js';
+  +import { logger } from '../../logging/logger.js';
+- +export async function handleListGuardians(
+- interaction: ChatInputCommandInteraction,
+- services: Services
+  +): Promise<void> {
+- const resourceId = interaction.options.getString('resource-id', true);
+- const callerId = interaction.user.id;
+-
+- try {
+-        const result = await services.resource.listGuardians(resourceId, callerId);
+-
+-        if (!result.success || !result.guardians) {
+-            await interaction.reply({
+-                content: `❌ ${result.error || 'Failed to list guardians'}`,
+-                ephemeral: true,
+-            });
+-            return;
+-        }
+
+---
+
 Comment #2693231065 by gemini-code-assist[bot] on apps/purrmission-bot/src/domain/repositories.ts:N/A
 State: N/A | Created: 2026-01-15T07:10:16Z
 
@@ -128,17 +134,16 @@ These comments are overly verbose and describe the developer's thought process r
 
 Code context:
 @@ -642,6 +647,24 @@ export class PrismaGuardianRepository implements GuardianRepository {
-     return rows.map((row) => this.mapPrismaToDomain(row));
-   }
- 
-+  async remove(resourceId: string, discordUserId: string): Promise<void> {
-+    // Delete validation is implicit: if not found, Prisma throws or deletes 0.
-+    // We want to delete specific entry.
-+    // Since composite key or fields are not id, we use deleteMany or delete with unique constraint if exists.
-+    // The schema likely has a unique compound index on [resourceId, discordUserId] or logic handles it.
-+    // Let's check if we can delete by ID if we find it first, or use deleteMany.
-+    // Safer to use deleteMany for non-unique-id based deletions if uncertain of schema constraints, 
-+    // but typically guardians are unique per resource/user.
-+
-+    // Using deleteMany is safe and idempotent-ish (won't fail if not found).
+return rows.map((row) => this.mapPrismaToDomain(row));
+}
 
+- async remove(resourceId: string, discordUserId: string): Promise<void> {
+- // Delete validation is implicit: if not found, Prisma throws or deletes 0.
+- // We want to delete specific entry.
+- // Since composite key or fields are not id, we use deleteMany or delete with unique constraint if exists.
+- // The schema likely has a unique compound index on [resourceId, discordUserId] or logic handles it.
+- // Let's check if we can delete by ID if we find it first, or use deleteMany.
+- // Safer to use deleteMany for non-unique-id based deletions if uncertain of schema constraints,
+- // but typically guardians are unique per resource/user.
+-
+- // Using deleteMany is safe and idempotent-ish (won't fail if not found).

--- a/scripts/antigravity.cjs
+++ b/scripts/antigravity.cjs
@@ -4,49 +4,51 @@ const path = require('node:path');
 const fs = require('node:fs');
 
 // 1. Sync
-console.log("🔄 Running Sync...");
+console.log('🔄 Running Sync...');
 try {
-    const syncScript = path.join(__dirname, 'sync-mcp.cjs');
-    execSync(`node ${syncScript}`, { stdio: "inherit" });
+  const syncScript = path.join(__dirname, 'sync-mcp.cjs');
+  execSync(`node ${syncScript}`, { stdio: 'inherit' });
 } catch (e) {
-    console.error("❌ Sync failed.");
-    process.exit(1);
+  console.error('❌ Sync failed.');
+  process.exit(1);
 }
 
 // Helper to find project
-const PROJECT_ROOT = path.resolve(__dirname, "..");
+const PROJECT_ROOT = path.resolve(__dirname, '..');
 function findProjectDir(filterName) {
-    const searchDirs = ['apps', 'packages'];
+  const searchDirs = ['apps', 'packages'];
 
-    for (const dir of searchDirs) {
-        const basePath = path.join(PROJECT_ROOT, dir);
-        if (!fs.existsSync(basePath)) continue;
+  for (const dir of searchDirs) {
+    const basePath = path.join(PROJECT_ROOT, dir);
+    if (!fs.existsSync(basePath)) continue;
 
-        const items = fs.readdirSync(basePath, { withFileTypes: true });
+    const items = fs.readdirSync(basePath, { withFileTypes: true });
 
-        for (const item of items) {
-            if (!item.isDirectory()) continue;
+    for (const item of items) {
+      if (!item.isDirectory()) continue;
 
-            // Match directory name (exact)
-            if (item.name === filterName) {
-                return path.join(basePath, item.name);
-            }
+      // Match directory name (exact)
+      if (item.name === filterName) {
+        return path.join(basePath, item.name);
+      }
 
-            // Match package.json name
-            try {
-                const pkgPath = path.join(basePath, item.name, 'package.json');
-                if (fs.existsSync(pkgPath)) {
-                    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-                    if (pkg.name === filterName) {
-                        return path.join(basePath, item.name);
-                    }
-                }
-            } catch (e) {
-                console.warn(`⚠️  Could not parse package.json in ${path.join(basePath, item.name)}: ${e.message}`);
-            }
+      // Match package.json name
+      try {
+        const pkgPath = path.join(basePath, item.name, 'package.json');
+        if (fs.existsSync(pkgPath)) {
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+          if (pkg.name === filterName) {
+            return path.join(basePath, item.name);
+          }
         }
+      } catch (e) {
+        console.warn(
+          `⚠️  Could not parse package.json in ${path.join(basePath, item.name)}: ${e.message}`
+        );
+      }
     }
-    return null;
+  }
+  return null;
 }
 
 // 2. Resolve Target Directory
@@ -55,16 +57,16 @@ let targetDir = PROJECT_ROOT;
 
 const filterIndex = args.indexOf('--filter');
 if (filterIndex !== -1 && filterIndex + 1 < args.length) {
-    const filterName = args[filterIndex + 1];
-    const foundDir = findProjectDir(filterName);
+  const filterName = args[filterIndex + 1];
+  const foundDir = findProjectDir(filterName);
 
-    if (foundDir) {
-        console.log(`🎯 Targeting project: ${foundDir}`);
-        targetDir = foundDir;
-    } else {
-        console.error(`❌ Error: Project '${filterName}' not found.`);
-        process.exit(1);
-    }
+  if (foundDir) {
+    console.log(`🎯 Targeting project: ${foundDir}`);
+    targetDir = foundDir;
+  } else {
+    console.error(`❌ Error: Project '${filterName}' not found.`);
+    process.exit(1);
+  }
 }
 
 // 3. Launch Antigravity IDE
@@ -72,22 +74,24 @@ console.log(`🚀 Launching Antigravity IDE in ${targetDir}...`);
 
 // Ensure 'antigravity' command exists
 try {
-    const checkCmd = process.platform === 'win32' ? 'where' : 'command -v';
-    execSync(`${checkCmd} antigravity`, { stdio: 'ignore' });
+  const checkCmd = process.platform === 'win32' ? 'where' : 'command -v';
+  execSync(`${checkCmd} antigravity`, { stdio: 'ignore' });
 } catch (e) {
-    console.warn("⚠️  'antigravity' command not found in PATH. Assuming User will restart IDE manually.");
-    // We don't exit hard here because this script might be run just for the sync part + setup
-    process.exit(0);
+  console.warn(
+    "⚠️  'antigravity' command not found in PATH. Assuming User will restart IDE manually."
+  );
+  // We don't exit hard here because this script might be run just for the sync part + setup
+  process.exit(0);
 }
 
 const child = spawn('antigravity', [targetDir], {
-    detached: true,
-    stdio: 'ignore'
+  detached: true,
+  stdio: 'ignore',
 });
 
 child.on('error', (err) => {
-    console.error(`❌ Failed to launch Antigravity IDE: ${err.message}`);
-    process.exit(1);
+  console.error(`❌ Failed to launch Antigravity IDE: ${err.message}`);
+  process.exit(1);
 });
 
 child.unref();

--- a/scripts/backup-db.ts
+++ b/scripts/backup-db.ts
@@ -1,71 +1,74 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { env } from '../apps/purrmission-bot/src/config/env.js';
 import { logger } from '../apps/purrmission-bot/src/logging/logger.js';
 
 /**
  * Backup the SQLite database.
  * Copies the .db file to a backups/ directory with a timestamp.
- * 
+ *
  * @returns The absolute path to the backup file
  */
 export async function backupDatabase(): Promise<string> {
-    const dbUrl = env.DATABASE_URL;
+  const dbUrl = env.DATABASE_URL;
 
-    if (!dbUrl.startsWith('file:')) {
-        logger.warn('⚠️ Backup skipped: DATABASE_URL does not start with "file:", assuming non-SQLite DB.');
-        throw new Error('Automated backup only supported for SQLite (file: protocol)');
-    }
+  if (!dbUrl.startsWith('file:')) {
+    logger.warn(
+      '⚠️ Backup skipped: DATABASE_URL does not start with "file:", assuming non-SQLite DB.'
+    );
+    throw new Error('Automated backup only supported for SQLite (file: protocol)');
+  }
 
-    // Parse file path from URL robustly for SQLite
-    if (!dbUrl.startsWith('file:')) {
-        throw new Error('backup-db script only supports SQLite (DATABASE_URL must start with file:)');
-    }
+  // Parse file path from URL robustly for SQLite
+  if (!dbUrl.startsWith('file:')) {
+    throw new Error('backup-db script only supports SQLite (DATABASE_URL must start with file:)');
+  }
 
-    // Remove 'file:' prefix. Handle both file:./path and file:///path
-    // Prisma uses file:./path for relative and file:/path or file:///path for absolute.
-    let dbPath = dbUrl.replace(/^file:/, '');
+  // Remove 'file:' prefix. Handle both file:./path and file:///path
+  // Prisma uses file:./path for relative and file:/path or file:///path for absolute.
+  let dbPath = dbUrl.replace(/^file:/, '');
 
-    // If it starts with ///, it's an absolute path (e.g. file:///path/to/db)
-    if (dbPath.startsWith('///')) {
-        dbPath = dbPath.slice(2); // Keep one / for absolute path
-    } else if (dbPath.startsWith('//')) {
-        // file://localhost/path or file://path -> usually interpreted as absolute path /path
-        dbPath = dbPath.slice(1);
-    }
-    // Otherwise it's something like ./path or ../path or /path
+  // If it starts with ///, it's an absolute path (e.g. file:///path/to/db)
+  if (dbPath.startsWith('///')) {
+    dbPath = dbPath.slice(2); // Keep one / for absolute path
+  } else if (dbPath.startsWith('//')) {
+    // file://localhost/path or file://path -> usually interpreted as absolute path /path
+    dbPath = dbPath.slice(1);
+  }
+  // Otherwise it's something like ./path or ../path or /path
 
-    // Remove query parameters (Prisma supports them, e.g. ?connection_limit=1)
-    dbPath = dbPath.split('?')[0];
+  // Remove query parameters (Prisma supports them, e.g. ?connection_limit=1)
+  dbPath = dbPath.split('?')[0];
 
-    // Resolve absolute path relative to CWD
-    const absoluteDbPath = path.resolve(process.cwd(), dbPath);
+  // Resolve absolute path relative to CWD
+  const absoluteDbPath = path.resolve(process.cwd(), dbPath);
 
-    if (!fs.existsSync(absoluteDbPath)) {
-        throw new Error(`Database file not found at: ${absoluteDbPath}`);
-    }
+  if (!fs.existsSync(absoluteDbPath)) {
+    throw new Error(`Database file not found at: ${absoluteDbPath}`);
+  }
 
-    const backupDir = path.resolve(process.cwd(), 'backups');
-    if (!fs.existsSync(backupDir)) {
-        fs.mkdirSync(backupDir, { recursive: true });
-    }
+  const backupDir = path.resolve(process.cwd(), 'backups');
+  if (!fs.existsSync(backupDir)) {
+    fs.mkdirSync(backupDir, { recursive: true });
+  }
 
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const filename = path.basename(absoluteDbPath);
-    const backupName = `${path.parse(filename).name}-${timestamp}${path.parse(filename).ext}`;
-    const backupPath = path.join(backupDir, backupName);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filename = path.basename(absoluteDbPath);
+  const backupName = `${path.parse(filename).name}-${timestamp}${path.parse(filename).ext}`;
+  const backupPath = path.join(backupDir, backupName);
 
-    logger.info(`📦 Backing up database to: ${backupPath}`);
-    fs.copyFileSync(absoluteDbPath, backupPath);
-    logger.info('✅ Backup completed successfully.');
+  logger.info(`📦 Backing up database to: ${backupPath}`);
+  fs.copyFileSync(absoluteDbPath, backupPath);
+  logger.info('✅ Backup completed successfully.');
 
-    return backupPath;
+  return backupPath;
 }
 
 // Allow running directly
-if (process.argv[1] === import.meta.filename) {
-    backupDatabase().catch(err => {
-        console.error('❌ Backup failed:', err);
-        process.exit(1);
-    });
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  backupDatabase().catch((err) => {
+    console.error('❌ Backup failed:', err);
+    process.exit(1);
+  });
 }

--- a/scripts/check-guardians.ts
+++ b/scripts/check-guardians.ts
@@ -1,37 +1,36 @@
-
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 async function checkGuardians() {
-    const envId = '1e4b4a9d-ba02-40ba-9506-0bfb255dd73a';
-    console.log(`Looking up environment: ${envId}`);
+  const envId = '1e4b4a9d-ba02-40ba-9506-0bfb255dd73a';
+  console.log(`Looking up environment: ${envId}`);
 
-    const env = await prisma.environment.findUnique({
-        where: { id: envId }
-    });
+  const env = await prisma.environment.findUnique({
+    where: { id: envId },
+  });
 
-    if (!env) {
-        console.error('Environment not found!');
-        return;
-    }
+  if (!env) {
+    console.error('Environment not found!');
+    return;
+  }
 
-    console.log(`Found Environment: ${env.name}, Resource ID: ${env.resourceId}`);
+  console.log(`Found Environment: ${env.name}, Resource ID: ${env.resourceId}`);
 
-    const resource = await prisma.resource.findUnique({
-        where: { id: env.resourceId },
-        include: { guardians: true }
-    });
+  const resource = await prisma.resource.findUnique({
+    where: { id: env.resourceId },
+    include: { guardians: true },
+  });
 
-    if (!resource) {
-        console.error('Resource not found!');
-        return;
-    }
+  if (!resource) {
+    console.error('Resource not found!');
+    return;
+  }
 
-    console.log('Resource:', resource.name);
-    console.log('Guardians:', resource.guardians);
+  console.log('Resource:', resource.name);
+  console.log('Guardians:', resource.guardians);
 }
 
 checkGuardians()
-    .catch(console.error)
-    .finally(() => prisma.$disconnect());
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());

--- a/scripts/encrypt-totp-secrets.ts
+++ b/scripts/encrypt-totp-secrets.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env tsx
 /**
  * Migration script to encrypt existing plaintext TOTP secrets.
- * 
+ *
  * This script should be run once after deploying the TOTP encryption feature.
  * It will:
  * 1. Read all TOTP accounts from the database
  * 2. Check if secrets are already encrypted (by attempting to decrypt)
  * 3. Encrypt any plaintext secrets found
  * 4. Update the database with encrypted values
- * 
+ *
  * Usage:
  *   ENCRYPTION_KEY=<your-key> tsx scripts/encrypt-totp-secrets.ts
- * 
+ *
  * Safety:
  * - Dry run by default (use --apply to actually update the database)
  * - IMPORTANT: Back up your database manually before using the --apply flag.
@@ -40,13 +40,13 @@ function isEncrypted(value: string): boolean {
 
 /**
  * Check if a value looks like a valid Base32 TOTP secret (plaintext).
- * 
+ *
  * This is a heuristic check with limitations:
  * - Base32 alphabet consists of A-Z, 2-7, and optional padding (=)
  * - Typical TOTP secrets are 16-32 characters (80-160 bits)
  * - May produce false negatives for very short or long secrets
  * - May produce false positives for encrypted data that happens to contain only Base32 chars
- * 
+ *
  * Used in conjunction with isEncrypted() to determine migration needs.
  */
 function looksLikePlaintextSecret(value: string): boolean {
@@ -75,7 +75,9 @@ function encryptAndValidate(
 ): { encryptedSecret: string; encryptedBackupKey: string | null } {
   const encryptedSecret = secretIsEncrypted ? secret : encryptValue(secret);
   const encryptedBackupKey = backupKey
-    ? (backupIsEncrypted ? backupKey : encryptValue(backupKey))
+    ? backupIsEncrypted
+      ? backupKey
+      : encryptValue(backupKey)
     : null;
 
   // Validate by decrypting
@@ -96,7 +98,9 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`Mode: ${APPLY_CHANGES ? '✍️  APPLY (will modify database)' : '👁️  DRY RUN (read-only)'}\n`);
+  console.log(
+    `Mode: ${APPLY_CHANGES ? '✍️  APPLY (will modify database)' : '👁️  DRY RUN (read-only)'}\n`
+  );
 
   const prisma = new PrismaClient();
 
@@ -184,7 +188,9 @@ async function main() {
     }
 
     if (!APPLY_CHANGES) {
-      console.log('\n🚨 WARNING: This operation can be destructive. Please back up your database before proceeding.');
+      console.log(
+        '\n🚨 WARNING: This operation can be destructive. Please back up your database before proceeding.'
+      );
       console.log('💡 This was a dry run. Use --apply flag to actually update the database:');
       console.log('   ENCRYPTION_KEY=<your-key> tsx scripts/encrypt-totp-secrets.ts --apply');
       return;
@@ -210,7 +216,6 @@ async function main() {
     });
 
     console.log(`\n✅ Successfully encrypted ${accountsToUpdate.length} TOTP account(s)`);
-
   } catch (error) {
     console.error('\n❌ Error during migration:', error);
     process.exit(1);

--- a/scripts/gh-pr-review-comments.cjs
+++ b/scripts/gh-pr-review-comments.cjs
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 
 function showHelp() {
-    console.log(`
+  console.log(`
 Usage:
   node scripts/gh-pr-review-comments.cjs <pr-number> [review-id] [--file <output-file>] [--delta]
 
@@ -39,163 +39,178 @@ let deltaMode = false;
 
 // Parse arguments
 for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === '--help' || arg === '-h') {
-        showHelp();
-        process.exit(0);
-    } else if (arg === '--file' || arg === '-f') {
-        outputFile = args[i + 1];
-        i++; // skip next arg
-    } else if (arg === '--delta') {
-        deltaMode = true;
-    } else if (!prNumber) {
-        prNumber = arg;
-    } else if (!reviewId) {
-        reviewId = arg;
-    }
+  const arg = args[i];
+  if (arg === '--help' || arg === '-h') {
+    showHelp();
+    process.exit(0);
+  } else if (arg === '--file' || arg === '-f') {
+    outputFile = args[i + 1];
+    i++; // skip next arg
+  } else if (arg === '--delta') {
+    deltaMode = true;
+  } else if (!prNumber) {
+    prNumber = arg;
+  } else if (!reviewId) {
+    reviewId = arg;
+  }
 }
 
 if (!prNumber) {
-    console.error("❌ Error: Missing required arguments. PR Number is mandatory.");
-    showHelp();
-    process.exit(1);
+  console.error('❌ Error: Missing required arguments. PR Number is mandatory.');
+  showHelp();
+  process.exit(1);
 }
 
 function getCurrentUser() {
-    try {
-        return execSync('gh api user --jq .login', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-    } catch (e) {
-        console.warn("⚠️ Could not determine current user. Delta mode might be inaccurate.");
-        return null;
-    }
+  try {
+    return execSync('gh api user --jq .login', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch (e) {
+    console.warn('⚠️ Could not determine current user. Delta mode might be inaccurate.');
+    return null;
+  }
 }
 
 function getLastAddressedTime(prNum, user) {
-    if (!user) return null;
-    try {
-        // Fetch issue comments (timeline) to find the "addressed" marker
-        // Sorting by created_at desc to find latest
-        const cmd = `gh api "repos/:owner/:repo/issues/${prNum}/comments?sort=created&direction=desc" --paginate`;
-        const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
-        const comments = JSON.parse(output);
+  if (!user) return null;
+  try {
+    // Fetch issue comments (timeline) to find the "addressed" marker
+    // Sorting by created_at desc to find latest
+    const cmd = `gh api "repos/:owner/:repo/issues/${prNum}/comments?sort=created&direction=desc" --paginate`;
+    const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const comments = JSON.parse(output);
 
-        const patterns = [
-            "Code Review Feedback Addressed",
-            "Code Review Addressed",
-            "CR Feedback Addressed",
-            "CR Addressed",
-            "### 📝 CR Feedback Addressed",
-            "### 📝Code Review Feedback Addressed",
-            "[Found and addressed a total of"
-        ];
+    const patterns = [
+      'Code Review Feedback Addressed',
+      'Code Review Addressed',
+      'CR Feedback Addressed',
+      'CR Addressed',
+      '### 📝 CR Feedback Addressed',
+      '### 📝Code Review Feedback Addressed',
+      '[Found and addressed a total of',
+    ];
 
-        const marker = comments.find(c => {
-            if (c.user.login !== user) return false;
-            const body = c.body.toLowerCase();
-            return patterns.some(p => body.includes(p.toLowerCase()));
-        });
+    const marker = comments.find((c) => {
+      if (c.user.login !== user) return false;
+      const body = c.body.toLowerCase();
+      return patterns.some((p) => body.includes(p.toLowerCase()));
+    });
 
-        return marker ? new Date(marker.created_at) : null;
-    } catch (e) {
-        return null;
-    }
+    return marker ? new Date(marker.created_at) : null;
+  } catch (e) {
+    return null;
+  }
 }
 
 try {
-    let cutoffDate = null;
+  let cutoffDate = null;
 
-    if (deltaMode) {
-        console.log("🕵️ Delta Mode: Looking for your last 'Address' comment...");
-        const user = getCurrentUser();
-        cutoffDate = getLastAddressedTime(prNumber, user);
+  if (deltaMode) {
+    console.log("🕵️ Delta Mode: Looking for your last 'Address' comment...");
+    const user = getCurrentUser();
+    cutoffDate = getLastAddressedTime(prNumber, user);
 
-        if (cutoffDate) {
-            console.log(`📅 Found marker. Fetching comments after: ${cutoffDate.toLocaleString()}`);
-        } else {
-            console.log("⚠️ No 'Code Review Addressed' comment found. Fetching ALL history.");
-        }
+    if (cutoffDate) {
+      console.log(`📅 Found marker. Fetching comments after: ${cutoffDate.toLocaleString()}`);
+    } else {
+      console.log("⚠️ No 'Code Review Addressed' comment found. Fetching ALL history.");
     }
+  }
 
-    // If no reviewId provided, try to discover reviews with unaddressed comments
-    if (!reviewId) {
-        if (!deltaMode) console.log(`🔍 No Review ID provided. Searching for reviews in PR #${prNumber}...`);
+  // If no reviewId provided, try to discover reviews with unaddressed comments
+  if (!reviewId) {
+    if (!deltaMode)
+      console.log(`🔍 No Review ID provided. Searching for reviews in PR #${prNumber}...`);
 
-        // Fetch all comments to aggregate Review IDs
-        const cmd = `gh api "repos/:owner/:repo/pulls/${prNumber}/comments" --paginate`;
-        const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
-        let comments = JSON.parse(output);
-
-        // Filter by date if in delta mode
-        if (cutoffDate) {
-            comments = comments.filter(c => new Date(c.created_at) > cutoffDate);
-        }
-
-        if (!Array.isArray(comments) || comments.length === 0) {
-            console.log(cutoffDate ? "✅ No new comments found since your last update!" : "No inline comments found for this PR.");
-            process.exit(0);
-        }
-
-        // Group by review_id
-        const reviews = {};
-        comments.forEach(c => {
-            if (c.pull_request_review_id) {
-                if (!reviews[c.pull_request_review_id]) {
-                    reviews[c.pull_request_review_id] = {
-                        id: c.pull_request_review_id,
-                        author: c.user.login,
-                        count: 0,
-                        lastDate: c.created_at
-                    };
-                }
-                reviews[c.pull_request_review_id].count++;
-                if (new Date(c.created_at) > new Date(reviews[c.pull_request_review_id].lastDate)) {
-                    reviews[c.pull_request_review_id].lastDate = c.created_at;
-                }
-            }
-        });
-
-        const reviewsList = Object.values(reviews);
-
-        if (reviewsList.length === 0) {
-            console.log("Found comments, but none are associated with a review ID.");
-            process.exit(0);
-        }
-
-        console.log(`\nFound ${reviewsList.length} Active Review Threads:`);
-        console.log("------------------------------------------------------------");
-        console.log(String("ID").padEnd(15) + String("Author").padEnd(20) + String("Comments").padEnd(10) + "Latest");
-        console.log("------------------------------------------------------------");
-
-        reviewsList.forEach(r => {
-            console.log(`${String(r.id).padEnd(15)} ${String(r.author).padEnd(20)} ${String(r.count).padEnd(10)} ${new Date(r.lastDate).toLocaleString()}`);
-        });
-        console.log("------------------------------------------------------------");
-        console.log("\nTo fetch comments for a specific review, run:");
-        console.log(`node scripts/gh-pr-review-comments.cjs ${prNumber} <REVIEW_ID>`);
-
-        process.exit(0);
-    }
-
-    // Fetch specific review comments
-    const cmd = `gh api "repos/:owner/:repo/pulls/${prNumber}/reviews/${reviewId}/comments"`;
+    // Fetch all comments to aggregate Review IDs
+    const cmd = `gh api "repos/:owner/:repo/pulls/${prNumber}/comments" --paginate`;
     const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
     let comments = JSON.parse(output);
 
     // Filter by date if in delta mode
     if (cutoffDate) {
-        comments = comments.filter(c => new Date(c.created_at) > cutoffDate);
+      comments = comments.filter((c) => new Date(c.created_at) > cutoffDate);
     }
 
     if (!Array.isArray(comments) || comments.length === 0) {
-        console.log("No comments found for this review" + (cutoffDate ? " in the new window." : "."));
-        process.exit(0);
+      console.log(
+        cutoffDate
+          ? '✅ No new comments found since your last update!'
+          : 'No inline comments found for this PR.'
+      );
+      process.exit(0);
     }
 
-    let formattedOutput = "";
+    // Group by review_id
+    const reviews = {};
+    comments.forEach((c) => {
+      if (c.pull_request_review_id) {
+        if (!reviews[c.pull_request_review_id]) {
+          reviews[c.pull_request_review_id] = {
+            id: c.pull_request_review_id,
+            author: c.user.login,
+            count: 0,
+            lastDate: c.created_at,
+          };
+        }
+        reviews[c.pull_request_review_id].count++;
+        if (new Date(c.created_at) > new Date(reviews[c.pull_request_review_id].lastDate)) {
+          reviews[c.pull_request_review_id].lastDate = c.created_at;
+        }
+      }
+    });
 
-    comments.forEach(c => {
-        const originalLine = c.original_line || c.line || "N/A";
-        const header = `------------------------------------------------------------
+    const reviewsList = Object.values(reviews);
+
+    if (reviewsList.length === 0) {
+      console.log('Found comments, but none are associated with a review ID.');
+      process.exit(0);
+    }
+
+    console.log(`\nFound ${reviewsList.length} Active Review Threads:`);
+    console.log('------------------------------------------------------------');
+    console.log(
+      String('ID').padEnd(15) +
+        String('Author').padEnd(20) +
+        String('Comments').padEnd(10) +
+        'Latest'
+    );
+    console.log('------------------------------------------------------------');
+
+    reviewsList.forEach((r) => {
+      console.log(
+        `${String(r.id).padEnd(15)} ${String(r.author).padEnd(20)} ${String(r.count).padEnd(10)} ${new Date(r.lastDate).toLocaleString()}`
+      );
+    });
+    console.log('------------------------------------------------------------');
+    console.log('\nTo fetch comments for a specific review, run:');
+    console.log(`node scripts/gh-pr-review-comments.cjs ${prNumber} <REVIEW_ID>`);
+
+    process.exit(0);
+  }
+
+  // Fetch specific review comments
+  const cmd = `gh api "repos/:owner/:repo/pulls/${prNumber}/reviews/${reviewId}/comments"`;
+  const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+  let comments = JSON.parse(output);
+
+  // Filter by date if in delta mode
+  if (cutoffDate) {
+    comments = comments.filter((c) => new Date(c.created_at) > cutoffDate);
+  }
+
+  if (!Array.isArray(comments) || comments.length === 0) {
+    console.log('No comments found for this review' + (cutoffDate ? ' in the new window.' : '.'));
+    process.exit(0);
+  }
+
+  let formattedOutput = '';
+
+  comments.forEach((c) => {
+    const originalLine = c.original_line || c.line || 'N/A';
+    const header = `------------------------------------------------------------
 Comment #${c.id} by ${c.user.login} on ${c.path}:${originalLine}
 State: ${c.state || 'N/A'} | Created: ${c.created_at}
 
@@ -205,21 +220,20 @@ Code context:
 ${c.diff_hunk}
 
 `;
-        formattedOutput += header;
-    });
+    formattedOutput += header;
+  });
 
-    if (outputFile) {
-        fs.appendFileSync(outputFile, formattedOutput, 'utf8');
-        console.log(`✔ Review comments appended to: ${outputFile}`);
-    } else {
-        process.stdout.write(formattedOutput);
-    }
-
+  if (outputFile) {
+    fs.appendFileSync(outputFile, formattedOutput, 'utf8');
+    console.log(`✔ Review comments appended to: ${outputFile}`);
+  } else {
+    process.stdout.write(formattedOutput);
+  }
 } catch (error) {
-    console.error("❌ Error execution failed:");
-    console.error(error.message);
-    if (error.stderr) {
-        console.error(error.stderr.toString());
-    }
-    process.exit(1);
+  console.error('❌ Error execution failed:');
+  console.error(error.message);
+  if (error.stderr) {
+    console.error(error.stderr.toString());
+  }
+  process.exit(1);
 }

--- a/scripts/list-envs.ts
+++ b/scripts/list-envs.ts
@@ -1,13 +1,12 @@
-
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 async function listEnvironments() {
-    const envs = await prisma.environment.findMany();
-    console.log('Environments:', envs);
+  const envs = await prisma.environment.findMany();
+  console.log('Environments:', envs);
 }
 
 listEnvironments()
-    .catch(console.error)
-    .finally(() => prisma.$disconnect());
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());

--- a/scripts/ops.test.ts
+++ b/scripts/ops.test.ts
@@ -42,7 +42,6 @@ describe('Operations Scripts', () => {
       }
     }
   });
-
   describe('backup-db', () => {
     it('should create a backup file for a valid SQLite DB', async () => {
       // Mock env.DATABASE_URL if possible, or just rely on existing dev.db if it exists

--- a/scripts/seed-verification.ts
+++ b/scripts/seed-verification.ts
@@ -5,69 +5,74 @@ const prisma = new PrismaClient();
 
 const encryptionKeyHex = process.env.ENCRYPTION_KEY;
 if (!encryptionKeyHex) {
-    throw new Error('ENCRYPTION_KEY environment variable is not set. Please provide a 32-byte hex-encoded key.');
+  throw new Error(
+    'ENCRYPTION_KEY environment variable is not set. Please provide a 32-byte hex-encoded key.'
+  );
 }
 const encryptionKey = Buffer.from(encryptionKeyHex, 'hex');
 
 async function main() {
-    const userId = process.env.SEED_USER_ID || '342649576785838080';
-    const apiKey = process.env.SEED_API_KEY || 'test-api-key';
+  const userId = process.env.SEED_USER_ID || '342649576785838080';
+  const apiKey = process.env.SEED_API_KEY || 'test-api-key';
 
-    console.log(`Seeding data for User ID: ${userId}`);
+  console.log(`Seeding data for User ID: ${userId}`);
 
-    // 1. Create Project
-    const project = await prisma.project.create({
-        data: {
-            name: 'Pawthy Verification Project',
-            description: 'Project for verifying CLI',
-            ownerId: userId,
-            environments: {
+  // 1. Create Project
+  const project = await prisma.project.create({
+    data: {
+      name: 'Pawthy Verification Project',
+      description: 'Project for verifying CLI',
+      ownerId: userId,
+      environments: {
+        create: {
+          name: 'Development',
+          slug: 'dev',
+          resource: {
+            create: {
+              name: 'Test Database Credentials',
+              mode: 'ONE_OF_N',
+              apiKey: apiKey,
+              guardians: {
                 create: {
-                    name: 'Development',
-                    slug: 'dev',
-                    resource: {
-                        create: {
-                            name: 'Test Database Credentials',
-                            mode: 'ONE_OF_N',
-                            apiKey: apiKey,
-                            guardians: {
-                                create: {
-                                    discordUserId: userId,
-                                    role: 'OWNER'
-                                }
-                            },
-                            fields: {
-                                create: [
-                                    { name: 'DB_HOST', value: encryptWithKey('localhost', encryptionKey) },
-                                    { name: 'DB_USER', value: encryptWithKey('admin', encryptionKey) },
-                                    { name: 'DB_PASS', value: encryptWithKey('P@wthY-S3cr3t-V3r1fy-Pa$$', encryptionKey) }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
+                  discordUserId: userId,
+                  role: 'OWNER',
+                },
+              },
+              fields: {
+                create: [
+                  { name: 'DB_HOST', value: encryptWithKey('localhost', encryptionKey) },
+                  { name: 'DB_USER', value: encryptWithKey('admin', encryptionKey) },
+                  {
+                    name: 'DB_PASS',
+                    value: encryptWithKey('P@wthY-S3cr3t-V3r1fy-Pa$$', encryptionKey),
+                  },
+                ],
+              },
+            },
+          },
         },
+      },
+    },
+    include: {
+      environments: {
         include: {
-            environments: {
-                include: {
-                    resource: true
-                }
-            }
-        }
-    });
+          resource: true,
+        },
+      },
+    },
+  });
 
-    console.log('✅ Created Project:', project.name);
-    console.log('✅ Created Environment: Development');
-    console.log('✅ Created Resource linked to Environment');
-    console.log('✅ Added Guardian:', userId);
+  console.log('✅ Created Project:', project.name);
+  console.log('✅ Created Environment: Development');
+  console.log('✅ Created Resource linked to Environment');
+  console.log('✅ Added Guardian:', userId);
 }
 
 main()
-    .catch((e) => {
-        console.error(e);
-        process.exit(1);
-    })
-    .finally(async () => {
-        await prisma.$disconnect();
-    });
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/sync-mcp.cjs
+++ b/scripts/sync-mcp.cjs
@@ -15,416 +15,400 @@
  *                (Useful if you want this project to be the SINGLE source of truth).
  */
 
-const fs = require("node:fs");
-const path = require("node:path");
-const os = require("node:os");
-const dotenv = require("dotenv");
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const dotenv = require('dotenv');
 
 // --- Configuration ---
 
 // 1. Project Configs
-const PROJECT_ROOT = path.resolve(__dirname, "..");
-const PROJECT_MCP_PATH = path.join(PROJECT_ROOT, "mcp.json");
-const LOCAL_MCP_PATH = path.join(PROJECT_ROOT, "mcp.local.json"); // For personal overrides (ignored by git)
-const ENV_PATH = path.join(PROJECT_ROOT, ".env");
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const PROJECT_MCP_PATH = path.join(PROJECT_ROOT, 'mcp.json');
+const LOCAL_MCP_PATH = path.join(PROJECT_ROOT, 'mcp.local.json'); // For personal overrides (ignored by git)
+const ENV_PATH = path.join(PROJECT_ROOT, '.env');
 
 // 2. Global Config Paths
 // Platform specific paths for Claude and VS Code
 let CLAUDE_CONFIG_DIR;
 
-if (process.platform === "win32") {
-    CLAUDE_CONFIG_DIR = path.join(process.env.APPDATA, "Claude");
-} else if (process.platform === "darwin") {
-    CLAUDE_CONFIG_DIR = path.join(
-        os.homedir(),
-        "Library",
-        "Application Support",
-        "Claude",
-    );
+if (process.platform === 'win32') {
+  CLAUDE_CONFIG_DIR = path.join(process.env.APPDATA, 'Claude');
+} else if (process.platform === 'darwin') {
+  CLAUDE_CONFIG_DIR = path.join(os.homedir(), 'Library', 'Application Support', 'Claude');
 } else {
-    // Linux
-    CLAUDE_CONFIG_DIR = path.join(os.homedir(), ".config", "Claude");
+  // Linux
+  CLAUDE_CONFIG_DIR = path.join(os.homedir(), '.config', 'Claude');
 }
 
-const GLOBAL_MCP_PATH = path.join(CLAUDE_CONFIG_DIR, "claude_desktop_config.json");
-const ANTIGRAVITY_CONFIG_PATH = path.join(os.homedir(), ".gemini/antigravity/mcp_config.json");
-const VSCODE_MCP_PATH = path.join(PROJECT_ROOT, ".vscode", "mcp.json"); // Per-project VS Code config
-const CODEX_CONFIG_PATH = path.join(PROJECT_ROOT, ".codex", "config.toml");
-const USER_CODEX_CONFIG_PATH = path.join(os.homedir(), ".codex", "config.toml");
-const CODEX_EXCLUDED_SERVER_NAMES = new Set(["filesystem"]);
+const GLOBAL_MCP_PATH = path.join(CLAUDE_CONFIG_DIR, 'claude_desktop_config.json');
+const ANTIGRAVITY_CONFIG_PATH = path.join(os.homedir(), '.gemini/antigravity/mcp_config.json');
+const VSCODE_MCP_PATH = path.join(PROJECT_ROOT, '.vscode', 'mcp.json'); // Per-project VS Code config
+const CODEX_CONFIG_PATH = path.join(PROJECT_ROOT, '.codex', 'config.toml');
+const USER_CODEX_CONFIG_PATH = path.join(os.homedir(), '.codex', 'config.toml');
+const CODEX_EXCLUDED_SERVER_NAMES = new Set(['filesystem']);
 
 // --- Helpers ---
 
 function ensureDirectoryExists(filePath) {
-    const dirname = path.dirname(filePath);
-    if (!fs.existsSync(dirname)) {
-        fs.mkdirSync(dirname, { recursive: true });
-    }
+  const dirname = path.dirname(filePath);
+  if (!fs.existsSync(dirname)) {
+    fs.mkdirSync(dirname, { recursive: true });
+  }
 }
 
 function parseEnv() {
-    if (fs.existsSync(ENV_PATH)) {
-        return dotenv.parse(fs.readFileSync(ENV_PATH));
-    }
-    return {};
+  if (fs.existsSync(ENV_PATH)) {
+    return dotenv.parse(fs.readFileSync(ENV_PATH));
+  }
+  return {};
 }
 
 function substitute(value, envVars) {
-    if (typeof value !== "string") return value;
-    return value.replace(/\$\{([^}]+)\}/g, (_, key) => {
-        return process.env[key] || envVars[key] || "";
-    });
+  if (typeof value !== 'string') return value;
+  return value.replace(/\$\{([^}]+)\}/g, (_, key) => {
+    return process.env[key] || envVars[key] || '';
+  });
 }
 
 function escapeTomlString(value) {
-    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 function renderTomlStringArray(values) {
-    if (!Array.isArray(values) || values.length === 0) {
-        return "[]";
-    }
+  if (!Array.isArray(values) || values.length === 0) {
+    return '[]';
+  }
 
-    return `[${values
-        .map((value) => `"${escapeTomlString(String(value))}"`)
-        .join(", ")}]`;
+  return `[${values.map((value) => `"${escapeTomlString(String(value))}"`).join(', ')}]`;
 }
 
 function escapeRegExp(value) {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function ensureCodexProjectTrusted() {
-    const escapedProjectRoot = escapeTomlString(PROJECT_ROOT);
-    const sectionHeader = `[projects."${escapedProjectRoot}"]`;
-    const sectionKeyPatterns = [PROJECT_ROOT, escapedProjectRoot]
-        .filter((value, index, values) => values.indexOf(value) === index)
-        .map((value) => escapeRegExp(value))
-        .join("|");
+  const escapedProjectRoot = escapeTomlString(PROJECT_ROOT);
+  const sectionHeader = `[projects."${escapedProjectRoot}"]`;
+  const sectionKeyPatterns = [PROJECT_ROOT, escapedProjectRoot]
+    .filter((value, index, values) => values.indexOf(value) === index)
+    .map((value) => escapeRegExp(value))
+    .join('|');
 
-    ensureDirectoryExists(USER_CODEX_CONFIG_PATH);
+  ensureDirectoryExists(USER_CODEX_CONFIG_PATH);
 
-    let content = "";
-    if (fs.existsSync(USER_CODEX_CONFIG_PATH)) {
-        content = fs.readFileSync(USER_CODEX_CONFIG_PATH, "utf8");
-    }
+  let content = '';
+  if (fs.existsSync(USER_CODEX_CONFIG_PATH)) {
+    content = fs.readFileSync(USER_CODEX_CONFIG_PATH, 'utf8');
+  }
 
-    const sectionPattern = new RegExp(
-        `(^|\\n)\\[projects\\."(?:${sectionKeyPatterns})"\\]\\n([\\s\\S]*?)(?=\\n\\[[^\\]]+\\]|$)`,
-        "m",
-    );
+  const sectionPattern = new RegExp(
+    `(^|\\n)\\[projects\\."(?:${sectionKeyPatterns})"\\]\\n([\\s\\S]*?)(?=\\n\\[[^\\]]+\\]|$)`,
+    'm'
+  );
 
-    if (sectionPattern.test(content)) {
-        content = content.replace(sectionPattern, (match, prefix, body) => {
-            if (/^trust_level\s*=.*$/m.test(body)) {
-                const nextBody = body.replace(/^trust_level\s*=.*$/m, 'trust_level = "trusted"');
-                return `${prefix}${sectionHeader}\n${nextBody}`;
-            }
-            return `${prefix}${sectionHeader}\ntrust_level = "trusted"\n${body}`;
-        });
-    } else {
-        const separator = content.trimEnd().length === 0 ? "" : "\n\n";
-        content = `${content.trimEnd()}${separator}${sectionHeader}\ntrust_level = "trusted"\n`;
-    }
+  if (sectionPattern.test(content)) {
+    content = content.replace(sectionPattern, (match, prefix, body) => {
+      if (/^trust_level\s*=.*$/m.test(body)) {
+        const nextBody = body.replace(/^trust_level\s*=.*$/m, 'trust_level = "trusted"');
+        return `${prefix}${sectionHeader}\n${nextBody}`;
+      }
+      return `${prefix}${sectionHeader}\ntrust_level = "trusted"\n${body}`;
+    });
+  } else {
+    const separator = content.trimEnd().length === 0 ? '' : '\n\n';
+    content = `${content.trimEnd()}${separator}${sectionHeader}\ntrust_level = "trusted"\n`;
+  }
 
-    fs.writeFileSync(USER_CODEX_CONFIG_PATH, `${content.trimEnd()}\n`);
+  fs.writeFileSync(USER_CODEX_CONFIG_PATH, `${content.trimEnd()}\n`);
 }
 
 function renderCodexConfig(processedProjectServers) {
-    const lines = [
-        "# Generated by scripts/sync-mcp.cjs",
-        "# Do not edit manually. This file is local-only and gitignored.",
-        "",
-    ];
+  const lines = [
+    '# Generated by scripts/sync-mcp.cjs',
+    '# Do not edit manually. This file is local-only and gitignored.',
+    '',
+  ];
 
-    for (const [serverName, serverConfig] of Object.entries(processedProjectServers)) {
-        if (CODEX_EXCLUDED_SERVER_NAMES.has(serverName)) {
-            continue;
-        }
-
-        const envEntries = Object.entries(serverConfig.env || {}).filter(([, value]) => {
-            return typeof value === "string" && value.trim() !== "";
-        });
-
-        lines.push(`[mcp_servers.${serverName}]`);
-
-        if (typeof serverConfig.command === "string" && serverConfig.command.length > 0) {
-            lines.push(`command = "${escapeTomlString(serverConfig.command)}"`);
-        }
-
-        if (Array.isArray(serverConfig.args) && serverConfig.args.length > 0) {
-            lines.push(`args = ${renderTomlStringArray(serverConfig.args)}`);
-        }
-
-        if (typeof serverConfig.url === "string" && serverConfig.url.length > 0) {
-            lines.push(`url = "${escapeTomlString(serverConfig.url)}"`);
-        } else if (
-            typeof serverConfig.serverUrl === "string" &&
-            serverConfig.serverUrl.length > 0
-        ) {
-            lines.push(`url = "${escapeTomlString(serverConfig.serverUrl)}"`);
-        }
-
-        if (typeof serverConfig.command === "string" && serverConfig.command.length > 0) {
-            const cwd = serverConfig.cwd || PROJECT_ROOT;
-            lines.push(`cwd = "${escapeTomlString(cwd)}"`);
-        }
-
-        if (serverName === "github") {
-            const githubToken = processedProjectServers.github?.env?.GITHUB_PERSONAL_ACCESS_TOKEN;
-            if (!githubToken) {
-                lines.push("enabled = false");
-            }
-            lines.push("startup_timeout_sec = 20");
-            lines.push("tool_timeout_sec = 60");
-        } else if (serverName === "prisma") {
-            lines.push("startup_timeout_sec = 20");
-            lines.push("tool_timeout_sec = 90");
-        } else {
-            lines.push("startup_timeout_sec = 20");
-            lines.push("tool_timeout_sec = 60");
-        }
-
-        if (envEntries.length > 0) {
-            lines.push("");
-            lines.push(`[mcp_servers.${serverName}.env]`);
-            for (const [envKey, envValue] of envEntries) {
-                lines.push(`${envKey} = "${escapeTomlString(String(envValue))}"`);
-            }
-        }
-
-        lines.push("");
+  for (const [serverName, serverConfig] of Object.entries(processedProjectServers)) {
+    if (CODEX_EXCLUDED_SERVER_NAMES.has(serverName)) {
+      continue;
     }
 
-    return `${lines.join("\n").trimEnd()}\n`;
+    const envEntries = Object.entries(serverConfig.env || {}).filter(([, value]) => {
+      return typeof value === 'string' && value.trim() !== '';
+    });
+
+    lines.push(`[mcp_servers.${serverName}]`);
+
+    if (typeof serverConfig.command === 'string' && serverConfig.command.length > 0) {
+      lines.push(`command = "${escapeTomlString(serverConfig.command)}"`);
+    }
+
+    if (Array.isArray(serverConfig.args) && serverConfig.args.length > 0) {
+      lines.push(`args = ${renderTomlStringArray(serverConfig.args)}`);
+    }
+
+    if (typeof serverConfig.url === 'string' && serverConfig.url.length > 0) {
+      lines.push(`url = "${escapeTomlString(serverConfig.url)}"`);
+    } else if (typeof serverConfig.serverUrl === 'string' && serverConfig.serverUrl.length > 0) {
+      lines.push(`url = "${escapeTomlString(serverConfig.serverUrl)}"`);
+    }
+
+    if (typeof serverConfig.command === 'string' && serverConfig.command.length > 0) {
+      const cwd = serverConfig.cwd || PROJECT_ROOT;
+      lines.push(`cwd = "${escapeTomlString(cwd)}"`);
+    }
+
+    if (serverName === 'github') {
+      const githubToken = processedProjectServers.github?.env?.GITHUB_PERSONAL_ACCESS_TOKEN;
+      if (!githubToken) {
+        lines.push('enabled = false');
+      }
+      lines.push('startup_timeout_sec = 20');
+      lines.push('tool_timeout_sec = 60');
+    } else if (serverName === 'prisma') {
+      lines.push('startup_timeout_sec = 20');
+      lines.push('tool_timeout_sec = 90');
+    } else {
+      lines.push('startup_timeout_sec = 20');
+      lines.push('tool_timeout_sec = 60');
+    }
+
+    if (envEntries.length > 0) {
+      lines.push('');
+      lines.push(`[mcp_servers.${serverName}.env]`);
+      for (const [envKey, envValue] of envEntries) {
+        lines.push(`${envKey} = "${escapeTomlString(String(envValue))}"`);
+      }
+    }
+
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
 }
 
 function syncMcp() {
-    console.log("🔄 Syncing MCP Configuration...");
+  console.log('🔄 Syncing MCP Configuration...');
 
-    // 1. Read Project Config
-    if (!fs.existsSync(PROJECT_MCP_PATH)) {
-        console.error("❌ Error: mcp.json not found in project root.");
-        process.exit(1);
+  // 1. Read Project Config
+  if (!fs.existsSync(PROJECT_MCP_PATH)) {
+    console.error('❌ Error: mcp.json not found in project root.');
+    process.exit(1);
+  }
+
+  let projectConfig;
+  try {
+    projectConfig = JSON.parse(fs.readFileSync(PROJECT_MCP_PATH, 'utf8'));
+  } catch (e) {
+    console.error('❌ Error: mcp.json contains invalid JSON.');
+    if (e instanceof Error) {
+      console.error(`   Details: ${e.message}`);
     }
+    process.exit(1);
+  }
 
-    let projectConfig;
+  // Ensure mcpServers exists
+  if (!projectConfig.mcpServers) {
+    projectConfig.mcpServers = {};
+  }
+
+  // 1a. Apply Local Overrides
+  if (fs.existsSync(LOCAL_MCP_PATH)) {
     try {
-        projectConfig = JSON.parse(fs.readFileSync(PROJECT_MCP_PATH, "utf8"));
+      console.log('   🔸 Detected mcp.local.json. Applying overrides...');
+      const localConfig = JSON.parse(fs.readFileSync(LOCAL_MCP_PATH, 'utf8'));
+      if (localConfig.mcpServers) {
+        for (const [key, value] of Object.entries(localConfig.mcpServers)) {
+          if (projectConfig.mcpServers[key]) {
+            // Merge shallowly for now (flags like disabled, env, etc)
+            projectConfig.mcpServers[key] = { ...projectConfig.mcpServers[key], ...value };
+          } else {
+            // Strict mode: Ignore local-only servers to prevent pollution.
+            console.warn(`      ⚠️  Ignoring local-only server: ${key} (not in mcp.json)`);
+          }
+        }
+      }
     } catch (e) {
-        console.error(
-            "❌ Error: mcp.json contains invalid JSON.",
-        );
-        if (e instanceof Error) {
-            console.error(`   Details: ${e.message}`);
-        }
-        process.exit(1);
+      console.warn(`⚠️  Warning: mcp.local.json exists but is invalid: ${e.message}. Ignoring.`);
     }
+  }
 
-    // Ensure mcpServers exists
-    if (!projectConfig.mcpServers) {
-        projectConfig.mcpServers = {};
-    }
+  // 2. Read (or Init) Global Config
+  let globalConfig = { mcpServers: {} };
+  const args = process.argv.slice(2);
+  const replaceMode = args.includes('--replace');
 
-    // 1a. Apply Local Overrides
-    if (fs.existsSync(LOCAL_MCP_PATH)) {
-        try {
-            console.log("   🔸 Detected mcp.local.json. Applying overrides...");
-            const localConfig = JSON.parse(fs.readFileSync(LOCAL_MCP_PATH, "utf8"));
-            if (localConfig.mcpServers) {
-                for (const [key, value] of Object.entries(localConfig.mcpServers)) {
-                    if (projectConfig.mcpServers[key]) {
-                        // Merge shallowly for now (flags like disabled, env, etc)
-                        projectConfig.mcpServers[key] = { ...projectConfig.mcpServers[key], ...value };
-                    } else {
-                        // Strict mode: Ignore local-only servers to prevent pollution.
-                        console.warn(`      ⚠️  Ignoring local-only server: ${key} (not in mcp.json)`);
-                    }
-                }
-            }
-        } catch (e) {
-            console.warn(`⚠️  Warning: mcp.local.json exists but is invalid: ${e.message}. Ignoring.`);
-        }
-    }
-
-    // 2. Read (or Init) Global Config
-    let globalConfig = { mcpServers: {} };
-    const args = process.argv.slice(2);
-    const replaceMode = args.includes("--replace");
-
-    if (fs.existsSync(GLOBAL_MCP_PATH)) {
-        try {
-            const content = fs.readFileSync(GLOBAL_MCP_PATH, "utf8");
-            globalConfig = JSON.parse(content);
-            if (!globalConfig || typeof globalConfig !== "object") {
-                globalConfig = {};
-            }
-            if (
-                !globalConfig.mcpServers ||
-                typeof globalConfig.mcpServers !== "object"
-            ) {
-                globalConfig.mcpServers = {};
-            }
-        } catch (e) {
-            console.warn(
-                "⚠️  Warning: Global config found but invalid/unreadable. Overwriting.",
-            );
-            globalConfig = { mcpServers: {} };
-        }
-    } else {
-        ensureDirectoryExists(GLOBAL_MCP_PATH);
-    }
-
-    if (replaceMode) {
-        console.log("🔥 Replace mode: Clearing existing global servers.");
+  if (fs.existsSync(GLOBAL_MCP_PATH)) {
+    try {
+      const content = fs.readFileSync(GLOBAL_MCP_PATH, 'utf8');
+      globalConfig = JSON.parse(content);
+      if (!globalConfig || typeof globalConfig !== 'object') {
+        globalConfig = {};
+      }
+      if (!globalConfig.mcpServers || typeof globalConfig.mcpServers !== 'object') {
         globalConfig.mcpServers = {};
+      }
+    } catch (e) {
+      console.warn('⚠️  Warning: Global config found but invalid/unreadable. Overwriting.');
+      globalConfig = { mcpServers: {} };
+    }
+  } else {
+    ensureDirectoryExists(GLOBAL_MCP_PATH);
+  }
+
+  if (replaceMode) {
+    console.log('🔥 Replace mode: Clearing existing global servers.');
+    globalConfig.mcpServers = {};
+  }
+
+  // 3. Merge Strategies
+  const servers = projectConfig.mcpServers || {};
+  const processedProjectServers = {};
+
+  // Load .env vars once
+  const fileEnvVars = parseEnv();
+
+  for (const [key, config] of Object.entries(servers)) {
+    // 3a. Check for disabled flag
+    if (config.disabled === true) {
+      console.log(`   ⛔ Skipping disabled server: ${key}`);
+      if (globalConfig.mcpServers && globalConfig.mcpServers[key]) {
+        delete globalConfig.mcpServers[key];
+        console.log(`      - Removed ${key} from global config (disabled locally).`);
+      }
+      continue;
     }
 
-    // 3. Merge Strategies
-    const servers = projectConfig.mcpServers || {};
-    const processedProjectServers = {};
+    // Basic validation
+    if (!config.command && !config.url && !config.serverUrl) {
+      console.warn(
+        `⚠️  Skipping invalid server '${key}': missing 'command', 'url', or 'serverUrl'`
+      );
+      continue;
+    }
 
-    // Load .env vars once
-    const fileEnvVars = parseEnv();
+    const serverConfig = structuredClone(config);
 
-    for (const [key, config] of Object.entries(servers)) {
-        // 3a. Check for disabled flag
-        if (config.disabled === true) {
-            console.log(`   ⛔ Skipping disabled server: ${key}`);
-            if (globalConfig.mcpServers && globalConfig.mcpServers[key]) {
-                delete globalConfig.mcpServers[key];
-                console.log(`      - Removed ${key} from global config (disabled locally).`);
-            }
-            continue;
-        }
-
-        // Basic validation
-        if (!config.command && !config.url && !config.serverUrl) {
-            console.warn(
-                `⚠️  Skipping invalid server '${key}': missing 'command', 'url', or 'serverUrl'`,
-            );
-            continue;
-        }
-
-        const serverConfig = structuredClone(config);
-
-        // 1. Filesystem: Resolve relative paths
-        if (key === "filesystem" && Array.isArray(serverConfig.args)) {
-            const newArgs = serverConfig.args.map((arg) => {
-                if (typeof arg === 'string' && !path.isAbsolute(arg) && !arg.startsWith('-') && !arg.startsWith('@')) {
-                    return path.resolve(process.cwd(), arg);
-                }
-                return arg;
-            });
-            serverConfig.args = newArgs;
-            console.log(`   - Resolved relative paths for 'filesystem' server.`);
-        }
-
-        // 2. Generic Variable Substitution
-        if (Array.isArray(serverConfig.args)) {
-            serverConfig.args = serverConfig.args.map((arg) =>
-                substitute(arg, fileEnvVars),
-            );
-        }
-
-        // 5. Env Block Substitution
-        if (serverConfig.env && typeof serverConfig.env === "object") {
-            for (const [envKey, envValue] of Object.entries(serverConfig.env)) {
-                serverConfig.env[envKey] = substitute(envValue, fileEnvVars);
-            }
-        }
-
-        // 6. CWD Resolution
+    // 1. Filesystem: Resolve relative paths
+    if (key === 'filesystem' && Array.isArray(serverConfig.args)) {
+      const newArgs = serverConfig.args.map((arg) => {
         if (
-            serverConfig.cwd &&
-            typeof serverConfig.cwd === "string" &&
-            !path.isAbsolute(serverConfig.cwd)
+          typeof arg === 'string' &&
+          !path.isAbsolute(arg) &&
+          !arg.startsWith('-') &&
+          !arg.startsWith('@')
         ) {
-            serverConfig.cwd = path.resolve(process.cwd(), serverConfig.cwd);
+          return path.resolve(process.cwd(), arg);
         }
+        return arg;
+      });
+      serverConfig.args = newArgs;
+      console.log(`   - Resolved relative paths for 'filesystem' server.`);
+    }
 
-        // 3. Postgres/Prisma Handling
-        // (Simplified for now, add logic if needed)
+    // 2. Generic Variable Substitution
+    if (Array.isArray(serverConfig.args)) {
+      serverConfig.args = serverConfig.args.map((arg) => substitute(arg, fileEnvVars));
+    }
 
-        // 4. Context7: Special Handling
-        if (key === "context7" && Array.isArray(serverConfig.args)) {
-            const flagIndex = serverConfig.args.indexOf("--api-key");
-            if (flagIndex !== -1 && flagIndex + 1 < serverConfig.args.length) {
-                const apiKeyValue = serverConfig.args[flagIndex + 1];
-                if (!apiKeyValue || apiKeyValue.trim() === "") {
-                    console.log("   - Removing empty --api-key argument (optional).");
-                    serverConfig.args.splice(flagIndex, 2);
-                }
-            }
+    // 5. Env Block Substitution
+    if (serverConfig.env && typeof serverConfig.env === 'object') {
+      for (const [envKey, envValue] of Object.entries(serverConfig.env)) {
+        serverConfig.env[envKey] = substitute(envValue, fileEnvVars);
+      }
+    }
+
+    // 6. CWD Resolution
+    if (
+      serverConfig.cwd &&
+      typeof serverConfig.cwd === 'string' &&
+      !path.isAbsolute(serverConfig.cwd)
+    ) {
+      serverConfig.cwd = path.resolve(process.cwd(), serverConfig.cwd);
+    }
+
+    // 3. Postgres/Prisma Handling
+    // (Simplified for now, add logic if needed)
+
+    // 4. Context7: Special Handling
+    if (key === 'context7' && Array.isArray(serverConfig.args)) {
+      const flagIndex = serverConfig.args.indexOf('--api-key');
+      if (flagIndex !== -1 && flagIndex + 1 < serverConfig.args.length) {
+        const apiKeyValue = serverConfig.args[flagIndex + 1];
+        if (!apiKeyValue || apiKeyValue.trim() === '') {
+          console.log('   - Removing empty --api-key argument (optional).');
+          serverConfig.args.splice(flagIndex, 2);
         }
-
-        globalConfig.mcpServers[key] = serverConfig;
-        processedProjectServers[key] = serverConfig;
-        console.log(`   - Synced server: ${key}`);
+      }
     }
 
-    // 4a. Write Global Config
-    try {
-        ensureDirectoryExists(GLOBAL_MCP_PATH);
-        fs.writeFileSync(GLOBAL_MCP_PATH, JSON.stringify(globalConfig, null, 2), {
-            mode: 0o600,
-        });
-        console.log(
-            `✅ Global: Synced to ${GLOBAL_MCP_PATH}`,
-        );
-    } catch (e) {
-        console.error(`❌ Error: Could not write to global config: ${e.message}`);
-        process.exit(1);
+    globalConfig.mcpServers[key] = serverConfig;
+    processedProjectServers[key] = serverConfig;
+    console.log(`   - Synced server: ${key}`);
+  }
+
+  // 4a. Write Global Config
+  try {
+    ensureDirectoryExists(GLOBAL_MCP_PATH);
+    fs.writeFileSync(GLOBAL_MCP_PATH, JSON.stringify(globalConfig, null, 2), {
+      mode: 0o600,
+    });
+    console.log(`✅ Global: Synced to ${GLOBAL_MCP_PATH}`);
+  } catch (e) {
+    console.error(`❌ Error: Could not write to global config: ${e.message}`);
+    process.exit(1);
+  }
+
+  // 4b. Write VS Code Config
+  try {
+    const vscodeConfig = { servers: {} };
+    // Re-create the VS Code config from the processed servers that belong to this project.
+    for (const key of Object.keys(processedProjectServers)) {
+      if (Object.prototype.hasOwnProperty.call(processedProjectServers, key)) {
+        vscodeConfig.servers[key] = processedProjectServers[key];
+      }
     }
 
-    // 4b. Write VS Code Config
-    try {
-        const vscodeConfig = { servers: {} };
-        // Re-create the VS Code config from the processed servers that belong to this project.
-        for (const key of Object.keys(processedProjectServers)) {
-            if (Object.prototype.hasOwnProperty.call(processedProjectServers, key)) {
-                vscodeConfig.servers[key] = processedProjectServers[key];
-            }
-        }
+    ensureDirectoryExists(VSCODE_MCP_PATH);
+    fs.writeFileSync(VSCODE_MCP_PATH, JSON.stringify(vscodeConfig, null, 2));
+    console.log(`✅ VS Code: Synced to ${VSCODE_MCP_PATH}`);
+  } catch (e) {
+    console.error(`❌ Error: Could not write to VS Code config: ${e.message}`);
+    // Don't exit, just warn
+  }
 
-        ensureDirectoryExists(VSCODE_MCP_PATH);
-        fs.writeFileSync(VSCODE_MCP_PATH, JSON.stringify(vscodeConfig, null, 2));
-        console.log(`✅ VS Code: Synced to ${VSCODE_MCP_PATH}`);
-    } catch (e) {
-        console.error(`❌ Error: Could not write to VS Code config: ${e.message}`);
-        // Don't exit, just warn
-    }
+  // 4c. Write Antigravity Config
+  try {
+    ensureDirectoryExists(ANTIGRAVITY_CONFIG_PATH);
+    // Antigravity might expect a slightly different format or strictly specific one.
+    // Assuming same format as Claude Desktop for now.
+    fs.writeFileSync(ANTIGRAVITY_CONFIG_PATH, JSON.stringify(globalConfig, null, 2), {
+      mode: 0o600,
+    });
+    console.log(`✅ Antigravity: Synced to ${ANTIGRAVITY_CONFIG_PATH}`);
+  } catch (e) {
+    console.error(`❌ Error: Could not write to Antigravity config: ${e.message}`);
+  }
 
-    // 4c. Write Antigravity Config
-    try {
-        ensureDirectoryExists(ANTIGRAVITY_CONFIG_PATH);
-        // Antigravity might expect a slightly different format or strictly specific one.
-        // Assuming same format as Claude Desktop for now.
-        fs.writeFileSync(ANTIGRAVITY_CONFIG_PATH, JSON.stringify(globalConfig, null, 2), {
-            mode: 0o600,
-        });
-        console.log(`✅ Antigravity: Synced to ${ANTIGRAVITY_CONFIG_PATH}`);
-    } catch (e) {
-        console.error(`❌ Error: Could not write to Antigravity config: ${e.message}`);
-    }
+  // 4d. Write Codex Config
+  try {
+    const codexConfig = renderCodexConfig(processedProjectServers);
+    ensureDirectoryExists(CODEX_CONFIG_PATH);
+    fs.writeFileSync(CODEX_CONFIG_PATH, codexConfig);
+    console.log(`✅ Codex: Synced to ${CODEX_CONFIG_PATH}`);
+  } catch (e) {
+    console.error(`❌ Error: Could not write to Codex config: ${e.message}`);
+  }
 
-    // 4d. Write Codex Config
-    try {
-        const codexConfig = renderCodexConfig(processedProjectServers);
-        ensureDirectoryExists(CODEX_CONFIG_PATH);
-        fs.writeFileSync(CODEX_CONFIG_PATH, codexConfig);
-        console.log(`✅ Codex: Synced to ${CODEX_CONFIG_PATH}`);
-    } catch (e) {
-        console.error(`❌ Error: Could not write to Codex config: ${e.message}`);
-    }
-
-    // 4e. Trust this project for Codex
-    try {
-        ensureCodexProjectTrusted();
-        console.log(`✅ Codex: Trusted project in ${USER_CODEX_CONFIG_PATH}`);
-    } catch (e) {
-        console.error(`❌ Error: Could not update Codex trust config: ${e.message}`);
-    }
+  // 4e. Trust this project for Codex
+  try {
+    ensureCodexProjectTrusted();
+    console.log(`✅ Codex: Trusted project in ${USER_CODEX_CONFIG_PATH}`);
+  } catch (e) {
+    console.error(`❌ Error: Could not update Codex trust config: ${e.message}`);
+  }
 }
 
 syncMcp();

--- a/turbo.json
+++ b/turbo.json
@@ -1,27 +1,18 @@
 {
-    "$schema": "https://turbo.build/schema.json",
-    "globalEnv": [
-        "DISCORD_BOT_TOKEN",
-        "DISCORD_CLIENT_ID",
-        "DISCORD_GUILD_ID",
-        "DATABASE_URL"
-    ],
-    "tasks": {
-        "build": {
-            "dependsOn": [
-                "^build"
-            ],
-            "outputs": [
-                "dist/**"
-            ]
-        },
-        "lint": {},
-        "dev": {
-            "cache": false,
-            "persistent": true
-        },
-        "discord:deploy-commands": {
-            "cache": false
-        }
+  "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["DISCORD_BOT_TOKEN", "DISCORD_CLIENT_ID", "DISCORD_GUILD_ID", "DATABASE_URL"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "lint": {},
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "discord:deploy-commands": {
+      "cache": false
     }
+  }
 }


### PR DESCRIPTION
## Description
Replaces generic `as any` mock casts and non-null `!` assertions across test files, domain logic, CLI commands, and scripts with typed mock helpers and explicit assertions.

## Verification
- [x] `pnpm lint` passes with 0 errors and 0 warnings.
- [x] Zero `eslint-disable` workarounds added.
- [x] All tests continue to pass cleanly.

Closes #74