### PR TITLE
docs(github): update default issue template labels to type:* format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to help us improve
 title: '[BUG] '
-labels: ['bug']
+labels: ['type: bug']
 assignees: []
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest an idea for this project
 title: '[FEAT] '
-labels: ['enhancement']
+labels: ['type: feature']
 assignees: []
 ---
 


### PR DESCRIPTION
## Summary
Updates the GitHub issue templates (`bug_report.md` and `feature_request.md`) to use the new standardized `type: bug` and `type: feature` labels as part of the repository label overhaul.

## Changes Made
- Update `labels` field in `.github/ISSUE_TEMPLATE/bug_report.md` to `['type: bug']`
- Update `labels` field in `.github/ISSUE_TEMPLATE/feature_request.md` to `['type: feature']`