### PR TITLE
feat: cut Pawthy CLI over to stabilized request-grant APIs

### DIFF
--- a/apps/pawthy/src/commands/init.ts
+++ b/apps/pawthy/src/commands/init.ts
@@ -263,7 +263,9 @@ export const initCommand = new Command('init')
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 401) {
-          console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
+          console.error(chalk.red('Session expired or revoked. Please run `pawthy login` again.'));
+        } else if (error.response?.status === 403) {
+          console.error(chalk.red('Access forbidden: Insufficient permissions or wrong audience.'));
         } else {
           console.error(chalk.red(`Failed to fetch data: ${error.message}`));
         }

--- a/apps/pawthy/src/commands/login.ts
+++ b/apps/pawthy/src/commands/login.ts
@@ -89,6 +89,11 @@ export const loginCommand = new Command('login')
             } else if (errorCode === 'access_denied') {
               console.error(chalk.red('\nAccess denied by user.'));
               process.exit(1);
+            } else if (errorCode === 'invalid_grant') {
+              console.error(
+                chalk.red('\nInvalid or replayed authorization request. Please try again.')
+              );
+              process.exit(1);
             } else {
               console.error(chalk.red(`\nAuthentication failed: ${errorCode || 'Unknown error'}`));
               process.exit(1);

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -72,35 +72,120 @@ export const pullCommand = new Command('pull')
 
     const envPath = path.resolve(process.cwd(), file);
 
+    // Whitelisting / selective keys sync (Issue #80)
+    const keysWhitelist = getKeysWhitelist(options.keys, config);
+    const keysParam = keysWhitelist ? Array.from(keysWhitelist).join(',') : undefined;
+
     try {
       console.log(chalk.dim('Fetching secrets from Purrmission...'));
 
       // 1. Fetch Secrets
+      const url = new URL(`${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`);
+      if (keysParam) {
+        url.searchParams.set('keys', keysParam);
+      }
+
       const res = await axios.get<{
         secrets?: Record<string, string>;
         status?: string;
         message?: string;
-      }>(`${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`, {
+        requestId?: string;
+      }>(url.toString(), {
         headers: { Authorization: `Bearer ${token}` },
         validateStatus: (status) => status >= 200 && status < 300,
       });
 
+      let secrets: Record<string, string> = {};
+
       if (res.status === 202) {
-        console.log(`\n${chalk.yellow('⏳ Access Pending Approval')}`);
-        console.log(chalk.white(res.data.message));
-        console.log(
-          chalk.dim(
-            '\nPlease run this command again once your request has been approved in Discord.'
-          )
+        const { requestId } = res.data;
+        console.log(`\n⏳ ${chalk.yellow('Access Pending Approval')}`);
+        console.log(chalk.white(`Request ID: ${requestId}`));
+        console.log('Polling for approval...');
+
+        const pollInterval = 5000;
+        const timeout = 5 * 60 * 1000; // 5 minutes
+        const start = Date.now();
+        let approved = false;
+        let finalGrantId = '';
+
+        while (Date.now() - start < timeout) {
+          await new Promise((resolve) => setTimeout(resolve, pollInterval));
+
+          try {
+            const statusRes = await axios.get<{
+              status: string;
+              grantId?: string;
+            }>(`${apiUrl}/api/requests/${requestId}`, {
+              headers: { Authorization: `Bearer ${token}` },
+            });
+
+            const { status, grantId } = statusRes.data;
+
+            if (status === 'APPROVED') {
+              console.log(chalk.green('\n✅ Approval granted! Fetching secrets...'));
+              approved = true;
+              finalGrantId = grantId || '';
+              break;
+            } else if (status === 'DENIED') {
+              console.error(chalk.red('\n❌ Access request was denied by a guardian.'));
+              process.exit(1);
+            } else if (status === 'EXPIRED') {
+              console.error(chalk.red('\n❌ Access request has expired.'));
+              process.exit(1);
+            } else if (status === 'REVOKED') {
+              console.error(chalk.red('\n❌ Access request has been revoked.'));
+              process.exit(1);
+            } else if (status === 'PENDING') {
+              process.stdout.write('.');
+            } else {
+              console.log(chalk.white(`\nState: ${status}`));
+            }
+          } catch (pollErr) {
+            if (axios.isAxiosError(pollErr) && pollErr.response) {
+              const s = pollErr.response.status;
+              if (s === 401) {
+                console.error(chalk.red('\nSession expired or unauthorized.'));
+                process.exit(1);
+              } else if (s === 403) {
+                console.error(
+                  chalk.red('\nAccess forbidden: Insufficient permissions or wrong audience.')
+                );
+                process.exit(1);
+              } else if (s === 404) {
+                console.error(chalk.red('\nRequest not found.'));
+                process.exit(1);
+              }
+            }
+            process.stdout.write('?');
+          }
+        }
+
+        if (!approved) {
+          console.error(chalk.red('\nAuthentication/Approval timed out. Please try again.'));
+          process.exit(1);
+        }
+
+        // Fetch secrets using the grant ID
+        const secretsUrl = new URL(
+          `${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`
         );
-        process.exit(1);
-        return;
+        if (finalGrantId) {
+          secretsUrl.searchParams.set('grantId', finalGrantId);
+        }
+        if (keysParam) {
+          secretsUrl.searchParams.set('keys', keysParam);
+        }
+
+        const secretsRes = await axios.get<{
+          secrets?: Record<string, string>;
+        }>(secretsUrl.toString(), {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        secrets = secretsRes.data.secrets || {};
+      } else {
+        secrets = res.data.secrets || {};
       }
-
-      let secrets = res.data.secrets || {};
-
-      // Whitelisting / selective keys sync (Issue #80)
-      const keysWhitelist = getKeysWhitelist(options.keys, config);
 
       if (keysWhitelist) {
         const ignoredKeys: string[] = [];
@@ -166,13 +251,9 @@ export const pullCommand = new Command('pull')
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 401) {
-          console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
+          console.error(chalk.red('Session expired or revoked. Please run `pawthy login` again.'));
         } else if (error.response?.status === 403) {
-          console.error(
-            chalk.red(
-              'Access denied. You do not have permission to view secrets in this environment.'
-            )
-          );
+          console.error(chalk.red('Access forbidden: Insufficient permissions or wrong audience.'));
         } else if (error.response?.status === 404) {
           console.error(chalk.red('Project or Environment not found. It may have been deleted.'));
         } else {

--- a/apps/pawthy/src/commands/push.ts
+++ b/apps/pawthy/src/commands/push.ts
@@ -172,7 +172,7 @@ export const pushCommand = new Command('push')
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 401) {
-          console.error(chalk.red('Session expired. Please run `pawthy login` again.'));
+          console.error(chalk.red('Session expired or revoked. Please run `pawthy login` again.'));
         } else if (error.response?.status === 403) {
           const targetEnv = envId || 'this environment';
           console.error(
@@ -182,6 +182,15 @@ export const pushCommand = new Command('push')
           );
         } else if (error.response?.status === 404) {
           console.error(chalk.red('Project or Environment not found. It may have been deleted.'));
+        } else if (error.response?.status === 409) {
+          console.error(chalk.red('Conflict detected: Remote secret version has changed.'));
+        } else if (error.response?.status === 400) {
+          const data = error.response.data as any;
+          const message = data?.error || data?.message || 'Invalid data';
+          const details = data?.details
+            ? `\nDetails: ${JSON.stringify(data.details, null, 2)}`
+            : '';
+          console.error(chalk.red(`Validation failed: ${message}${details}`));
         } else {
           console.error(chalk.red(`Failed to push secrets: ${error.message}`));
         }

--- a/apps/purrmission-bot/src/domain/ports.ts
+++ b/apps/purrmission-bot/src/domain/ports.ts
@@ -1,4 +1,4 @@
-import type { Principal, Project, Environment, ApprovalRequest } from './models.js';
+import type { Principal, Project, Environment, ApprovalRequest, ApprovalGrant } from './models.js';
 
 // ---------------------------------------------------------------------------
 // Shared Boundary Errors
@@ -173,7 +173,7 @@ export interface DomainPorts {
     action: string,
     targetKey?: string | null,
     correlationId?: string
-  ): Promise<{ success: boolean; request?: ApprovalRequest }>;
+  ): Promise<{ success: boolean; request?: ApprovalRequest; error?: string }>;
   recordApprovalDecision(
     principal: Principal,
     requestId: string,
@@ -185,4 +185,9 @@ export interface DomainPorts {
     requestId: string,
     correlationId?: string
   ): Promise<ApprovalRequest | null>;
+  getApprovalGrantByRequestId(
+    principal: Principal,
+    requestId: string,
+    correlationId?: string
+  ): Promise<ApprovalGrant | null>;
 }

--- a/apps/purrmission-bot/src/domain/ports_impl.ts
+++ b/apps/purrmission-bot/src/domain/ports_impl.ts
@@ -7,7 +7,7 @@ import type {
   CallbackDestinationDTO,
 } from './ports.js';
 import { ForbiddenError, NotFoundError } from './ports.js';
-import type { Principal, Project, Environment, ApprovalRequest } from './models.js';
+import type { Principal, Project, Environment, ApprovalRequest, ApprovalGrant } from './models.js';
 import { ProjectService } from './project.js';
 import { ResourceService, ApprovalService } from './services.js';
 
@@ -323,5 +323,15 @@ export class DomainPortsImpl implements DomainPorts {
     }
 
     return request;
+  }
+
+  async getApprovalGrantByRequestId(
+    principal: Principal,
+    requestId: string
+  ): Promise<ApprovalGrant | null> {
+    const request = await this.getApprovalRequest(principal, requestId);
+    if (!request) return null;
+
+    return this.approvalService.deps.repositories.approvalGrants.findByRequestId(requestId);
   }
 }

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -8,10 +8,8 @@
  */
 
 import crypto from 'node:crypto';
-import type {
+import {
   ApprovalRequest,
-  ApprovalDecision,
-  DecisionResult,
   Resource,
   Guardian,
   TOTPAccount,
@@ -22,6 +20,9 @@ import type {
   TOTPLinkEnvelope,
   Credential,
   ApprovalGrant,
+  Principal,
+  ApprovalDecision,
+  DecisionResult,
 } from './models.js';
 import type { Repositories } from './repositories.js';
 import { logger } from '../logging/logger.js';
@@ -34,7 +35,6 @@ import {
   isEffectiveGuardian,
   isEffectiveOwner,
   hasCapability,
-  Principal,
 } from './policy.js';
 import { getPrismaClient } from '../infra/prismaClient.js';
 import { generateTOTPCode } from './totp.js';
@@ -1249,7 +1249,13 @@ export class ResourceService {
     const { repositories } = this.deps;
     const userPrincipal: Principal =
       typeof principal === 'string'
-        ? { type: 'DISCORD_USER', id: principal, authKind: 'DISCORD', actorDiscordId: principal }
+        ? {
+            type: 'DISCORD_USER',
+            id: principal,
+            subjectId: principal,
+            authKind: 'DISCORD',
+            actorDiscordId: principal,
+          }
         : principal;
 
     const actorId = userPrincipal.id;
@@ -1378,6 +1384,7 @@ export class ResourceService {
     const principal: Principal = {
       type: 'DISCORD_USER',
       id: actorId,
+      subjectId: actorId,
       authKind: 'DISCORD',
       actorDiscordId: actorId,
     };

--- a/apps/purrmission-bot/src/http/server.ts
+++ b/apps/purrmission-bot/src/http/server.ts
@@ -242,6 +242,14 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
           });
         }
 
+        let grantId: string | null = null;
+        if (approvalRequest.status === 'APPROVED') {
+          const grant = await services.ports.getApprovalGrantByRequestId(principal, id);
+          if (grant) {
+            grantId = grant.id;
+          }
+        }
+
         return {
           requestId: approvalRequest.id,
           resourceId: approvalRequest.resourceId,
@@ -250,6 +258,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
           expiresAt: approvalRequest.expiresAt.toISOString(),
           resolvedBy: approvalRequest.resolvedBy ?? null,
           resolvedAt: approvalRequest.resolvedAt?.toISOString() ?? null,
+          grantId,
         };
       } catch (err) {
         if (err instanceof ForbiddenError) {
@@ -306,7 +315,9 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
         return {
           access_token: result.token,
           token_type: 'Bearer',
-          expires_in: Math.round((result.apiToken.expiresAt.getTime() - Date.now()) / 1000),
+          expires_in: result.apiToken.expiresAt
+            ? Math.round((result.apiToken.expiresAt.getTime() - Date.now()) / 1000)
+            : 0,
         };
       } catch (e: unknown) {
         if (e instanceof SlowDownError) {
@@ -550,7 +561,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     },
     async (req, rep) => {
       const { projectId, envId } = req.params as { projectId: string; envId: string };
-      const { grantId } = (req.query || {}) as { grantId?: string };
+      const { grantId, keys } = (req.query || {}) as { grantId?: string; keys?: string };
       const userId = req.user.id;
 
       const project = await services.project.getProject(projectId);
@@ -573,19 +584,25 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
             resourceId,
             userId,
             'secrets.read',
-            null
+            keys || null
           );
           if (activeGrant) {
             resolvedGrantId = activeGrant.id;
           }
         }
 
-        const secrets = await services.ports.getSecrets(
-          principal,
-          projectId,
-          envId,
-          resolvedGrantId
-        );
+        let secrets = await services.ports.getSecrets(principal, projectId, envId, resolvedGrantId);
+
+        if (keys) {
+          const filterKeys = new Set(
+            keys
+              .split(',')
+              .map((k) => k.trim())
+              .filter(Boolean)
+          );
+          secrets = Object.fromEntries(Object.entries(secrets).filter(([k]) => filterKeys.has(k)));
+        }
+
         return { secrets };
       } catch (err) {
         if (err instanceof ForbiddenError) {
@@ -593,7 +610,8 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
           const approval = await services.approval.findActiveApproval(
             resourceId,
             userId,
-            'secrets.read'
+            'secrets.read',
+            keys || null
           );
 
           if (approval) {
@@ -617,7 +635,8 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
           const result = await services.ports.createApprovalRequest(
             principal,
             resourceId,
-            'secrets.read'
+            'secrets.read',
+            keys || null
           );
           if (!result.success || !result.request) {
             throw new Error(

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -71,7 +71,7 @@ describe('System API E2E Tests', () => {
         mockFindActiveApproval.fn(resourceId, userId),
       findActiveUnconsumedGrant: async (resourceId: string, userId: string) => {
         const approval = await mockFindActiveApproval.fn(resourceId, userId);
-        if (approval && approval.status === 'APPROVED') {
+        if (approval && (approval as any).status === 'APPROVED') {
           return { id: 'mock-grant-id', resourceId, userId };
         }
         return null;
@@ -90,9 +90,9 @@ describe('System API E2E Tests', () => {
     ports: {
       getSecrets: async (principal: any, projectId: string, envId: string, grantId?: string) => {
         const userId = principal.subjectId ?? principal.id;
-        const project = await mockGetProject.fn(projectId);
+        const project: any = await mockGetProject.fn(projectId);
         if (!project) throw new ResourceNotFoundError('Project not found');
-        const env = await mockGetEnvironmentById.fn(projectId, envId);
+        const env: any = await mockGetEnvironmentById.fn(projectId, envId);
         if (!env) throw new ResourceNotFoundError('Environment not found');
 
         // 1. Owner access


### PR DESCRIPTION
Closes #130

## Overview
This PR refactors Pawthy CLI commands (\login\, \init\, \pull\, and \push\) to integrate with the hardened request/grant lifecycle, selective scoped queries, and robust API error responses.

## Key Changes
1. **Request Grant & Polling Integration**:
   - Refactored \GET /api/requests/:id\ endpoint to return the \grantId\ once approved by implementing the \ports.getApprovalGrantByRequestId\ helper.
   - Refactored \pawthy pull\ to support console-interactive active request status polling when receiving a \202 Pending\ status from the secrets reveal API, retrieving and consuming the secrets dynamically via the scoped \grantId\ once approved.
2. **Selective Keys Scope**:
   - Refactored GET secrets route to accept a \keys\ query parameter, scoping auto-approval requests to target keys, and filtering returned secrets list.
   - Configured \pawthy pull\ to pass requested keys in the search parameters.
3. **Robust Error Handling**:
   - Refactored \pawthy push\, \login\, \init\, and \pull\ to explicitly parse, format, and display authorization (403), expiration/revocation (401), validation (400), and conflict (409) errors with clean, non-sensitive descriptions.