### PR TITLE
feat: cut Discord commands, interactions, and HTTP routes over to DomainPorts

### DIFF
--- a/apps/purrmission-bot/src/discord/commands/approve.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/approve.test.ts
@@ -16,8 +16,9 @@ describe('Approve Command', () => {
     } as unknown as ChatInputCommandInteraction;
 
     const services = {
-      approval: {
-        recordDecision: mock.fn(async () => ({ success: true })),
+      ports: {
+        recordApprovalDecision: mock.fn(async () => ({ success: true })),
+        getApprovalRequest: mock.fn(async () => ({ id: 'req-123', resourceId: 'res-1' })),
       },
     } as unknown as Services;
 
@@ -28,13 +29,19 @@ describe('Approve Command', () => {
       1
     );
     assert.strictEqual(
-      (services.approval.recordDecision as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      (services.ports.recordApprovalDecision as unknown as ReturnType<typeof mock.fn>).mock.calls
+        .length,
       1
     );
     assert.deepStrictEqual(
-      (services.approval.recordDecision as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
-        .arguments,
-      ['req-123', 'APPROVE', 'guardian-1']
+      (services.ports.recordApprovalDecision as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
+        .arguments[1],
+      'req-123'
+    );
+    assert.deepStrictEqual(
+      (services.ports.recordApprovalDecision as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
+        .arguments[2],
+      'APPROVE'
     );
     assert.strictEqual(mockReply.mock.calls.length, 1);
     assert.match(mockReply.mock.calls[0].arguments[0].content, /APPROVED/);
@@ -51,8 +58,8 @@ describe('Approve Command', () => {
     } as unknown as ChatInputCommandInteraction;
 
     const services = {
-      approval: {
-        recordDecision: mock.fn(async () => ({ success: false, error: 'Not found' })),
+      ports: {
+        recordApprovalDecision: mock.fn(async () => ({ success: false, error: 'Not found' })),
       },
     } as unknown as Services;
 
@@ -75,8 +82,8 @@ describe('Approve Command', () => {
     } as unknown as ChatInputCommandInteraction;
 
     const services = {
-      approval: {
-        recordDecision: mock.fn(async () => {
+      ports: {
+        recordApprovalDecision: mock.fn(async () => {
           throw new Error('Database error');
         }),
       },

--- a/apps/purrmission-bot/src/discord/commands/decision.ts
+++ b/apps/purrmission-bot/src/discord/commands/decision.ts
@@ -2,6 +2,7 @@ import { ChatInputCommandInteraction, Colors } from 'discord.js';
 import type { Services } from '../../domain/services.js';
 import { logger } from '../../logging/logger.js';
 import type { ApprovalDecision, ApprovalRequest } from '../../domain/models.js';
+import type { Principal } from '../../domain/policy.js';
 
 /**
  * Handle approval/denial decision commands.
@@ -18,7 +19,16 @@ export async function handleDecisionCommand(
   const icon = decision === 'APPROVE' ? '✅' : '🚫'; // correction: DENY usually 🚫 or ❌
 
   try {
-    const result = await services.approval.recordDecision(requestId, decision, userId);
+    const principal: Principal = {
+      id: userId,
+      type: 'DISCORD_USER',
+      subjectId: userId,
+      authKind: 'DISCORD',
+      scopes: [],
+      audience: 'discord',
+    };
+
+    const result = await services.ports.recordApprovalDecision(principal, requestId, decision);
 
     if (result.success) {
       await interaction.reply({
@@ -27,42 +37,13 @@ export async function handleDecisionCommand(
       });
 
       // Update original message
-      const { request } = result;
+      const request = await services.ports.getApprovalRequest(principal, requestId);
       if (request) {
         await updateDiscordMessage(interaction, request, decision, userId, actionPastTense);
       }
-
-      // Handle Callback logic
-      if (result.action && result.action.type === 'CALL_CALLBACK_URL') {
-        const { url, status } = result.action;
-        try {
-          // Fire and forget fetch
-          fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              requestId,
-              status,
-              resolvedBy: userId,
-              resolvedAt: new Date().toISOString(),
-              context: request?.context,
-            }),
-          })
-            .then((res) => {
-              if (!res.ok) {
-                logger.warn('Callback URL returned non-200 status', { url, status: res.status });
-              }
-            })
-            .catch((err) => {
-              logger.error('Failed to call callback URL', { url, err });
-            });
-        } catch (err) {
-          logger.error('Error initiating callback request', { err });
-        }
-      }
     } else {
       await interaction.reply({
-        content: `❌ Failed to ${decision.toLowerCase()} request: ${result.error}`,
+        content: `❌ Failed to ${decision.toLowerCase()} request.`,
         ephemeral: true,
       });
     }

--- a/apps/purrmission-bot/src/discord/commands/decision.ts
+++ b/apps/purrmission-bot/src/discord/commands/decision.ts
@@ -1,8 +1,7 @@
 import { ChatInputCommandInteraction, Colors } from 'discord.js';
 import type { Services } from '../../domain/services.js';
 import { logger } from '../../logging/logger.js';
-import type { ApprovalDecision, ApprovalRequest } from '../../domain/models.js';
-import type { Principal } from '../../domain/policy.js';
+import type { ApprovalDecision, ApprovalRequest, Principal } from '../../domain/models.js';
 
 /**
  * Handle approval/denial decision commands.

--- a/apps/purrmission-bot/src/discord/commands/deny.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/deny.test.ts
@@ -16,8 +16,9 @@ describe('Deny Command', () => {
     } as unknown as ChatInputCommandInteraction;
 
     const services = {
-      approval: {
-        recordDecision: mock.fn(async () => ({ success: true })),
+      ports: {
+        recordApprovalDecision: mock.fn(async () => ({ success: true })),
+        getApprovalRequest: mock.fn(async () => ({ id: 'req-123', resourceId: 'res-1' })),
       },
     } as unknown as Services;
 
@@ -28,13 +29,19 @@ describe('Deny Command', () => {
       1
     );
     assert.strictEqual(
-      (services.approval.recordDecision as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      (services.ports.recordApprovalDecision as unknown as ReturnType<typeof mock.fn>).mock.calls
+        .length,
       1
     );
     assert.deepStrictEqual(
-      (services.approval.recordDecision as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
-        .arguments,
-      ['req-123', 'DENY', 'guardian-1']
+      (services.ports.recordApprovalDecision as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
+        .arguments[1],
+      'req-123'
+    );
+    assert.deepStrictEqual(
+      (services.ports.recordApprovalDecision as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
+        .arguments[2],
+      'DENY'
     );
     assert.strictEqual(mockReply.mock.calls.length, 1);
     assert.match(mockReply.mock.calls[0].arguments[0].content, /DENIED/);
@@ -51,8 +58,8 @@ describe('Deny Command', () => {
     } as unknown as ChatInputCommandInteraction;
 
     const services = {
-      approval: {
-        recordDecision: mock.fn(async () => ({ success: false, error: 'Not found' })),
+      ports: {
+        recordApprovalDecision: mock.fn(async () => ({ success: false, error: 'Not found' })),
       },
     } as unknown as Services;
 
@@ -75,8 +82,8 @@ describe('Deny Command', () => {
     } as unknown as ChatInputCommandInteraction;
 
     const services = {
-      approval: {
-        recordDecision: mock.fn(async () => {
+      ports: {
+        recordApprovalDecision: mock.fn(async () => {
           throw new Error('Database error');
         }),
       },

--- a/apps/purrmission-bot/src/discord/interactions/approvalButtons.ts
+++ b/apps/purrmission-bot/src/discord/interactions/approvalButtons.ts
@@ -15,6 +15,7 @@ import {
 import type { Services } from '../../domain/services.js';
 import type { ApprovalDecision, AccessRequestContext } from '../../domain/models.js';
 import type { Repositories } from '../../domain/repositories.js';
+import type { Principal } from '../../domain/policy.js';
 import { generateTOTPCode } from '../../domain/totp.js';
 import { logger } from '../../logging/logger.js';
 
@@ -105,12 +106,30 @@ export async function handleApprovalButton(
   await interaction.deferUpdate();
 
   try {
-    // Record the decision
-    const result = await services.approval.recordDecision(requestId, action, userId);
+    const principal: Principal = {
+      id: userId,
+      type: 'DISCORD_USER',
+      subjectId: userId,
+      authKind: 'DISCORD',
+      scopes: [],
+      audience: 'discord',
+    };
+
+    // Record the decision via the ports layer
+    const result = await services.ports.recordApprovalDecision(principal, requestId, action);
 
     if (!result.success) {
       await interaction.followUp({
-        content: `❌ ${result.error}`,
+        content: `❌ Request decision recording failed.`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const request = await services.ports.getApprovalRequest(principal, requestId);
+    if (!request) {
+      await interaction.followUp({
+        content: `❌ Could not retrieve approval request details.`,
         ephemeral: true,
       });
       return;
@@ -152,12 +171,12 @@ export async function handleApprovalButton(
     });
 
     // If approved, reveal the data to the requester
-    if (action === 'APPROVE' && result.request) {
-      const context = result.request.context;
+    if (action === 'APPROVE') {
+      const context = request.context;
       if (isAccessRequestContext(context)) {
         await revealAccessToRequester(
           context,
-          result.request.resourceId,
+          request.resourceId,
           repositories,
           services,
           discordClient
@@ -166,8 +185,8 @@ export async function handleApprovalButton(
     }
 
     // If denied, notify the requester via DM
-    if (action === 'DENY' && result.request) {
-      const context = result.request.context;
+    if (action === 'DENY') {
+      const context = request.context;
       if (isAccessRequestContext(context)) {
         try {
           const user = await discordClient.users.fetch(context.requesterId);
@@ -180,15 +199,6 @@ export async function handleApprovalButton(
           });
         }
       }
-    }
-
-    // Handle callback if configured
-    if (result.action?.type === 'CALL_CALLBACK_URL') {
-      logger.info('Callback URL configured', {
-        url: result.action.url,
-        status: result.action.status,
-      });
-      // TODO: Implement actual HTTP callback
     }
 
     logger.info('Approval button processed', { requestId, action, userId });

--- a/apps/purrmission-bot/src/discord/interactions/approvalButtons.ts
+++ b/apps/purrmission-bot/src/discord/interactions/approvalButtons.ts
@@ -13,9 +13,8 @@ import {
   ButtonStyle,
 } from 'discord.js';
 import type { Services } from '../../domain/services.js';
-import type { ApprovalDecision, AccessRequestContext } from '../../domain/models.js';
+import type { ApprovalDecision, AccessRequestContext, Principal } from '../../domain/models.js';
 import type { Repositories } from '../../domain/repositories.js';
-import type { Principal } from '../../domain/policy.js';
 import { generateTOTPCode } from '../../domain/totp.js';
 import { logger } from '../../logging/logger.js';
 

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -39,6 +39,8 @@ import {
 import { getPrismaClient } from '../infra/prismaClient.js';
 import { generateTOTPCode } from './totp.js';
 import { computeKeyedDigest, deterministicUUID } from './crypto.js';
+import { DomainPorts } from './ports.js';
+import { DomainPortsImpl } from './ports_impl.js';
 
 /**
  * Service dependencies.
@@ -1715,6 +1717,7 @@ export interface Services {
   audit: AuditService;
   auth: AuthService;
   project: ProjectService;
+  ports: DomainPorts;
 }
 
 /**
@@ -1730,12 +1733,14 @@ export function createServices(baseDeps: { repositories: Repositories }): Servic
   const approval = new ApprovalService(fullDeps);
   fullDeps.approval = approval;
   const resource = new ResourceService(fullDeps);
+  const project = new ProjectService(baseDeps.repositories.projects, resource);
 
   return {
     approval,
     resource,
     audit,
     auth: new AuthService(baseDeps.repositories.auth, baseDeps.repositories.credentials),
-    project: new ProjectService(baseDeps.repositories.projects, resource),
+    project,
+    ports: new DomainPortsImpl(project, resource, approval),
   };
 }

--- a/apps/purrmission-bot/src/http/server.ts
+++ b/apps/purrmission-bot/src/http/server.ts
@@ -4,16 +4,10 @@
  * Provides the HTTP API for external services to request approvals.
  */
 import formBody from '@fastify/formbody';
-import type { Client, TextChannel } from 'discord.js';
+import type { Client } from 'discord.js';
 import Fastify, { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 
-import {
-  createAccessRequestEmbed,
-  createApprovalButtons,
-  createApprovalEmbed,
-  isAccessRequestContext,
-} from '../discord/interactions/approvalButtons.js';
 import {
   AccessDeniedError,
   ExpiredTokenError,
@@ -22,7 +16,6 @@ import {
   SlowDownError,
 } from '../domain/auth.js';
 import { ResourceNotFoundError } from '../domain/errors.js';
-import type { ApprovalRequest, ResourceField } from '../domain/models.js';
 import type { Services } from '../domain/services.js';
 import { logger } from '../logging/logger.js';
 import crypto from 'node:crypto';
@@ -201,16 +194,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     }
     const approvalRequest = result.request;
 
-    // Send Discord message to guardians
-    try {
-      await sendApprovalMessage(deps, result, body.channelId);
-    } catch (error) {
-      logger.warn('Failed to send Discord notification for approval request', {
-        requestId: approvalRequest.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      // Continue anyway - the request was created successfully
-    }
+    // Discord notification is enqueued via the transactional outbox and processed by the worker
 
     logger.info('Approval request created via API', {
       requestId: approvalRequest.id,
@@ -236,32 +220,44 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
       const { id } = request.params;
       const userId = request.user.id;
 
-      const approvalRequest = await services.approval.getApprovalRequest(id);
-      if (!approvalRequest) {
-        return reply.status(404).send({
-          error: 'Request not found',
-        });
-      }
-
-      // Exact-object authorization
-      const isRequester = approvalRequest.requesterId === userId;
-      const isGuardian = await services.resource.isGuardian(approvalRequest.resourceId, userId);
-
-      if (!isRequester && !isGuardian) {
-        throw new AccessDeniedError(
-          'Access denied: You do not have permission to view this request.'
-        );
-      }
-
-      return {
-        requestId: approvalRequest.id,
-        resourceId: approvalRequest.resourceId,
-        status: approvalRequest.status,
-        createdAt: approvalRequest.createdAt.toISOString(),
-        expiresAt: approvalRequest.expiresAt.toISOString(),
-        resolvedBy: approvalRequest.resolvedBy ?? null,
-        resolvedAt: approvalRequest.resolvedAt?.toISOString() ?? null,
+      const rawPrincipal = (request as any).principal;
+      const principal = {
+        type: rawPrincipal?.type || 'DISCORD_USER',
+        id: rawPrincipal?.id || rawPrincipal?.subjectId || rawPrincipal?.userId || userId,
+        authKind: rawPrincipal?.authKind || 'DISCORD',
+        actorDiscordId:
+          rawPrincipal?.actorDiscordId ||
+          rawPrincipal?.id ||
+          rawPrincipal?.subjectId ||
+          rawPrincipal?.userId ||
+          userId,
       };
+
+      try {
+        const approvalRequest = await services.ports.getApprovalRequest(principal, id);
+        if (!approvalRequest) {
+          return reply.status(404).send({
+            error: 'Request not found',
+          });
+        }
+
+        return {
+          requestId: approvalRequest.id,
+          resourceId: approvalRequest.resourceId,
+          status: approvalRequest.status,
+          createdAt: approvalRequest.createdAt.toISOString(),
+          expiresAt: approvalRequest.expiresAt.toISOString(),
+          resolvedBy: approvalRequest.resolvedBy ?? null,
+          resolvedAt: approvalRequest.resolvedAt?.toISOString() ?? null,
+        };
+      } catch (err) {
+        if (err instanceof ForbiddenError) {
+          throw new AccessDeniedError(
+            'Access denied: You do not have permission to view this request.'
+          );
+        }
+        throw err;
+      }
     }
   );
 
@@ -553,6 +549,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     },
     async (req, rep) => {
       const { projectId, envId } = req.params as { projectId: string; envId: string };
+      const { grantId } = (req.query || {}) as { grantId?: string };
       const userId = req.user.id;
 
       const project = await services.project.getProject(projectId);
@@ -565,140 +562,89 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
 
       const resourceId = environment.resourceId;
 
-      // Project owner has immediate access
-      if (project.ownerId === userId) {
-        const fields = await services.resource.listFields(resourceId);
-        return { secrets: fieldsToSecrets(fields) };
-      }
+      const rawPrincipal = (req as any).principal;
+      const principal = {
+        type: rawPrincipal?.type || 'DISCORD_USER',
+        id: rawPrincipal?.id || rawPrincipal?.subjectId || rawPrincipal?.userId || userId,
+        authKind: rawPrincipal?.authKind || 'DISCORD',
+        actorDiscordId:
+          rawPrincipal?.actorDiscordId ||
+          rawPrincipal?.id ||
+          rawPrincipal?.subjectId ||
+          rawPrincipal?.userId ||
+          userId,
+      };
 
-      // Project Members (READER or WRITER) have immediate access
-      const memberRole = await services.project.getMemberRole(projectId, userId);
-      if (memberRole === 'READER' || memberRole === 'WRITER') {
-        const fields = await services.resource.listFields(resourceId);
-        return { secrets: fieldsToSecrets(fields) };
-      }
-
-      // Guardians also have immediate access
-      const isGuardian = await services.resource.isGuardian(resourceId, userId);
-      if (isGuardian) {
-        const fields = await services.resource.listFields(resourceId);
-        return { secrets: fieldsToSecrets(fields) };
-      }
-
-      // Fetch the current resource version for V2 state tracking
-      let targetVersion = 'v1';
-      if (typeof services.resource.getResource === 'function') {
-        const resourceObj = await services.resource.getResource(resourceId);
-        targetVersion = resourceObj?.version || 'v1';
-      }
-
-      // Non-owner/non-guardian: Check for active approval or create one
-      let approval: ApprovalRequest | null = await services.approval.findActiveApproval(
-        resourceId,
-        userId,
-        'secrets.read'
-      );
-
-      if (!approval) {
-        // Create a new approval request
-        const result = await services.approval.createApprovalRequest({
-          resourceId,
-          requesterId: userId,
-          requesterType: (req as any).principal?.type || 'DISCORD_USER',
-          authKind: (req as any).principal?.authKind || 'DISCORD',
-          action: 'secrets.read',
-          targetVersion,
-          policyVersion: targetVersion,
-          context: {
-            requesterId: userId,
-            type: 'SECRET_ACCESS',
-            description: `CLI pull request for ${project.name}:${environment.name}`,
-          },
-        });
-
-        if (!result.success || !result.request) {
-          throw new Error(`Failed to create approval request: ${result.error || 'Unknown error'}`);
-        }
-        approval = result.request;
-
-        // Send Discord notification to guardians
-        try {
-          await sendApprovalMessage(deps, result);
-        } catch (notifyError) {
-          logger.warn('Failed to send Discord notification for approval request', {
-            requestId: approval.id,
-            error: notifyError instanceof Error ? notifyError.message : String(notifyError),
-          });
-          // Continue anyway - the request was created successfully
-        }
-      }
-
-      if (!approval) {
-        throw new Error('Approval request could not be found or created');
-      }
-
-      if (approval.status === 'PENDING') {
-        rep.status(202);
-        return {
-          status: 'pending',
-          message: 'Secret access is pending approval in Discord',
-          requestId: approval.id,
-        };
-      }
-
-      if (approval.status === 'APPROVED') {
-        // Find active unconsumed grant
-        let activeGrant = null;
-        if (typeof services.approval.findActiveUnconsumedGrant === 'function') {
-          activeGrant = await services.approval.findActiveUnconsumedGrant(
+      try {
+        // Resolve active grant first if not explicitly passed
+        let resolvedGrantId = grantId;
+        if (!resolvedGrantId) {
+          const activeGrant = await services.approval.findActiveUnconsumedGrant(
             resourceId,
             userId,
             'secrets.read',
             null
           );
+          if (activeGrant) {
+            resolvedGrantId = activeGrant.id;
+          }
         }
 
-        if (activeGrant) {
-          // Atomically consume the grant
-          const prisma = getPrismaClient();
-          try {
-            await prisma.$transaction(async (tx) => {
-              await services.approval.consumeGrant(
-                activeGrant.id,
-                (req as any).principal || {
-                  type: 'DISCORD_USER',
-                  id: userId,
-                  authKind: 'DISCORD',
-                  actorDiscordId: userId,
-                },
-                'secrets.read',
-                targetVersion,
-                targetVersion,
-                tx
+        const secrets = await services.ports.getSecrets(
+          principal,
+          projectId,
+          envId,
+          resolvedGrantId
+        );
+        return { secrets };
+      } catch (err) {
+        if (err instanceof ForbiddenError) {
+          // Check for active approval or create one
+          const approval = await services.approval.findActiveApproval(
+            resourceId,
+            userId,
+            'secrets.read'
+          );
+
+          if (approval) {
+            if (approval.status === 'PENDING') {
+              rep.status(202);
+              return {
+                status: 'pending',
+                message: 'Secret access is pending approval in Discord',
+                requestId: approval.id,
+              };
+            }
+            if (approval.status === 'APPROVED') {
+              throw new AccessDeniedError(
+                'Access denied: Active approval is approved but grant is missing or consumed.'
               );
-            });
-          } catch (consumeErr) {
-            logger.error('Failed to consume approval grant for secrets access', {
-              resourceId,
-              userId,
-              error: consumeErr instanceof Error ? consumeErr.message : String(consumeErr),
-            });
-            throw consumeErr;
+            }
+            throw new AccessDeniedError('Access denied: Secrets access was denied');
           }
-        } else {
-          const hasGrantRepo = !!(services.approval as any).deps?.repositories?.approvalGrants;
-          if (hasGrantRepo) {
-            throw new AccessDeniedError(
-              'Access denied: No active unconsumed approval grant found. Please request approval again.'
+
+          // Create a new approval request
+          const result = await services.ports.createApprovalRequest(
+            principal,
+            resourceId,
+            'secrets.read'
+          );
+          if (!result.success || !result.request) {
+            throw new Error(
+              `Failed to create approval request: ${result.error || 'Unknown error'}`
             );
           }
+          const newApproval = result.request;
+
+          rep.status(202);
+          return {
+            status: 'pending',
+            message: 'Secret access is pending approval in Discord',
+            requestId: newApproval.id,
+          };
         }
-
-        const fields = await services.resource.listFields(resourceId);
-        return { secrets: fieldsToSecrets(fields) };
+        throw err;
       }
-
-      throw new AccessDeniedError('Access denied: Secrets access not approved');
     }
   );
 
@@ -905,93 +851,6 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
 }
 
 /**
- * Send the approval message to Discord.
- */
-async function sendApprovalMessage(
-  deps: HttpServerDeps,
-  result: Awaited<ReturnType<typeof deps.services.approval.createApprovalRequest>>,
-  channelId?: string
-): Promise<void> {
-  const { discordClient } = deps;
-  const { request, resource, guardians } = result;
-
-  if (!request || !resource || !guardians) {
-    return;
-  }
-
-  // Determine which channel to use
-  // Priority: explicit channelId > first guardian's DM > skip
-  let channel: TextChannel | null = null;
-
-  if (channelId) {
-    const fetchedChannel = await discordClient.channels.fetch(channelId).catch(() => null);
-    if (fetchedChannel?.isTextBased() && 'send' in fetchedChannel) {
-      channel = fetchedChannel as TextChannel;
-    }
-  }
-
-  // If no channel specified, try to DM the first guardian
-  // TODO: Implement better notification strategy (e.g., dedicated channel per resource)
-  if (!channel && guardians.length > 0) {
-    try {
-      const owner = guardians.find((g) => g.role === 'OWNER') ?? guardians[0];
-      const user = await discordClient.users.fetch(owner.discordUserId);
-      const dm = await user.createDM();
-
-      // Create and send message
-      const embed = isAccessRequestContext(request.context)
-        ? createAccessRequestEmbed(resource.name, request.context, request.expiresAt)
-        : createApprovalEmbed(resource.name, request.context, request.expiresAt);
-      const buttons = createApprovalButtons(request.id);
-
-      // Mention other guardians
-      const mentions = guardians
-        .filter((g) => g.discordUserId !== owner.discordUserId)
-        .map((g) => `<@${g.discordUserId}>`)
-        .join(' ');
-
-      await dm.send({
-        content: mentions.length > 0 ? `Guardians: ${mentions}` : undefined,
-        embeds: [embed],
-        components: [buttons],
-      });
-
-      logger.info('Sent approval DM to guardian', {
-        requestId: request.id,
-        guardianId: owner.discordUserId,
-      });
-      return;
-    } catch (error) {
-      logger.warn('Failed to DM guardian, trying channel', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
-  // Send to channel if available
-  if (channel) {
-    const embed = isAccessRequestContext(request.context)
-      ? createAccessRequestEmbed(resource.name, request.context, request.expiresAt)
-      : createApprovalEmbed(resource.name, request.context, request.expiresAt);
-    const buttons = createApprovalButtons(request.id);
-
-    // Mention all guardians
-    const mentions = guardians.map((g) => `<@${g.discordUserId}>`).join(' ');
-
-    await channel.send({
-      content: mentions.length > 0 ? `🔐 Approval needed! ${mentions}` : '🔐 Approval needed!',
-      embeds: [embed],
-      components: [buttons],
-    });
-
-    logger.info('Sent approval message to channel', {
-      requestId: request.id,
-      channelId: channel.id,
-    });
-  }
-}
-
-/**
  * Start the HTTP server.
  */
 export async function startHttpServer(
@@ -1004,8 +863,4 @@ export async function startHttpServer(
   logger.info(`HTTP server listening on port ${port}`);
 
   return server;
-}
-
-function fieldsToSecrets(fields: ResourceField[]): Record<string, string> {
-  return Object.fromEntries(fields.map((f) => [f.name, f.value]));
 }

--- a/apps/purrmission-bot/src/http/server.ts
+++ b/apps/purrmission-bot/src/http/server.ts
@@ -16,6 +16,7 @@ import {
   SlowDownError,
 } from '../domain/auth.js';
 import { ResourceNotFoundError } from '../domain/errors.js';
+import type { Principal } from '../domain/models.js';
 import type { Services } from '../domain/services.js';
 import { logger } from '../logging/logger.js';
 import crypto from 'node:crypto';
@@ -80,6 +81,17 @@ function redactBody(body: unknown): unknown {
  */
 export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
   const { services, discordClient } = deps;
+
+  function extractPrincipal(req: FastifyRequest, userId: string): Principal {
+    const raw = (req as any).principal;
+    return {
+      type: raw?.type || 'DISCORD_USER',
+      id: raw?.id || raw?.subjectId || raw?.userId || userId,
+      subjectId: raw?.subjectId || raw?.userId || raw?.id || userId,
+      authKind: raw?.authKind || 'DISCORD',
+      actorDiscordId: raw?.actorDiscordId || raw?.id || raw?.subjectId || raw?.userId || userId,
+    };
+  }
 
   const server = Fastify({
     logger: false, // We use our own logger
@@ -220,18 +232,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
       const { id } = request.params;
       const userId = request.user.id;
 
-      const rawPrincipal = (request as any).principal;
-      const principal = {
-        type: rawPrincipal?.type || 'DISCORD_USER',
-        id: rawPrincipal?.id || rawPrincipal?.subjectId || rawPrincipal?.userId || userId,
-        authKind: rawPrincipal?.authKind || 'DISCORD',
-        actorDiscordId:
-          rawPrincipal?.actorDiscordId ||
-          rawPrincipal?.id ||
-          rawPrincipal?.subjectId ||
-          rawPrincipal?.userId ||
-          userId,
-      };
+      const principal = extractPrincipal(request, userId);
 
       try {
         const approvalRequest = await services.ports.getApprovalRequest(principal, id);
@@ -562,18 +563,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
 
       const resourceId = environment.resourceId;
 
-      const rawPrincipal = (req as any).principal;
-      const principal = {
-        type: rawPrincipal?.type || 'DISCORD_USER',
-        id: rawPrincipal?.id || rawPrincipal?.subjectId || rawPrincipal?.userId || userId,
-        authKind: rawPrincipal?.authKind || 'DISCORD',
-        actorDiscordId:
-          rawPrincipal?.actorDiscordId ||
-          rawPrincipal?.id ||
-          rawPrincipal?.subjectId ||
-          rawPrincipal?.userId ||
-          userId,
-      };
+      const principal = extractPrincipal(req, userId);
 
       try {
         // Resolve active grant first if not explicitly passed
@@ -679,12 +669,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
 
       const resourceId = environment.resourceId;
 
-      const principal = (req as any).principal || {
-        type: 'DISCORD_USER',
-        id: userId,
-        authKind: 'DISCORD',
-        actorDiscordId: userId,
-      };
+      const principal = extractPrincipal(req, userId);
 
       await services.resource.setSecrets(resourceId, secrets, principal);
 

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert';
 import type { Client } from 'discord.js';
 import type { FastifyInstance } from 'fastify';
 import type { Services } from '../domain/services.js';
+import { ForbiddenError } from '../domain/auth.js';
+import { ResourceNotFoundError } from '../domain/errors.js';
 import { createHttpServer } from '../http/server.js';
 
 // Minimal mock Discord client
@@ -67,6 +69,14 @@ describe('System API E2E Tests', () => {
       getApprovalRequest: (id: string) => mockGetApprovalRequest.fn(id),
       findActiveApproval: (resourceId: string, userId: string) =>
         mockFindActiveApproval.fn(resourceId, userId),
+      findActiveUnconsumedGrant: async (resourceId: string, userId: string) => {
+        const approval = await mockFindActiveApproval.fn(resourceId, userId);
+        if (approval && approval.status === 'APPROVED') {
+          return { id: 'mock-grant-id', resourceId, userId };
+        }
+        return null;
+      },
+      consumeGrant: async () => true,
     },
     auth: {
       validateToken: (token: string) => mockValidateToken.fn(token),
@@ -76,6 +86,57 @@ describe('System API E2E Tests', () => {
       getEnvironmentById: (projectId: string, envId: string) =>
         mockGetEnvironmentById.fn(projectId, envId),
       getMemberRole: (projectId: string, userId: string) => mockGetMemberRole.fn(projectId, userId),
+    },
+    ports: {
+      getSecrets: async (principal: any, projectId: string, envId: string, grantId?: string) => {
+        const userId = principal.id;
+        const project = await mockGetProject.fn(projectId);
+        if (!project) throw new ResourceNotFoundError('Project not found');
+        const env = await mockGetEnvironmentById.fn(projectId, envId);
+        if (!env) throw new ResourceNotFoundError('Environment not found');
+
+        // 1. Owner access
+        if (project.ownerId === userId) {
+          const fields = await mockListFields.fn(env.resourceId);
+          return Object.fromEntries((fields as any[]).map((f) => [f.name, f.value]));
+        }
+
+        // 2. Member role access
+        const role = await mockGetMemberRole.fn(projectId, userId);
+        if (role === 'READER' || role === 'WRITER') {
+          const fields = await mockListFields.fn(env.resourceId);
+          return Object.fromEntries((fields as any[]).map((f) => [f.name, f.value]));
+        }
+
+        // 3. Guardian access
+        const isGuardian = await mockIsGuardian.fn(env.resourceId, userId);
+        if (isGuardian) {
+          const fields = await mockListFields.fn(env.resourceId);
+          return Object.fromEntries((fields as any[]).map((f) => [f.name, f.value]));
+        }
+
+        // 4. Grant access
+        if (grantId) {
+          const fields = await mockListFields.fn(env.resourceId);
+          return Object.fromEntries((fields as any[]).map((f) => [f.name, f.value]));
+        }
+
+        // Fallback: throw ForbiddenError
+        throw new ForbiddenError('Access denied: Secrets access not approved');
+      },
+      createApprovalRequest: async (principal: any, resourceId: string, action: string) => {
+        const result = await mockCreateApprovalRequest.fn({
+          resourceId,
+          requesterId: principal.id,
+          requesterType: principal.type,
+          authKind: principal.authKind,
+          action,
+        });
+        return result;
+      },
+      getApprovalRequest: async (principal: any, requestId: string) => {
+        return mockGetApprovalRequest.fn(requestId);
+      },
     },
   } as unknown as Services;
 

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -89,7 +89,7 @@ describe('System API E2E Tests', () => {
     },
     ports: {
       getSecrets: async (principal: any, projectId: string, envId: string, grantId?: string) => {
-        const userId = principal.id;
+        const userId = principal.subjectId ?? principal.id;
         const project = await mockGetProject.fn(projectId);
         if (!project) throw new ResourceNotFoundError('Project not found');
         const env = await mockGetEnvironmentById.fn(projectId, envId);
@@ -127,7 +127,7 @@ describe('System API E2E Tests', () => {
       createApprovalRequest: async (principal: any, resourceId: string, action: string) => {
         const result = await mockCreateApprovalRequest.fn({
           resourceId,
-          requesterId: principal.id,
+          requesterId: principal.subjectId ?? principal.id,
           requesterType: principal.type,
           authKind: principal.authKind,
           action,


### PR DESCRIPTION
Closes #128
Closes #129

## Overview
This PR refactors all Discord interactions, slash commands, buttons, and Fastify HTTP routes to route operations through the unified, policy-aware \DomainPorts\ boundary layer.

## Key Changes
1. **Services container**: Integrated \ports: DomainPorts\ (instantiated as \DomainPortsImpl\) into the \Services\ interface and factory in \services.ts\.
2. **Discord Slash Commands & Button Interactions**:
   - Refactored \decision.ts\ and \pprovalButtons.ts\ to delegate approval requests, status queries, and approval decision recording to \services.ports\ using normalized principal contexts.
   - Completely deleted legacy, synchronous, blocking callback executions inside slash commands and button interaction handlers.
3. **Fastify HTTP Routes**:
   - Normalized request headers, API key contexts, and session tokens into clean \Principal\ objects inside \server.ts\.
   - Refactored GET secrets route to fetch secrets via \services.ports.getSecrets\.
   - Refactored GET requests status route to call \services.ports.getApprovalRequest\.
   - Removed synchronous Discord notifications from route handlers, delegating them entirely to the transactional outbox pipeline.
4. **Unit and E2E Tests**:
   - Updated E2E mocks in \system_api.test.ts\ to emulate \DomainPorts\ methods.
   - Updated unit tests in \pprove.test.ts\ and \deny.test.ts\ to assert on \services.ports\.