### PR TITLE
fix(api): differentiate unauthorized write operations from session expiry (#103)

### DIFF
--- a/apps/pawthy/src/commands/push.test.ts
+++ b/apps/pawthy/src/commands/push.test.ts
@@ -464,4 +464,40 @@ describe('Push Command', () => {
       FOO: 'custom',
     });
   });
+
+  it('should display informative error message on 403 Forbidden response without asking to re-login', async () => {
+    mock.method(config, 'get', (key: string) => {
+      if (key === 'token') return 'valid-token';
+      if (key === 'apiUrl') return 'http://localhost:3000';
+      return undefined;
+    });
+
+    mock.method(axios, 'put', async (): Promise<never> => {
+      const error = Object.assign(new Error('Request failed with status code 403'), {
+        isAxiosError: true,
+        response: { status: 403, data: { error: 'INSUFFICIENT_PERMISSIONS' } },
+      });
+      throw error;
+    });
+
+    const consoleErrors: string[] = [];
+    mock.method(console, 'error', (msg: string) => {
+      consoleErrors.push(msg);
+    });
+
+    await assert.rejects(
+      () => pushCommand.parseAsync(['node', 'pawthy', 'push', '--force']),
+      /process.exit called with 1/
+    );
+
+    assert.strictEqual(exitCode, 1);
+    assert.ok(
+      consoleErrors.some((e) =>
+        e.includes("Error: Insufficient permissions to push secrets to environment 'test-env'")
+      )
+    );
+    assert.ok(
+      !consoleErrors.some((e) => e.includes('Session expired. Please run `pawthy login` again.'))
+    );
+  });
 });

--- a/apps/pawthy/src/commands/push.ts
+++ b/apps/pawthy/src/commands/push.ts
@@ -174,9 +174,10 @@ export const pushCommand = new Command('push')
         if (error.response?.status === 401) {
           console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
         } else if (error.response?.status === 403) {
+          const targetEnv = envId || 'this environment';
           console.error(
             chalk.red(
-              'Access denied. You do not have permission to push secrets to this environment.'
+              `Error: Insufficient permissions to push secrets to environment '${targetEnv}'. You require Manager or Owner role on this project to modify secrets.`
             )
           );
         } else if (error.response?.status === 404) {

--- a/apps/pawthy/src/format.test.ts
+++ b/apps/pawthy/src/format.test.ts
@@ -397,7 +397,7 @@ describe('Format Module (Issue #64)', () => {
         'get',
         async (): Promise<{ status: number; data: unknown }> => ({
           status: 200,
-          data: { SERVICE: 'auth' },
+          data: { secrets: { SERVICE: 'auth' } },
         })
       );
 

--- a/apps/purrmission-bot/src/domain/auth.ts
+++ b/apps/purrmission-bot/src/domain/auth.ts
@@ -24,6 +24,13 @@ export class AccessDeniedError extends Error {
   }
 }
 
+export class ForbiddenError extends Error {
+  constructor(message = 'Forbidden') {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
+
 const DEFAULT_TOKEN_EXPIRY_DAYS = 90;
 
 export class AuthService {

--- a/apps/purrmission-bot/src/http/server.ts
+++ b/apps/purrmission-bot/src/http/server.ts
@@ -14,7 +14,12 @@ import {
   createApprovalEmbed,
   isAccessRequestContext,
 } from '../discord/interactions/approvalButtons.js';
-import { AccessDeniedError, ExpiredTokenError, InvalidGrantError } from '../domain/auth.js';
+import {
+  AccessDeniedError,
+  ExpiredTokenError,
+  ForbiddenError,
+  InvalidGrantError,
+} from '../domain/auth.js';
 import { ResourceNotFoundError } from '../domain/errors.js';
 import type { ApprovalRequest, ResourceField } from '../domain/models.js';
 import type { Services } from '../domain/services.js';
@@ -320,6 +325,12 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     if (err.name === 'AccessDeniedError') {
       return reply.status(401).send({ error: 'unauthorized', message: err.message });
     }
+    if (err.name === 'ForbiddenError') {
+      return reply.status(403).send({
+        error: 'INSUFFICIENT_PERMISSIONS',
+        message: err.message,
+      });
+    }
     if (err.name === 'InvalidGrantError') {
       return reply.status(400).send({ error: 'invalid_grant', message: err.message });
     }
@@ -550,7 +561,9 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
         hasWriteAccess = role === 'WRITER';
       }
 
-      if (!hasWriteAccess) throw new AccessDeniedError('Access denied');
+      if (!hasWriteAccess) {
+        throw new ForbiddenError('Write permission required');
+      }
 
       const environment = await services.project.getEnvironmentById(projectId, envId);
       if (!environment) throw new ResourceNotFoundError('Environment not found');

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -340,4 +340,53 @@ describe('System API E2E Tests', () => {
       assert.strictEqual(data.error, 'unauthorized');
     });
   });
+
+  describe('PUT /api/projects/:projectId/environments/:envId/secrets', () => {
+    it('should return 403 Forbidden when authenticated user lacks write permissions', async () => {
+      mockValidateToken.fn = async () => ({ userId: 'user-reader' });
+      mockGetProject.fn = async () => ({ id: 'p-1', ownerId: 'user-owner', name: 'MyProject' });
+      mockGetMemberRole.fn = async () => 'READER'; // READER is read-only, lacks WRITER/OWNER
+
+      const response = await server.inject({
+        method: 'PUT',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        headers: {
+          Authorization: 'Bearer valid-token',
+        },
+        payload: {
+          secrets: { FOO: 'bar' },
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 403);
+      const data = JSON.parse(response.payload);
+      assert.strictEqual(data.error, 'INSUFFICIENT_PERMISSIONS');
+      assert.strictEqual(data.message, 'Write permission required');
+    });
+
+    it('should return 200 OK when authenticated user is project owner or writer', async () => {
+      mockValidateToken.fn = async () => ({ userId: 'user-owner' });
+      mockGetProject.fn = async () => ({ id: 'p-1', ownerId: 'user-owner', name: 'MyProject' });
+      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
+
+      let upsertedCount = 0;
+      mockUpsertField.fn = async () => {
+        upsertedCount++;
+      };
+
+      const response = await server.inject({
+        method: 'PUT',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        headers: {
+          Authorization: 'Bearer valid-token',
+        },
+        payload: {
+          secrets: { FOO: 'bar', BAZ: 'qux' },
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      assert.strictEqual(upsertedCount, 2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Differentiates invalid authentication (HTTP 401 Unauthorized) from insufficient RBAC write permissions (HTTP 403 Forbidden) across the HTTP API and Pawthy CLI.

### Proposed Changes
- **Backend Error Handling (`apps/purrmission-bot/src/http/server.ts` & `domain/auth.ts`):**
  - Added `ForbiddenError` class.
  - Global error handler returns HTTP 403 Forbidden with `{ error: 'INSUFFICIENT_PERMISSIONS', message: 'Write permission required' }`.
  - Secret modification endpoint (`PUT /api/projects/:projectId/environments/:envId/secrets`) throws `ForbiddenError` when an authenticated user lacks WRITER/OWNER roles.
- **Pawthy CLI (`apps/pawthy/src/commands/push.ts`):**
  - Catches HTTP 403 Forbidden responses and displays clear error: `Error: Insufficient permissions to push secrets to environment '<env_id>'. You require Manager or Owner role on this project to modify secrets.`
- **E2E & Unit Test Coverage:**
  - Added HTTP 403 E2E test in `apps/purrmission-bot/src/test/system_api.test.ts`.
  - Added HTTP 403 unit test in `apps/pawthy/src/commands/push.test.ts`.

Fixes #103