### PR TITLE
feat(cli): support .env.* variants with environment override cascading (#63)

### DIFF
--- a/apps/pawthy/src/cascade_stress.test.ts
+++ b/apps/pawthy/src/cascade_stress.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, mock, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import axios from 'axios';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { getCandidateEnvFiles, loadCascadingEnv } from './loader.js';
+import { pullCommand } from './commands/pull.js';
+import { pushCommand } from './commands/push.js';
+import { config } from './config.js';
+
+describe('Milestone 2 Environment Cascading Stress & Edge Case Harness', () => {
+  let tempDir: string;
+  let exitCode: number | null = null;
+
+  beforeEach(async () => {
+    exitCode = null;
+
+    // Reset Commander options for pull and push commands
+    pullCommand.setOptionValueWithSource('file', undefined, 'default');
+    pullCommand.setOptionValueWithSource('format', undefined, 'default');
+    pullCommand.setOptionValueWithSource('projectId', undefined, 'default');
+    pullCommand.setOptionValueWithSource('envId', undefined, 'default');
+    pullCommand.setOptionValueWithSource('keys', undefined, 'default');
+    pullCommand.setOptionValueWithSource('merge', undefined, 'default');
+    pullCommand.setOptionValueWithSource('env', undefined, 'default');
+    pullCommand.setOptionValue('merge', undefined);
+
+    pushCommand.setOptionValueWithSource('file', undefined, 'default');
+    pushCommand.setOptionValueWithSource('format', undefined, 'default');
+    pushCommand.setOptionValueWithSource('force', undefined, 'default');
+    pushCommand.setOptionValueWithSource('projectId', undefined, 'default');
+    pushCommand.setOptionValueWithSource('envId', undefined, 'default');
+    pushCommand.setOptionValueWithSource('keys', undefined, 'default');
+    pushCommand.setOptionValueWithSource('env', undefined, 'default');
+    pushCommand.setOptionValue('keys', undefined);
+
+    // Create a temp directory (with possible spaces in name to test space handling)
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy test space-dir-'));
+
+    mock.method(process, 'cwd', () => tempDir);
+
+    mock.method(process, 'exit', (code?: number) => {
+      exitCode = code ?? null;
+      throw new Error(`process.exit called with ${code}`);
+    });
+
+    // Default mock config
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    // Write a standard .pawthyrc file in tempDir
+    await fs.writeFile(
+      path.join(tempDir, '.pawthyrc'),
+      JSON.stringify({ projectId: 'test-project', envId: 'test-env' })
+    );
+  });
+
+  afterEach(async () => {
+    mock.restoreAll();
+    delete process.env.PAWTHY_PROJECT_ID;
+    delete process.env.PAWTHY_ENV_ID;
+
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup error
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Category 1: Missing Intermediate Files in Cascading Matrix
+  // ---------------------------------------------------------------------------
+  describe('Category 1: Missing Intermediate Files Matrix', () => {
+    it('1.1: missing .env.staging & .env.local (only .env and .env.staging.local exist)', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'VAR_BASE=base\nSHARED_VAR=base');
+      await fs.writeFile(
+        path.join(tempDir, '.env.staging.local'),
+        'VAR_STAGING_LOCAL=stg_loc\nSHARED_VAR=override_stg_loc'
+      );
+
+      const loaded = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+
+      assert.strictEqual(loaded.VAR_BASE, 'base');
+      assert.strictEqual(loaded.VAR_STAGING_LOCAL, 'stg_loc');
+      assert.strictEqual(loaded.SHARED_VAR, 'override_stg_loc');
+    });
+
+    it('1.2: missing .env and .env.staging.local (only .env.staging and .env.local exist)', async () => {
+      await fs.writeFile(path.join(tempDir, '.env.staging'), 'SHARED=from_staging\nSTAGING_ONLY=1');
+      await fs.writeFile(path.join(tempDir, '.env.local'), 'SHARED=from_local\nLOCAL_ONLY=1');
+
+      const loaded = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+
+      assert.strictEqual(loaded.SHARED, 'from_local'); // .env.local overrides .env.staging
+      assert.strictEqual(loaded.STAGING_ONLY, '1');
+      assert.strictEqual(loaded.LOCAL_ONLY, '1');
+    });
+
+    it('1.3: only highest precedence file (.env.staging.local) exists', async () => {
+      await fs.writeFile(path.join(tempDir, '.env.staging.local'), 'HIGHEST=true');
+
+      const loaded = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+
+      assert.strictEqual(loaded.HIGHEST, 'true');
+      assert.strictEqual(Object.keys(loaded).length, 1);
+    });
+
+    it('1.4: no candidate env files exist at all', async () => {
+      const loaded = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+      assert.deepStrictEqual(loaded, {});
+    });
+
+    it('1.5: pawthy push -E staging with missing intermediate files loads merged result', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'BASE=1\nOVERRIDE=base');
+      await fs.writeFile(
+        path.join(tempDir, '.env.staging.local'),
+        'OVERRIDE=stg_local\nLOCAL_SECRET=secret'
+      );
+
+      let pushedData: Record<string, string> = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock.method(axios, 'put', async (_url: string, body: any) => {
+        pushedData = body.secrets;
+        return { status: 200, data: { success: true } };
+      });
+
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force', '-E', 'staging']);
+
+      assert.deepStrictEqual(pushedData, {
+        BASE: '1',
+        OVERRIDE: 'stg_local',
+        LOCAL_SECRET: 'secret',
+      });
+    });
+
+    it('1.6: pawthy push -E staging when zero candidate files exist gracefully exits', async () => {
+      let putCalled = false;
+      mock.method(axios, 'put', async () => {
+        putCalled = true;
+        return { status: 200, data: { success: true } };
+      });
+
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force', '-E', 'staging']);
+
+      assert.strictEqual(putCalled, false);
+      assert.strictEqual(exitCode, null); // Graceful completion (no exit code 1)
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Category 2: CLI Flag Edge Cases & Combinations
+  // ---------------------------------------------------------------------------
+  describe('Category 2: CLI Flag Edge Cases & Disambiguation', () => {
+    it('2.1: environment profile with special characters, symbols, and dots', async () => {
+      const profile = 'v1.2-alpha_build.99';
+      const candidates = getCandidateEnvFiles(tempDir, profile);
+
+      assert.deepStrictEqual(candidates, [
+        path.join(tempDir, '.env'),
+        path.join(tempDir, `.env.${profile}`),
+        path.join(tempDir, '.env.local'),
+        path.join(tempDir, `.env.${profile}.local`),
+      ]);
+
+      await fs.writeFile(path.join(tempDir, `.env.${profile}`), 'ENV_SPECIFIC=v1.2');
+      const loaded = loadCascadingEnv({ rootDir: tempDir, environment: profile });
+      assert.strictEqual(loaded.ENV_SPECIFIC, 'v1.2');
+    });
+
+    it('2.2: environment profile with whitespace padding', async () => {
+      const candidates = getCandidateEnvFiles(tempDir, '  production  ');
+      assert.strictEqual(candidates[1], path.join(tempDir, '.env.production'));
+      assert.strictEqual(candidates[3], path.join(tempDir, '.env.production.local'));
+    });
+
+    it('2.3: disambiguation between -E (env profile) and -e (env ID)', async () => {
+      let requestedUrl = '';
+      let pushedData: Record<string, string> = {};
+
+      await fs.writeFile(path.join(tempDir, '.env.staging'), 'STAGING_VAR=100');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock.method(axios, 'put', async (url: string, body: any) => {
+        requestedUrl = url;
+        pushedData = body.secrets;
+        return { status: 200, data: { success: true } };
+      });
+
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      // Pass -E staging AND -e remote_env_999 AND -p remote_proj_888
+      await pushCommand.parseAsync([
+        'node',
+        'pawthy',
+        'push',
+        '--force',
+        '-E',
+        'staging',
+        '-e',
+        'remote_env_999',
+        '-p',
+        'remote_proj_888',
+      ]);
+
+      assert.ok(
+        requestedUrl.includes('/projects/remote_proj_888/environments/remote_env_999/secrets')
+      );
+      assert.strictEqual(pushedData.STAGING_VAR, '100');
+    });
+
+    it('2.4: pawthy pull -E staging -e remote_env_999 -m writes to .env.staging and merges existing file', async () => {
+      let requestedUrl = '';
+      await fs.writeFile(
+        path.join(tempDir, '.env.staging'),
+        'LOCAL_STAGING_KEY=local_val\n# preserve comment'
+      );
+
+      mock.method(axios, 'get', async (url: string) => {
+        requestedUrl = url;
+        return {
+          status: 200,
+          data: { secrets: { REMOTE_KEY: 'remote_val' } },
+        };
+      });
+
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      await pullCommand.parseAsync([
+        'node',
+        'pawthy',
+        'pull',
+        '-E',
+        'staging',
+        '-e',
+        'remote_env_999',
+        '-p',
+        'remote_proj_888',
+        '-m',
+      ]);
+
+      assert.ok(
+        requestedUrl.includes('/projects/remote_proj_888/environments/remote_env_999/secrets')
+      );
+
+      const fileContent = await fs.readFile(path.join(tempDir, '.env.staging'), 'utf-8');
+      assert.ok(fileContent.includes('LOCAL_STAGING_KEY=local_val'));
+      assert.ok(fileContent.includes('REMOTE_KEY=remote_val'));
+      assert.ok(fileContent.includes('# preserve comment'));
+    });
+
+    it('2.5: pawthy pull explicit -f overrides -E target file', async () => {
+      mock.method(axios, 'get', async () => {
+        return { status: 200, data: { secrets: { FOO: 'bar' } } };
+      });
+
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      await pullCommand.parseAsync([
+        'node',
+        'pawthy',
+        'pull',
+        '-f',
+        'override_target.env',
+        '-E',
+        'staging',
+      ]);
+
+      const customExists = await fs
+        .access(path.join(tempDir, 'override_target.env'))
+        .then(() => true)
+        .catch(() => false);
+      const stagingExists = await fs
+        .access(path.join(tempDir, '.env.staging'))
+        .then(() => true)
+        .catch(() => false);
+
+      assert.strictEqual(customExists, true);
+      assert.strictEqual(stagingExists, false);
+    });
+
+    it('2.6: pawthy push explicit -f overrides -E cascading loader', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'BASE_VAR=base');
+      await fs.writeFile(path.join(tempDir, '.env.staging'), 'STAGING_VAR=staging');
+      await fs.writeFile(path.join(tempDir, 'explicit.env'), 'EXPLICIT_VAR=explicit');
+
+      let pushedData: Record<string, string> = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock.method(axios, 'put', async (_url: string, body: any) => {
+        pushedData = body.secrets;
+        return { status: 200, data: { success: true } };
+      });
+
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      await pushCommand.parseAsync([
+        'node',
+        'pawthy',
+        'push',
+        '--force',
+        '-f',
+        'explicit.env',
+        '-E',
+        'staging',
+      ]);
+
+      assert.deepStrictEqual(pushedData, { EXPLICIT_VAR: 'explicit' });
+    });
+
+    it('2.7: pawthy push -E staging -k FOO filters secrets loaded from cascade', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'FOO=base_foo\nBAR=base_bar');
+      await fs.writeFile(path.join(tempDir, '.env.staging'), 'FOO=stg_foo\nBAZ=stg_baz');
+
+      let pushedData: Record<string, string> = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock.method(axios, 'put', async (_url: string, body: any) => {
+        pushedData = body.secrets;
+        return { status: 200, data: { success: true } };
+      });
+
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      await pushCommand.parseAsync([
+        'node',
+        'pawthy',
+        'push',
+        '--force',
+        '-E',
+        'staging',
+        '-k',
+        'FOO',
+      ]);
+
+      assert.deepStrictEqual(pushedData, { FOO: 'stg_foo' });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Category 3: Directory Paths with Spaces & Permission Issues
+  // ---------------------------------------------------------------------------
+  describe('Category 3: Space-containing paths and Permission Faults', () => {
+    it('3.1: cascading env loader works in directory path containing spaces and special chars', async () => {
+      const spaceSubDir = path.join(tempDir, 'dir with spaces & # symbols');
+      await fs.mkdir(spaceSubDir, { recursive: true });
+
+      await fs.writeFile(path.join(spaceSubDir, '.env'), 'PATH_TEST=base');
+      await fs.writeFile(path.join(spaceSubDir, '.env.production'), 'PATH_TEST=prod');
+
+      const loaded = loadCascadingEnv({ rootDir: spaceSubDir, environment: 'production' });
+      assert.strictEqual(loaded.PATH_TEST, 'prod');
+    });
+
+    it('3.2: pawthy push -f non-existent file exits with code 1', async () => {
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      try {
+        await pushCommand.parseAsync([
+          'node',
+          'pawthy',
+          'push',
+          '--force',
+          '-f',
+          'non_existent_file.env',
+        ]);
+      } catch {
+        // Expected process.exit throw
+      }
+
+      assert.strictEqual(exitCode, 1);
+    });
+
+    it('3.3: pawthy pull when destination file has EACCES permission failure', async () => {
+      const readOnlyFile = path.join(tempDir, '.env');
+      await fs.writeFile(readOnlyFile, 'LOCKED=1');
+      await fs.chmod(readOnlyFile, 0o444); // Read-only
+
+      mock.method(axios, 'get', async () => {
+        return { status: 200, data: { secrets: { LOCKED: '2' } } };
+      });
+
+      mock.method(console, 'log', () => {});
+      mock.method(console, 'error', () => {});
+
+      try {
+        await pullCommand.parseAsync(['node', 'pawthy', 'pull', '--merge']);
+      } catch {
+        // Expected process.exit throw
+      }
+
+      // Re-enable write permissions so cleanup succeeds
+      await fs.chmod(readOnlyFile, 0o666);
+
+      assert.strictEqual(exitCode, 1);
+    });
+  });
+});

--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -15,10 +15,13 @@ describe('Pull Command', () => {
     exitCode = null;
 
     // Reset commander options to prevent test pollution
-    pullCommand.setOptionValue('file', '.env');
-    pullCommand.setOptionValue('projectId', undefined);
-    pullCommand.setOptionValue('envId', undefined);
-    pullCommand.setOptionValue('keys', undefined);
+    pullCommand.setOptionValueWithSource('file', undefined, 'default');
+    pullCommand.setOptionValueWithSource('format', undefined, 'default');
+    pullCommand.setOptionValueWithSource('projectId', undefined, 'default');
+    pullCommand.setOptionValueWithSource('envId', undefined, 'default');
+    pullCommand.setOptionValueWithSource('keys', undefined, 'default');
+    pullCommand.setOptionValueWithSource('merge', undefined, 'default');
+    pullCommand.setOptionValueWithSource('env', undefined, 'default');
     pullCommand.setOptionValue('merge', undefined);
 
     // Create a unique temp directory outside the repository
@@ -468,5 +471,76 @@ describe('Pull Command', () => {
 
     assert.ok(lines.includes('DATABASE_URL=postgres://prod-host/db'));
     assert.ok(!lines.includes('API_KEY=secret-key'));
+  });
+
+  it('should write secrets to environment-specific file when --env flag is passed', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    mock.method(axios, 'get', async () => {
+      return {
+        status: 200,
+        data: {
+          secrets: {
+            DEV_SECRET: 'dev-val',
+          },
+        },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pullCommand.parseAsync(['node', 'pawthy', 'pull', '-E', 'development']);
+
+    const devContent = await fs.readFile(path.join(tempDir, '.env.development'), 'utf-8');
+    assert.ok(devContent.includes('DEV_SECRET=dev-val'));
+  });
+
+  it('should preserve explicit -f flag over --env flag in pull command', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    mock.method(axios, 'get', async () => {
+      return {
+        status: 200,
+        data: {
+          secrets: {
+            CUSTOM_SECRET: 'custom-val',
+          },
+        },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pullCommand.parseAsync([
+      'node',
+      'pawthy',
+      'pull',
+      '-f',
+      'custom.env',
+      '-E',
+      'development',
+    ]);
+
+    const customContent = await fs.readFile(path.join(tempDir, 'custom.env'), 'utf-8');
+    assert.ok(customContent.includes('CUSTOM_SECRET=custom-val'));
+
+    // Ensure .env.development was not created
+    let devExists = true;
+    try {
+      await fs.access(path.join(tempDir, '.env.development'));
+    } catch {
+      devExists = false;
+    }
+    assert.strictEqual(devExists, false);
   });
 });

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -4,13 +4,19 @@ import chalk from 'chalk';
 import fs from 'fs/promises';
 import path from 'path';
 import { getToken, getApiUrl, getProjectConfig } from '../config.js';
+import { resolveFileAndFormat, SecretFormat, serializeSecrets } from '../format.js';
 
 export const pullCommand = new Command('pull')
-  .description('Pull secrets from Purrmission to local .env')
-  .option('-f, --file <path>', 'Path to .env file', '.env')
+  .description('Pull secrets from Purrmission to local secret file')
+  .option(
+    '-f, --file <path>',
+    'Path to secret file (default: .env, secrets.json, secrets.yaml, or secrets.toml depending on format)'
+  )
+  .option('-F, --format <format>', 'Secret file format (env, json, yaml, toml)')
+  .option('-E, --env <environment>', 'Environment variant (e.g. development, production)')
   .option('-p, --project-id <id>', 'Project ID')
   .option('-e, --env-id <id>', 'Environment ID')
-  .option('-m, --merge', 'Merge with existing .env file instead of overwriting')
+  .option('-m, --merge', 'Merge with existing file instead of overwriting')
   .option('-k, --keys <list>', 'Comma-separated list of keys to pull')
   .action(async (options) => {
     const token = getToken();
@@ -46,7 +52,25 @@ export const pullCommand = new Command('pull')
       return;
     }
 
-    const envPath = path.resolve(process.cwd(), options.file);
+    let file: string;
+    let format: SecretFormat;
+    try {
+      const resolved = resolveFileAndFormat(options.file, options.format);
+      file = resolved.file;
+      format = resolved.format;
+    } catch (err) {
+      console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+      process.exit(1);
+      return;
+    }
+
+    const isFileExplicit = pullCommand.getOptionValueSource('file') === 'cli';
+    const isFormatExplicit = pullCommand.getOptionValueSource('format') === 'cli';
+    if (options.env && !isFileExplicit && !isFormatExplicit && format === 'env') {
+      file = `.env.${options.env}`;
+    }
+
+    const envPath = path.resolve(process.cwd(), file);
 
     try {
       console.log(chalk.dim('Fetching secrets from Purrmission...'));
@@ -110,7 +134,7 @@ export const pullCommand = new Command('pull')
       if (shouldMerge) {
         try {
           const existingContent = await fs.readFile(envPath, 'utf-8');
-          content = mergeEnvSecrets(existingContent, secrets);
+          content = serializeSecrets(secrets, format, existingContent);
           isMerged = true;
         } catch (e: unknown) {
           if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -121,16 +145,12 @@ export const pullCommand = new Command('pull')
       }
 
       if (!isMerged) {
-        // 2. Format as .env
-        content =
-          Object.entries(secrets)
-            .map(([key, value]) => `${key}=${formatEnvValue(value)}`)
-            .join('\n') + '\n';
+        content = serializeSecrets(secrets, format);
 
         // 3. Write to file with safety check
         try {
           await fs.access(envPath);
-          console.warn(chalk.yellow(`\n⚠️  File ${options.file} already exists.`));
+          console.warn(chalk.yellow(`\n⚠️  File ${file} already exists.`));
           console.warn(chalk.yellow('Overwriting existing file...'));
         } catch {
           // File doesn't exist, proceed safe.
@@ -141,9 +161,7 @@ export const pullCommand = new Command('pull')
       await fs.writeFile(envPath, content);
 
       console.log(
-        chalk.green(
-          `\n✅ Successfully pulled ${Object.keys(secrets).length} secrets to ${options.file}`
-        )
+        chalk.green(`\n✅ Successfully pulled ${Object.keys(secrets).length} secrets to ${file}`)
       );
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -168,235 +186,6 @@ export const pullCommand = new Command('pull')
       process.exit(1);
     }
   });
-
-interface EnvBlock {
-  type: 'comment' | 'empty' | 'key-value';
-  raw: string;
-  key?: string;
-  value?: string;
-  leadingWhitespace?: string;
-  middleWhitespace?: string;
-  quote?: '"' | "'" | null;
-  comment?: string;
-}
-
-function parseEnv(content: string, eol: string = '\n'): EnvBlock[] {
-  const lines = content.split(/\r?\n/);
-  const blocks: EnvBlock[] = [];
-  let i = 0;
-  while (i < lines.length) {
-    const line = lines[i];
-
-    if (/^\s*#/.test(line) || /^\s*$/.test(line)) {
-      blocks.push({
-        type: /^\s*#/.test(line) ? 'comment' : 'empty',
-        raw: line,
-      });
-      i++;
-      continue;
-    }
-
-    const declMatch = line.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
-    if (!declMatch) {
-      blocks.push({
-        type: 'comment',
-        raw: line,
-      });
-      i++;
-      continue;
-    }
-
-    const leadingWhitespace = declMatch[1];
-    const key = declMatch[2];
-    const rest = declMatch[3];
-
-    const prefixLength = leadingWhitespace.length + key.length;
-    const middleWhitespaceMatch = line.slice(prefixLength).match(/^\s*=\s*/);
-    const middleWhitespace = middleWhitespaceMatch ? middleWhitespaceMatch[0] : '=';
-
-    let value = '';
-    let quote: '"' | "'" | null = null;
-    let trailingComment = '';
-    const rawBlockLines = [line];
-
-    if (rest.startsWith('"')) {
-      quote = '"';
-      const restValue = rest.slice(1);
-      let currentLineIndex = i;
-      let foundEnd = false;
-      let valAcc = '';
-
-      while (currentLineIndex < lines.length) {
-        const curLine = currentLineIndex === i ? restValue : lines[currentLineIndex];
-        let escaped = false;
-        let quoteIndex = -1;
-        for (let charIdx = 0; charIdx < curLine.length; charIdx++) {
-          const char = curLine[charIdx];
-          if (char === '\\') {
-            escaped = !escaped;
-          } else if (char === '"' && !escaped) {
-            quoteIndex = charIdx;
-            break;
-          } else {
-            escaped = false;
-          }
-        }
-
-        if (quoteIndex !== -1) {
-          valAcc += curLine.slice(0, quoteIndex);
-          trailingComment = curLine.slice(quoteIndex + 1);
-          foundEnd = true;
-          break;
-        } else {
-          valAcc += curLine + '\n';
-          if (currentLineIndex > i) {
-            rawBlockLines.push(lines[currentLineIndex]);
-          }
-          currentLineIndex++;
-        }
-      }
-
-      if (foundEnd) {
-        value = valAcc;
-        i = currentLineIndex + 1;
-      } else {
-        quote = null;
-        value = rest;
-        i++;
-      }
-    } else if (rest.startsWith("'")) {
-      quote = "'";
-      const restValue = rest.slice(1);
-      let currentLineIndex = i;
-      let foundEnd = false;
-      let valAcc = '';
-
-      while (currentLineIndex < lines.length) {
-        const curLine = currentLineIndex === i ? restValue : lines[currentLineIndex];
-        let escaped = false;
-        let quoteIndex = -1;
-        for (let charIdx = 0; charIdx < curLine.length; charIdx++) {
-          const char = curLine[charIdx];
-          if (char === '\\') {
-            escaped = !escaped;
-          } else if (char === "'" && !escaped) {
-            quoteIndex = charIdx;
-            break;
-          } else {
-            escaped = false;
-          }
-        }
-
-        if (quoteIndex !== -1) {
-          valAcc += curLine.slice(0, quoteIndex);
-          trailingComment = curLine.slice(quoteIndex + 1);
-          foundEnd = true;
-          break;
-        } else {
-          valAcc += curLine + '\n';
-          if (currentLineIndex > i) {
-            rawBlockLines.push(lines[currentLineIndex]);
-          }
-          currentLineIndex++;
-        }
-      }
-
-      if (foundEnd) {
-        value = valAcc;
-        i = currentLineIndex + 1;
-      } else {
-        quote = null;
-        value = rest;
-        i++;
-      }
-    } else {
-      const commentMatch = rest.match(/(\s+#.*)$/);
-      if (commentMatch) {
-        value = rest.slice(0, rest.length - commentMatch[1].length).trim();
-        trailingComment = commentMatch[1];
-      } else {
-        value = rest.trim();
-        trailingComment = '';
-      }
-      quote = null;
-      i++;
-    }
-
-    blocks.push({
-      type: 'key-value',
-      raw: rawBlockLines.join(eol),
-      key,
-      value,
-      leadingWhitespace,
-      middleWhitespace,
-      quote,
-      comment: trailingComment,
-    });
-  }
-  return blocks;
-}
-
-function formatEnvValue(value: string, originalQuote?: '"' | "'" | null): string {
-  if (value.includes('\n') || value.includes('\r')) {
-    return `"${value.replace(/"/g, '\\"')}"`;
-  }
-
-  if (/[#=\s'"]/.test(value)) {
-    const quote = originalQuote === '"' || originalQuote === "'" ? originalQuote : '"';
-    if (quote === '"') {
-      return `"${value.replace(/"/g, '\\"')}"`;
-    } else {
-      return `'${value.replace(/'/g, "\\'")}'`;
-    }
-  }
-
-  if (originalQuote === '"') {
-    return `"${value.replace(/"/g, '\\"')}"`;
-  } else if (originalQuote === "'") {
-    return `'${value.replace(/'/g, "\\'")}'`;
-  }
-
-  return value;
-}
-
-function mergeEnvSecrets(existingContent: string, secrets: Record<string, string>): string {
-  const eol = existingContent.includes('\r\n') ? '\r\n' : '\n';
-  const blocks = parseEnv(existingContent, eol);
-  const updatedKeys = new Set<string>();
-  const resultLines: string[] = [];
-
-  for (const block of blocks) {
-    if (block.type === 'key-value' && block.key) {
-      const key = block.key;
-      if (Object.prototype.hasOwnProperty.call(secrets, key)) {
-        const value = secrets[key];
-        resultLines.push(
-          block.leadingWhitespace +
-            key +
-            block.middleWhitespace +
-            formatEnvValue(value, block.quote) +
-            block.comment
-        );
-        updatedKeys.add(key);
-        continue;
-      }
-    }
-    resultLines.push(block.raw);
-  }
-
-  const newKeys = Object.keys(secrets).filter((k) => !updatedKeys.has(k));
-  if (newKeys.length > 0) {
-    if (resultLines.length > 0 && resultLines[resultLines.length - 1].trim() !== '') {
-      resultLines.push('');
-    }
-    for (const key of newKeys) {
-      const value = secrets[key];
-      resultLines.push(key + '=' + formatEnvValue(value));
-    }
-  }
-
-  return resultLines.join(eol);
-}
 
 function getKeysWhitelist(
   optionsKeys?: string,

--- a/apps/pawthy/src/commands/push.test.ts
+++ b/apps/pawthy/src/commands/push.test.ts
@@ -15,10 +15,13 @@ describe('Push Command', () => {
     exitCode = null;
 
     // Reset commander options to prevent test pollution
-    pushCommand.setOptionValue('file', '.env');
-    pushCommand.setOptionValue('force', undefined);
-    pushCommand.setOptionValue('projectId', undefined);
-    pushCommand.setOptionValue('envId', undefined);
+    pushCommand.setOptionValueWithSource('file', undefined, 'default');
+    pushCommand.setOptionValueWithSource('format', undefined, 'default');
+    pushCommand.setOptionValueWithSource('force', undefined, 'default');
+    pushCommand.setOptionValueWithSource('projectId', undefined, 'default');
+    pushCommand.setOptionValueWithSource('envId', undefined, 'default');
+    pushCommand.setOptionValueWithSource('keys', undefined, 'default');
+    pushCommand.setOptionValueWithSource('env', undefined, 'default');
     pushCommand.setOptionValue('keys', undefined);
 
     // Create a unique temp directory outside the repository
@@ -354,6 +357,111 @@ describe('Push Command', () => {
 
     assert.deepStrictEqual(pushedSecrets, {
       DATABASE_URL: 'postgres://localhost/db',
+    });
+  });
+
+  it('should load merged secrets from cascading env files when --env flag is passed', async () => {
+    let pushedSecrets: Record<string, string> = {};
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    await fs.writeFile(path.join(tempDir, '.env'), 'VAR1=base\nVAR2=base\nVAR3=base');
+    await fs.writeFile(path.join(tempDir, '.env.development'), 'VAR1=dev');
+    await fs.writeFile(path.join(tempDir, '.env.local'), 'VAR2=local');
+    await fs.writeFile(path.join(tempDir, '.env.development.local'), 'VAR3=dev_local');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+      pushedSecrets = data.secrets;
+      return {
+        status: 200,
+        data: { success: true },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force', '-E', 'development']);
+
+    assert.deepStrictEqual(pushedSecrets, {
+      VAR1: 'dev',
+      VAR2: 'local',
+      VAR3: 'dev_local',
+    });
+  });
+
+  it('should support standard cascading (.env < .env.local) when --env flag is not passed', async () => {
+    let pushedSecrets: Record<string, string> = {};
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    await fs.writeFile(path.join(tempDir, '.env'), 'FOO=base\nBAR=base');
+    await fs.writeFile(path.join(tempDir, '.env.local'), 'FOO=local');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+      pushedSecrets = data.secrets;
+      return {
+        status: 200,
+        data: { success: true },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']);
+
+    assert.deepStrictEqual(pushedSecrets, {
+      FOO: 'local',
+      BAR: 'base',
+    });
+  });
+
+  it('should preserve explicit -f flag override over cascading env loader', async () => {
+    let pushedSecrets: Record<string, string> = {};
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'test-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    await fs.writeFile(path.join(tempDir, '.env'), 'FOO=base');
+    await fs.writeFile(path.join(tempDir, '.env.local'), 'FOO=local');
+    await fs.writeFile(path.join(tempDir, 'custom.env'), 'FOO=custom');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.method(axios, 'put', async (url: string, data: any): Promise<any> => {
+      pushedSecrets = data.secrets;
+      return {
+        status: 200,
+        data: { success: true },
+      };
+    });
+
+    mock.method(console, 'log', () => {});
+    mock.method(console, 'error', () => {});
+
+    await pushCommand.parseAsync([
+      'node',
+      'pawthy',
+      'push',
+      '--force',
+      '-f',
+      'custom.env',
+      '-E',
+      'development',
+    ]);
+
+    assert.deepStrictEqual(pushedSecrets, {
+      FOO: 'custom',
     });
   });
 });

--- a/apps/pawthy/src/commands/push.ts
+++ b/apps/pawthy/src/commands/push.ts
@@ -3,14 +3,20 @@ import axios from 'axios';
 import chalk from 'chalk';
 import fs from 'fs/promises';
 import path from 'path';
-import dotenv from 'dotenv';
 import { getToken, getApiUrl, getProjectConfig } from '../config.js';
+import { loadCascadingEnv } from '../loader.js';
+import { resolveFileAndFormat, deserializeSecrets, SecretFormat } from '../format.js';
 
 export const pushCommand = new Command('push')
   .description(
-    'Push local .env secrets to Purrmission, updating existing values. This does not remove secrets.'
+    'Push local secrets to Purrmission, updating existing values. This does not remove secrets.'
   )
-  .option('-f, --file <path>', 'Path to .env file', '.env')
+  .option(
+    '-f, --file <path>',
+    'Path to secret file (default: .env, secrets.json, secrets.yaml, or secrets.toml depending on format)'
+  )
+  .option('-F, --format <format>', 'Secret file format (env, json, yaml, toml)')
+  .option('-E, --env <environment>', 'Environment variant (e.g. development, production)')
   .option('--force', 'Push secrets without confirmation')
   .option('-p, --project-id <id>', 'Project ID')
   .option('-e, --env-id <id>', 'Environment ID')
@@ -49,12 +55,61 @@ export const pushCommand = new Command('push')
       return;
     }
 
-    const envPath = path.resolve(process.cwd(), options.file);
+    let file: string;
+    let format: SecretFormat;
+    try {
+      const resolved = resolveFileAndFormat(options.file, options.format);
+      file = resolved.file;
+      format = resolved.format;
+    } catch (err) {
+      console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+      process.exit(1);
+      return;
+    }
+
+    const isFileExplicit = pushCommand.getOptionValueSource('file') === 'cli';
+    const isFormatExplicit = pushCommand.getOptionValueSource('format') === 'cli';
+    if (options.env && !isFileExplicit && !isFormatExplicit && format === 'env') {
+      file = `.env.${options.env}`;
+    }
+
+    const envPath = path.resolve(process.cwd(), file);
 
     try {
-      // 1. Read and Parse .env
-      const envContent = await fs.readFile(envPath, 'utf-8');
-      let secrets = dotenv.parse(envContent);
+      // 1. Read and Parse secrets file
+      let secrets: Record<string, string>;
+      if (!isFileExplicit && !isFormatExplicit && format === 'env') {
+        secrets = loadCascadingEnv({
+          rootDir: process.cwd(),
+          environment: options.env,
+        });
+      } else {
+        let envContent: string;
+        try {
+          envContent = await fs.readFile(envPath, 'utf-8');
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            'code' in error &&
+            (error as NodeJS.ErrnoException).code === 'ENOENT'
+          ) {
+            console.error(chalk.red(`File not found: ${envPath}`));
+            process.exit(1);
+            return;
+          }
+          throw error;
+        }
+
+        try {
+          secrets = deserializeSecrets(envContent, format, envPath);
+        } catch (parseError) {
+          console.error(
+            chalk.red(parseError instanceof Error ? parseError.message : String(parseError))
+          );
+          process.exit(1);
+          return;
+        }
+      }
 
       // Whitelisting / selective keys sync (Issue #80)
       const keysWhitelist = getKeysWhitelist(options.keys, config);

--- a/apps/pawthy/src/loader.test.ts
+++ b/apps/pawthy/src/loader.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, mock, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { getCandidateEnvFiles, loadCascadingEnv } from './loader.js';
+
+describe('Modular Environment Loader', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-loader-test-'));
+  });
+
+  afterEach(async () => {
+    mock.restoreAll();
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup error
+    }
+  });
+
+  describe('getCandidateEnvFiles', () => {
+    it('returns .env and .env.local in order when no environment is provided', () => {
+      const candidates = getCandidateEnvFiles(tempDir);
+      assert.deepStrictEqual(candidates, [
+        path.join(tempDir, '.env'),
+        path.join(tempDir, '.env.local'),
+      ]);
+    });
+
+    it('returns .env and .env.local when environment is empty or whitespace', () => {
+      const candidates = getCandidateEnvFiles(tempDir, '   ');
+      assert.deepStrictEqual(candidates, [
+        path.join(tempDir, '.env'),
+        path.join(tempDir, '.env.local'),
+      ]);
+    });
+
+    it('returns cascading paths in correct precedence order when environment is specified', () => {
+      const candidates = getCandidateEnvFiles(tempDir, 'development');
+      assert.deepStrictEqual(candidates, [
+        path.join(tempDir, '.env'),
+        path.join(tempDir, '.env.development'),
+        path.join(tempDir, '.env.local'),
+        path.join(tempDir, '.env.development.local'),
+      ]);
+    });
+
+    it('trims environment name when resolving candidate paths', () => {
+      const candidates = getCandidateEnvFiles(tempDir, ' production ');
+      assert.deepStrictEqual(candidates, [
+        path.join(tempDir, '.env'),
+        path.join(tempDir, '.env.production'),
+        path.join(tempDir, '.env.local'),
+        path.join(tempDir, '.env.production.local'),
+      ]);
+    });
+  });
+
+  describe('loadCascadingEnv', () => {
+    it('returns empty object when no candidate env files exist', () => {
+      const result = loadCascadingEnv({ rootDir: tempDir, environment: 'development' });
+      assert.deepStrictEqual(result, {});
+    });
+
+    it('loads standard cascading env files (.env < .env.local) when environment is omitted', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'BASE_VAR=base\nSHARED_VAR=from_base');
+      await fs.writeFile(
+        path.join(tempDir, '.env.local'),
+        'LOCAL_VAR=local\nSHARED_VAR=from_local'
+      );
+
+      const result = loadCascadingEnv({ rootDir: tempDir });
+      assert.deepStrictEqual(result, {
+        BASE_VAR: 'base',
+        LOCAL_VAR: 'local',
+        SHARED_VAR: 'from_local',
+      });
+    });
+
+    it('strictly respects priority cascade (.env < .env.{env} < .env.local < .env.{env}.local)', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'VAR1=env\nVAR2=env\nVAR3=env\nVAR4=env');
+      await fs.writeFile(
+        path.join(tempDir, '.env.staging'),
+        'VAR2=staging\nVAR3=staging\nVAR4=staging'
+      );
+      await fs.writeFile(path.join(tempDir, '.env.local'), 'VAR3=local\nVAR4=local');
+      await fs.writeFile(path.join(tempDir, '.env.staging.local'), 'VAR4=staging.local');
+
+      const result = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+      assert.deepStrictEqual(result, {
+        VAR1: 'env',
+        VAR2: 'staging',
+        VAR3: 'local',
+        VAR4: 'staging.local',
+      });
+    });
+
+    it('gracefully skips missing files in the cascade', async () => {
+      // Only .env and .env.development.local exist
+      await fs.writeFile(path.join(tempDir, '.env'), 'FOO=base\nBAR=base');
+      await fs.writeFile(path.join(tempDir, '.env.development.local'), 'FOO=dev_local');
+
+      const result = loadCascadingEnv({ rootDir: tempDir, environment: 'development' });
+      assert.deepStrictEqual(result, {
+        FOO: 'dev_local',
+        BAR: 'base',
+      });
+    });
+
+    it('correctly handles complex syntax edge cases (comments, quotes, multiline, equals)', async () => {
+      const content = [
+        '# This is a comment',
+        'PLAIN_KEY=plain_value',
+        "SINGLE_QUOTED='single quoted'",
+        'DOUBLE_QUOTED="double quoted with # comment char"',
+        'MULTILINE="line 1',
+        'line 2"',
+        'EQUALS_IN_VAL=foo=bar=baz',
+        'EMPTY_VAL=',
+      ].join('\n');
+
+      await fs.writeFile(path.join(tempDir, '.env'), content);
+
+      const result = loadCascadingEnv({ rootDir: tempDir });
+      assert.deepStrictEqual(result, {
+        PLAIN_KEY: 'plain_value',
+        SINGLE_QUOTED: 'single quoted',
+        DOUBLE_QUOTED: 'double quoted with # comment char',
+        MULTILINE: 'line 1\nline 2',
+        EQUALS_IN_VAL: 'foo=bar=baz',
+        EMPTY_VAL: '',
+      });
+    });
+
+    it('re-throws non-ENOENT file reading errors', async () => {
+      // Create a directory named .env so readFileSync fails with EISDIR (or similar non-ENOENT)
+      await fs.mkdir(path.join(tempDir, '.env'));
+
+      assert.throws(() => {
+        loadCascadingEnv({ rootDir: tempDir });
+      });
+    });
+  });
+});

--- a/apps/pawthy/src/loader.ts
+++ b/apps/pawthy/src/loader.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import dotenv from 'dotenv';
+
+/**
+ * Returns candidate .env file paths in order from lowest precedence to highest precedence.
+ *
+ * Cascading precedence (lowest to highest):
+ * .env < .env.{environment} < .env.local < .env.{environment}.local
+ */
+export function getCandidateEnvFiles(rootDir: string, environment?: string): string[] {
+  const baseDir = path.resolve(rootDir);
+  const candidateNames: string[] = ['.env'];
+
+  if (environment && environment.trim() !== '') {
+    const env = environment.trim();
+    candidateNames.push(`.env.${env}`);
+    candidateNames.push('.env.local');
+    candidateNames.push(`.env.${env}.local`);
+  } else {
+    candidateNames.push('.env.local');
+  }
+
+  return candidateNames.map((filename) => path.join(baseDir, filename));
+}
+
+/**
+ * Loads and merges environment variables from cascading .env files.
+ * Missing files (ENOENT) are gracefully skipped.
+ * Values from higher precedence files override lower precedence files.
+ */
+export function loadCascadingEnv(
+  options: { rootDir?: string; environment?: string } = {}
+): Record<string, string> {
+  const rootDir = options.rootDir || process.cwd();
+  const files = getCandidateEnvFiles(rootDir, options.environment);
+  const result: Record<string, string> = {};
+
+  for (const filePath of files) {
+    try {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const parsed = dotenv.parse(content);
+      Object.assign(result, parsed);
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as NodeJS.ErrnoException).code === 'ENOENT'
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return result;
+}

--- a/apps/pawthy/src/loader_stress.test.ts
+++ b/apps/pawthy/src/loader_stress.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { Command } from 'commander';
+import { getCandidateEnvFiles, loadCascadingEnv } from './loader.js';
+import { resolveFileAndFormat } from './format.js';
+
+describe('Empirical Stress Test Harness - Milestone 2 (.env.* Cascading & CLI Flags)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pawthy-stress-m2-'));
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup error
+    }
+  });
+
+  // =========================================================================
+  // 1. PRIORITY LEVELS CASCADING (.env < .env.staging < .env.local < .env.staging.local)
+  // =========================================================================
+  describe('1. Four Priority Levels Cascading', () => {
+    it('returns candidate file paths in exact order of lowest to highest precedence', () => {
+      const candidates = getCandidateEnvFiles(tempDir, 'staging');
+      assert.deepStrictEqual(candidates, [
+        path.join(tempDir, '.env'),
+        path.join(tempDir, '.env.staging'),
+        path.join(tempDir, '.env.local'),
+        path.join(tempDir, '.env.staging.local'),
+      ]);
+    });
+
+    it('resolves all 4 levels when all 4 files exist simultaneously', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'K1=v1_env\nK2=v2_env\nK3=v3_env\nK4=v4_env');
+      await fs.writeFile(
+        path.join(tempDir, '.env.staging'),
+        'K2=v2_staging\nK3=v3_staging\nK4=v4_staging'
+      );
+      await fs.writeFile(path.join(tempDir, '.env.local'), 'K3=v3_local\nK4=v4_local');
+      await fs.writeFile(path.join(tempDir, '.env.staging.local'), 'K4=v4_staging_local');
+
+      const result = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+      assert.deepStrictEqual(result, {
+        K1: 'v1_env',
+        K2: 'v2_staging',
+        K3: 'v3_local',
+        K4: 'v4_staging_local',
+      });
+    });
+
+    it('verifies Priority 2 (.env.staging) overrides Priority 1 (.env)', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'VAR=base');
+      await fs.writeFile(path.join(tempDir, '.env.staging'), 'VAR=staging');
+
+      const result = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+      assert.strictEqual(result['VAR'], 'staging');
+    });
+
+    it('verifies Priority 3 (.env.local) overrides Priority 2 (.env.staging)', async () => {
+      await fs.writeFile(path.join(tempDir, '.env.staging'), 'VAR=staging');
+      await fs.writeFile(path.join(tempDir, '.env.local'), 'VAR=local');
+
+      const result = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+      assert.strictEqual(result['VAR'], 'local');
+    });
+
+    it('verifies Priority 4 (.env.staging.local) overrides Priority 3 (.env.local)', async () => {
+      await fs.writeFile(path.join(tempDir, '.env.local'), 'VAR=local');
+      await fs.writeFile(path.join(tempDir, '.env.staging.local'), 'VAR=staging_local');
+
+      const result = loadCascadingEnv({ rootDir: tempDir, environment: 'staging' });
+      assert.strictEqual(result['VAR'], 'staging_local');
+    });
+  });
+
+  // =========================================================================
+  // 2. SUBSET EXISTENCE COMBINATIONS (All 16 combinations of 4 files)
+  // =========================================================================
+  describe('2. Precedence Combinations for All 16 File Existence Subsets', () => {
+    const filesSpec = [
+      { name: '.env', tag: 'P1_ENV', priority: 1 },
+      { name: '.env.staging', tag: 'P2_STAGING', priority: 2 },
+      { name: '.env.local', tag: 'P3_LOCAL', priority: 3 },
+      { name: '.env.staging.local', tag: 'P4_STAGING_LOCAL', priority: 4 },
+    ];
+
+    // Loop through all 2^4 = 16 combinations
+    for (let mask = 0; mask < 16; mask++) {
+      const activeFiles = filesSpec.filter((_, idx) => (mask & (1 << idx)) !== 0);
+      const activeNames = activeFiles.map((f) => f.name).join(', ') || 'NONE';
+
+      it(`Subset mask ${mask} [${activeNames}]: resolves highest priority file and skips missing files gracefully`, async () => {
+        const subDir = await fs.mkdtemp(path.join(tempDir, `mask-${mask}-`));
+
+        for (const fileObj of activeFiles) {
+          await fs.writeFile(
+            path.join(subDir, fileObj.name),
+            `SHARED_VAR=${fileObj.tag}\nUNIQUE_${fileObj.tag}=yes`
+          );
+        }
+
+        const result = loadCascadingEnv({ rootDir: subDir, environment: 'staging' });
+
+        if (activeFiles.length === 0) {
+          assert.deepStrictEqual(result, {});
+        } else {
+          const highestActive = activeFiles.reduce((prev, curr) =>
+            curr.priority > prev.priority ? curr : prev
+          );
+
+          // Highest priority existing file wins
+          assert.strictEqual(
+            result['SHARED_VAR'],
+            highestActive.tag,
+            `In subset [${activeNames}], expected SHARED_VAR to be '${highestActive.tag}' but got '${result['SHARED_VAR']}'`
+          );
+
+          // Unique keys from all existing files are merged
+          for (const fileObj of activeFiles) {
+            assert.strictEqual(result[`UNIQUE_${fileObj.tag}`], 'yes');
+          }
+        }
+      });
+    }
+  });
+
+  // =========================================================================
+  // 3. EDGE CASE CONTENT SYNTAX PARSING
+  // =========================================================================
+  describe('3. Edge Case Content Syntax Parsing', () => {
+    it('parses values containing multiple equal signs correctly', async () => {
+      await fs.writeFile(
+        path.join(tempDir, '.env'),
+        'URL=https://example.com/api?a=1&b=2\nEQUALS====\nCOMPLEX=foo=bar=baz'
+      );
+      const result = loadCascadingEnv({ rootDir: tempDir });
+      assert.strictEqual(result['URL'], 'https://example.com/api?a=1&b=2');
+      assert.strictEqual(result['EQUALS'], '===');
+      assert.strictEqual(result['COMPLEX'], 'foo=bar=baz');
+    });
+
+    it('handles trailing whitespace for unquoted vs quoted values', async () => {
+      await fs.writeFile(
+        path.join(tempDir, '.env'),
+        'UNQUOTED=value   \nQUOTED="value   "\nSINGLE_QUOTED=\'value   \''
+      );
+      const result = loadCascadingEnv({ rootDir: tempDir });
+      assert.strictEqual(result['UNQUOTED'], 'value');
+      assert.strictEqual(result['QUOTED'], 'value   ');
+      assert.strictEqual(result['SINGLE_QUOTED'], 'value   ');
+    });
+
+    it('parses multiline values enclosed in double quotes', async () => {
+      await fs.writeFile(path.join(tempDir, '.env'), 'MULTILINE="line 1\nline 2\nline 3"');
+      const result = loadCascadingEnv({ rootDir: tempDir });
+      assert.strictEqual(result['MULTILINE'], 'line 1\nline 2\nline 3');
+    });
+
+    it('ignores commented lines and handles inline comments correctly', async () => {
+      await fs.writeFile(
+        path.join(tempDir, '.env'),
+        '# FULL_COMMENT=ignored\n  # INDENTED_COMMENT=ignored\nINLINE=hello # inline comment\nQUOTED_HASH="val # hash"'
+      );
+      const result = loadCascadingEnv({ rootDir: tempDir });
+      assert.strictEqual(result['FULL_COMMENT'], undefined);
+      assert.strictEqual(result['INDENTED_COMMENT'], undefined);
+      assert.strictEqual(result['INLINE'], 'hello');
+      assert.strictEqual(result['QUOTED_HASH'], 'val # hash');
+    });
+
+    it('handles empty strings, quotes, and escaped quotes', async () => {
+      await fs.writeFile(
+        path.join(tempDir, '.env'),
+        'EMPTY=\nEMPTY_DBL=""\nEMPTY_SGL=\'\'\nESCAPED="hello \\"world\\""\nSINGLE=\'hello "world"\''
+      );
+      const result = loadCascadingEnv({ rootDir: tempDir });
+      assert.strictEqual(result['EMPTY'], '');
+      assert.strictEqual(result['EMPTY_DBL'], '');
+      assert.strictEqual(result['EMPTY_SGL'], '');
+      assert.strictEqual(result['ESCAPED'], 'hello \\"world\\"');
+      assert.strictEqual(result['SINGLE'], 'hello "world"');
+    });
+
+    it('handles export prefix and leading/trailing spaces around key and equals', async () => {
+      await fs.writeFile(
+        path.join(tempDir, '.env'),
+        'export EXPORTED=true\n  SPACED_KEY  =  spaced_value  '
+      );
+      const result = loadCascadingEnv({ rootDir: tempDir });
+      assert.strictEqual(result['EXPORTED'], 'true');
+      assert.strictEqual(result['SPACED_KEY'], 'spaced_value');
+    });
+  });
+
+  // =========================================================================
+  // 4. CLI OPTION BEHAVIOR: -f OVERRIDE vs -E FLAG
+  // =========================================================================
+  describe('4. CLI Option Non-Interference (-f, --file vs -E, --env)', () => {
+    function resolveCliOptions(args: string[]) {
+      const cmd = new Command('test')
+        .option('-f, --file <path>', 'Secret file')
+        .option('-F, --format <format>', 'Secret format')
+        .option('-E, --env <environment>', 'Environment');
+
+      cmd.parse(args, { from: 'user' });
+      const opts = cmd.opts();
+
+      const isFileExplicit = cmd.getOptionValueSource('file') === 'cli';
+      const isFormatExplicit = cmd.getOptionValueSource('format') === 'cli';
+
+      const resolved = resolveFileAndFormat(opts.file, opts.format);
+      let file = resolved.file;
+      const format = resolved.format;
+
+      if (opts.env && !isFileExplicit && !isFormatExplicit && format === 'env') {
+        file = `.env.${opts.env}`;
+      }
+
+      const shouldCascade = !isFileExplicit && !isFormatExplicit && format === 'env';
+
+      return { file, format, isFileExplicit, isFormatExplicit, shouldCascade, opts };
+    }
+
+    it('pawthy push -E staging -> defaults to .env.staging and enables cascading', () => {
+      const res = resolveCliOptions(['-E', 'staging']);
+      assert.strictEqual(res.file, '.env.staging');
+      assert.strictEqual(res.shouldCascade, true);
+    });
+
+    it('pawthy push -E staging -f custom.env -> explicit -f overrides file and disables cascading', () => {
+      const res = resolveCliOptions(['-E', 'staging', '-f', 'custom.env']);
+      assert.strictEqual(res.file, 'custom.env');
+      assert.strictEqual(res.shouldCascade, false);
+      assert.strictEqual(res.isFileExplicit, true);
+    });
+
+    it('pawthy push -E staging -f .env -> explicit -f .env overrides file and disables cascading', () => {
+      const res = resolveCliOptions(['-E', 'staging', '-f', '.env']);
+      assert.strictEqual(res.file, '.env');
+      assert.strictEqual(res.shouldCascade, false);
+      assert.strictEqual(res.isFileExplicit, true);
+    });
+
+    it('pawthy push -f custom.env -> explicit -f disables cascading', () => {
+      const res = resolveCliOptions(['-f', 'custom.env']);
+      assert.strictEqual(res.file, 'custom.env');
+      assert.strictEqual(res.shouldCascade, false);
+      assert.strictEqual(res.isFileExplicit, true);
+    });
+
+    it('pawthy push (no flags) -> defaults to .env and enables cascading (.env < .env.local)', () => {
+      const res = resolveCliOptions([]);
+      assert.strictEqual(res.file, '.env');
+      assert.strictEqual(res.shouldCascade, true);
+    });
+
+    it('pawthy pull -E staging -> target .env.staging', () => {
+      const res = resolveCliOptions(['-E', 'staging']);
+      assert.strictEqual(res.file, '.env.staging');
+    });
+
+    it('pawthy pull -E staging -f custom.env -> explicit -f overrides -E flag to custom.env', () => {
+      const res = resolveCliOptions(['-E', 'staging', '-f', 'custom.env']);
+      assert.strictEqual(res.file, 'custom.env');
+      assert.strictEqual(res.isFileExplicit, true);
+    });
+
+    it('pawthy pull -E staging -f .env -> explicit -f overrides -E flag to .env', () => {
+      const res = resolveCliOptions(['-E', 'staging', '-f', '.env']);
+      assert.strictEqual(res.file, '.env');
+      assert.strictEqual(res.isFileExplicit, true);
+    });
+
+    it('pawthy pull -f custom.env -> target custom.env', () => {
+      const res = resolveCliOptions(['-f', 'custom.env']);
+      assert.strictEqual(res.file, 'custom.env');
+    });
+
+    it('pawthy pull (no flags) -> target .env', () => {
+      const res = resolveCliOptions([]);
+      assert.strictEqual(res.file, '.env');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Enhances Pawthy CLI (`pawthy pull` and `pawthy push`) to support `.env.*` environment variants with proper priority cascading.

### Proposed Changes
- **Modular Environment Loader:** Created `apps/pawthy/src/loader.ts` supporting cascading resolution order:
  1. `.env` (Lowest)
  2. `.env.{env}`
  3. `.env.local`
  4. `.env.{env}.local` (Highest)
- **CLI Options:** Supported `-E, --env <environment>` option in `pawthy pull` and `pawthy push`.
- **Non-Interference Guard:** Explicit `-f, --file` flag overrides environment cascading to target specific custom files.
- **Empirical Stress Test Suites:** Added `loader.test.ts`, `loader_stress.test.ts`, and `cascade_stress.test.ts`.

Fixes #63