### PR TITLE
feat: enforce zero-trust, remove legacy bypasses, and align test mocks

### DIFF
--- a/apps/purrmission-bot/src/domain/credential_hardening.test.ts
+++ b/apps/purrmission-bot/src/domain/credential_hardening.test.ts
@@ -60,10 +60,9 @@ describe('Credential Lifecycle Hardening', () => {
         version: 'v1',
       });
 
-      // 1. Dual-read fallback: check legacy plaintext key works
+      // 1. Dual-read fallback: check legacy plaintext key fails closed (R8A/R8D cleanup)
       const foundLegacy = await services.resource.verifyApiKey('legacy_plain_key');
-      assert.ok(foundLegacy);
-      assert.strictEqual(foundLegacy.id, resource.id);
+      assert.strictEqual(foundLegacy, null);
 
       // 2. Mint new hardened API key
       const ownerId = 'user-owner';

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -814,12 +814,6 @@ export class ResourceService {
       return repositories.resources.findById(credential.subjectId);
     }
 
-    // 2. Dual-read fallback: check legacy plaintext apiKey in Resources table
-    const legacyResource = await repositories.resources.findByApiKey(apiKey);
-    if (legacyResource) {
-      return legacyResource;
-    }
-
     return null;
   }
 

--- a/apps/purrmission-bot/src/http/server.ts
+++ b/apps/purrmission-bot/src/http/server.ts
@@ -182,7 +182,6 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     const result = await services.approval.createApprovalRequest({
       resourceId: body.resourceId,
       context: body.context,
-      callbackUrl: body.callbackUrl,
       expiresInMs: body.expiresInMs,
       requesterId: resource.id,
       requesterType: 'SERVICE',

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -108,13 +108,6 @@ describe('System API E2E Tests', () => {
           return Object.fromEntries((fields as any[]).map((f) => [f.name, f.value]));
         }
 
-        // 3. Guardian access
-        const isGuardian = await mockIsGuardian.fn(env.resourceId, userId);
-        if (isGuardian) {
-          const fields = await mockListFields.fn(env.resourceId);
-          return Object.fromEntries((fields as any[]).map((f) => [f.name, f.value]));
-        }
-
         // 4. Grant access
         if (grantId) {
           const fields = await mockListFields.fn(env.resourceId);


### PR DESCRIPTION
Closes #124

## Overview
This PR completes the integration and conformance gate (Issue #124) by removing legacy bypasses and strictly aligning the test mocks with the production zero-trust policy model.

## Key Changes
1. **Plaintext API Key Fallback Removal**:
   - Retired the legacy plaintext API key dual-read fallback in [services.ts](file:///c:/PU/purrmission/apps/purrmission-bot/src/domain/services.ts).
   - Updated [credential_hardening.test.ts](file:///c:/PU/purrmission/apps/purrmission-bot/src/domain/credential_hardening.test.ts) to assert that legacy plaintext API key lookups fail closed.
2. **Arbitrary Callback URLs Disabled**:
   - Refactored \POST /api/requests\ route inside [server.ts](file:///c:/PU/purrmission/apps/purrmission-bot/src/http/server.ts) to ignore arbitrary client-supplied \callbackUrl\ inputs.
3. **Aligned E2E Mock Perms**:
   - Removed the Guardian direct read bypass from E2E mock implementation inside [system_api.test.ts](file:///c:/PU/purrmission/apps/purrmission-bot/src/test/system_api.test.ts).