### PR TITLE
fix(rbac): restore fail-closed prerequisite baseline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
           find apps/purrmission-bot/dist -type f -exec sha256sum {} \; | sort > dist-checksums.txt
           find dist-scripts -type f -exec sha256sum {} \; | sort >> dist-checksums.txt
           sha256sum package.json pnpm-lock.yaml ecosystem.config.cjs >> dist-checksums.txt
+          sha256sum scripts/deploy-migrations.ts scripts/reconcile-guardians-owners.ts scripts/validate-env.cjs >> dist-checksums.txt
           cat dist-checksums.txt
 
       - name: Deploy Commands
@@ -79,6 +80,8 @@ jobs:
             prisma
             dist-scripts
             dist-checksums.txt
+            scripts/deploy-migrations.ts
+            scripts/reconcile-guardians-owners.ts
             scripts/validate-env.cjs
 
   deploy:
@@ -209,7 +212,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT || 22 }}
           target: ${{ secrets.SSH_TARGET }}
-          source: 'apps,package.json,pnpm-lock.yaml,pnpm-workspace.yaml,ecosystem.config.cjs,dist-checksums.txt,prisma,dist-scripts,scripts/validate-env.cjs'
+          source: 'apps,package.json,pnpm-lock.yaml,pnpm-workspace.yaml,ecosystem.config.cjs,dist-checksums.txt,prisma,dist-scripts,scripts/deploy-migrations.ts,scripts/reconcile-guardians-owners.ts,scripts/validate-env.cjs'
 
       - name: Verify deployment integrity
         uses: appleboy/ssh-action@v1

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ Purrmission exposes seven top-level Discord slash commands:
 | Unlink Resource 2FA | `/resource 2fa unlink resource-id:<id>`                        |
 | Get Resource 2FA    | `/resource 2fa get resource-id:<id>`                           |
 
+> **Prerequisite hardening:** New Resource↔TOTP links and delegated TOTP reveals currently fail
+> closed. They remain disabled until #120 supplies authenticated, seed-version-bound custody
+> consent and #122 supplies request-bound conditional grant issuance. An `APPROVED` request records
+> a decision only; it is not reveal authority.
+
 ### `/guardian`
 
 | Action          | Command                                           |
@@ -207,6 +212,12 @@ pnpm discord:deploy-commands
 # 7. Start the bot
 pnpm dev:purrmission
 ```
+
+Always deploy migrations through `pnpm prisma:deploy`. It runs the required Guardian/owner
+reconciliation before Prisma applies the published Guardian uniqueness migration. Calling raw
+`prisma migrate deploy` bypasses that safety preflight and is unsupported. A fresh empty database
+is detected explicitly and skips reconciliation; an initialized database missing prerequisite
+tables fails closed.
 
 ### Environment Variables
 
@@ -285,17 +296,17 @@ purrmission/
 
 ### Scripts
 
-| Command                        | Description                   |
-| ------------------------------ | ----------------------------- |
-| `pnpm dev:purrmission`         | Start bot in development mode |
-| `pnpm build`                   | Build all packages            |
-| `pnpm test`                    | Run tests                     |
-| `pnpm lint`                    | Run ESLint                    |
-| `pnpm format`                  | Format code with Prettier     |
-| `pnpm discord:deploy-commands` | Register slash commands       |
-| `pnpm prisma:generate`         | Generate Prisma Client        |
-| `pnpm prisma:deploy`           | Apply database migrations     |
-| `pnpm prisma:studio`           | Open Prisma Studio            |
+| Command                        | Description                                         |
+| ------------------------------ | --------------------------------------------------- |
+| `pnpm dev:purrmission`         | Start bot in development mode                       |
+| `pnpm build`                   | Build all packages                                  |
+| `pnpm test`                    | Run tests                                           |
+| `pnpm lint`                    | Run ESLint                                          |
+| `pnpm format`                  | Format code with Prettier                           |
+| `pnpm discord:deploy-commands` | Register slash commands                             |
+| `pnpm prisma:generate`         | Generate Prisma Client                              |
+| `pnpm prisma:deploy`           | Reconcile RBAC data, then apply database migrations |
+| `pnpm prisma:studio`           | Open Prisma Studio                                  |
 
 ---
 

--- a/apps/pawthy/src/commands/pull.test.ts
+++ b/apps/pawthy/src/commands/pull.test.ts
@@ -67,12 +67,13 @@ describe('Pull Command', () => {
 
     // Mock axios.get to return 202 status
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mock.method(axios, 'get', async (): Promise<any> => {
+    const getMock = mock.method(axios, 'get', async (): Promise<any> => {
       return {
         status: 202,
         data: {
           status: 'pending',
           message: 'Secret access is pending approval in Discord',
+          requestId: 'request-1',
         },
       };
     });
@@ -88,6 +89,7 @@ describe('Pull Command', () => {
     }
 
     assert.strictEqual(exitCode, 1);
+    assert.strictEqual(getMock.mock.callCount(), 1, 'pending pulls must not enter a GET poll loop');
   });
 
   it('should prioritize CLI flags over env vars and .pawthyrc', async () => {

--- a/apps/pawthy/src/commands/pull.ts
+++ b/apps/pawthy/src/commands/pull.ts
@@ -100,89 +100,16 @@ export const pullCommand = new Command('pull')
       if (res.status === 202) {
         const { requestId } = res.data;
         console.log(`\n⏳ ${chalk.yellow('Access Pending Approval')}`);
-        console.log(chalk.white(`Request ID: ${requestId}`));
-        console.log('Polling for approval...');
-
-        const pollInterval = 5000;
-        const timeout = 5 * 60 * 1000; // 5 minutes
-        const start = Date.now();
-        let approved = false;
-        let finalGrantId = '';
-
-        while (Date.now() - start < timeout) {
-          await new Promise((resolve) => setTimeout(resolve, pollInterval));
-
-          try {
-            const statusRes = await axios.get<{
-              status: string;
-              grantId?: string;
-            }>(`${apiUrl}/api/requests/${requestId}`, {
-              headers: { Authorization: `Bearer ${token}` },
-            });
-
-            const { status, grantId } = statusRes.data;
-
-            if (status === 'APPROVED') {
-              console.log(chalk.green('\n✅ Approval granted! Fetching secrets...'));
-              approved = true;
-              finalGrantId = grantId || '';
-              break;
-            } else if (status === 'DENIED') {
-              console.error(chalk.red('\n❌ Access request was denied by a guardian.'));
-              process.exit(1);
-            } else if (status === 'EXPIRED') {
-              console.error(chalk.red('\n❌ Access request has expired.'));
-              process.exit(1);
-            } else if (status === 'REVOKED') {
-              console.error(chalk.red('\n❌ Access request has been revoked.'));
-              process.exit(1);
-            } else if (status === 'PENDING') {
-              process.stdout.write('.');
-            } else {
-              console.log(chalk.white(`\nState: ${status}`));
-            }
-          } catch (pollErr) {
-            if (axios.isAxiosError(pollErr) && pollErr.response) {
-              const s = pollErr.response.status;
-              if (s === 401) {
-                console.error(chalk.red('\nSession expired or unauthorized.'));
-                process.exit(1);
-              } else if (s === 403) {
-                console.error(
-                  chalk.red('\nAccess forbidden: Insufficient permissions or wrong audience.')
-                );
-                process.exit(1);
-              } else if (s === 404) {
-                console.error(chalk.red('\nRequest not found.'));
-                process.exit(1);
-              }
-            }
-            process.stdout.write('?');
-          }
-        }
-
-        if (!approved) {
-          console.error(chalk.red('\nAuthentication/Approval timed out. Please try again.'));
-          process.exit(1);
-        }
-
-        // Fetch secrets using the grant ID
-        const secretsUrl = new URL(
-          `${apiUrl}/api/projects/${projectId}/environments/${envId}/secrets`
+        if (requestId) console.log(chalk.white(`Request ID: ${requestId}`));
+        console.error(
+          chalk.yellow(
+            'Automatic approval polling is temporarily disabled. Re-run `pawthy pull` after approval.'
+          )
         );
-        if (finalGrantId) {
-          secretsUrl.searchParams.set('grantId', finalGrantId);
-        }
-        if (keysParam) {
-          secretsUrl.searchParams.set('keys', keysParam);
-        }
-
-        const secretsRes = await axios.get<{
-          secrets?: Record<string, string>;
-        }>(secretsUrl.toString(), {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        secrets = secretsRes.data.secrets || {};
+        // #130 owns the final POST/status/grant exchange. Until then, do not turn a pending
+        // response into an authority-bearing GET or keep a CLI process polling indefinitely.
+        process.exit(1);
+        return;
       } else {
         secrets = res.data.secrets || {};
       }

--- a/apps/purrmission-bot/README.md
+++ b/apps/purrmission-bot/README.md
@@ -47,6 +47,10 @@ Manage shared and personal 2FA accounts directly from Discord.
 | `/resource 2fa unlink`    | Remove a linked 2FA account          |
 | `/resource 2fa get`       | Retrieve the linked 2FA code         |
 
+New Resource↔TOTP links and delegated TOTP reveals currently fail closed pending the authenticated,
+seed-version-bound consent model in #120 and request-bound conditional grants in #122. Approval
+records decision state only and does not mint reveal authority.
+
 ### 🛡️ Guardian Management
 
 | Command / Subcommand                               | Description                  |
@@ -123,7 +127,7 @@ Uses Prisma with SQLite by default. From project root:
 
 ```bash
 pnpm prisma:studio    # View data
-pnpm prisma:deploy    # Apply migrations
+pnpm prisma:deploy    # Reconcile RBAC data, then apply migrations (required deployment path)
 ```
 
 ---

--- a/apps/purrmission-bot/src/api/resource.test.ts
+++ b/apps/purrmission-bot/src/api/resource.test.ts
@@ -4,6 +4,7 @@ import { createHttpServer } from '../http/server.js';
 import { createServices } from '../domain/services.js';
 import { createInMemoryRepositories } from '../domain/repositories.mock.js';
 import { createHash } from 'node:crypto';
+import { computeKeyedDigest } from '../domain/crypto.js';
 import type { FastifyInstance } from 'fastify';
 import type { Services } from '../domain/services.js';
 import type { Repositories } from '../domain/repositories.js';
@@ -40,6 +41,24 @@ describe('Resource API', () => {
       userId: userId,
       name: 'Test Token',
       expiresAt: new Date(Date.now() + 3600000),
+    });
+    await repositories.credentials.create({
+      type: 'PAWTHY_TOKEN',
+      subjectId: userId,
+      name: 'Resource API test token',
+      digest: computeKeyedDigest(validToken, 'PAWTHY_TOKEN'),
+      prefix: validToken.slice(0, 8),
+      scopes: [
+        'secret.metadata.read',
+        'secret.value.read',
+        'secret.write',
+        'secret.delete',
+        'totp.code.read',
+        'totp.link.manage',
+      ].join(','),
+      audience: 'cli',
+      expiresAt: new Date(Date.now() + 3600000),
+      revokedAt: null,
     });
 
     // Setup Resource
@@ -125,7 +144,7 @@ describe('Resource API', () => {
     assert.strictEqual(check, null);
   });
 
-  it('should link 2FA and get code', async () => {
+  it('should fail closed for provisional 2FA linking', async () => {
     // Create TOTP Account
     const account = await repositories.totp.create({
       ownerDiscordUserId: userId,
@@ -133,12 +152,13 @@ describe('Resource API', () => {
       secret: 'JBSWY3DPEHPK3PXP', // Valid base32
     });
 
-    const consent = await services.resource.createTOTPLinkConsent(
-      account.id,
+    const consent = await repositories.totp.createLinkConsent({
+      accountId: account.id,
       resourceId,
-      userId,
-      {}
-    );
+      ownerDiscordUserId: userId,
+      delegationPolicy: {},
+      expiresAt: new Date(Date.now() + 60_000),
+    });
 
     // Link
     const linkRes = await server.inject({
@@ -147,18 +167,9 @@ describe('Resource API', () => {
       headers: { Authorization: `Bearer ${validToken}` },
       payload: { totpAccountId: account.id, consentId: consent.id },
     });
-    assert.strictEqual(linkRes.statusCode, 200);
-
-    // Get Code
-    const codeRes = await server.inject({
-      method: 'POST',
-      url: `/api/resources/${resourceId}/2fa/code`,
-      headers: { Authorization: `Bearer ${validToken}` },
-    });
-    assert.strictEqual(codeRes.statusCode, 200);
-    const body = JSON.parse(codeRes.payload);
-    assert.ok(body.code);
-    assert.strictEqual(body.code.length, 6);
+    assert.strictEqual(linkRes.statusCode, 403);
+    assert.equal((await repositories.totp.findLinkConsentById(consent.id))?.usedAt, null);
+    assert.equal((await repositories.resources.findById(resourceId))?.totpAccountId, undefined);
   });
 
   it('should unlink 2FA', async () => {
@@ -168,13 +179,10 @@ describe('Resource API', () => {
       accountName: 'Google',
       secret: 'JBSWY3DPEHPK3PXP',
     });
-    const consent = await services.resource.createTOTPLinkConsent(
-      account.id,
-      resourceId,
-      userId,
-      {}
-    );
-    await services.resource.linkTOTPAccount(resourceId, account.id, userId, consent.id);
+    await repositories.resources.update(resourceId, {
+      totpAccountId: account.id,
+      version: 'existing-link-v1',
+    });
 
     // Unlink
     const unlinkRes = await server.inject({
@@ -188,7 +196,7 @@ describe('Resource API', () => {
     assert.strictEqual(check, null);
   });
 
-  it('should deny access if not guardian', async () => {
+  it('should deny access if the authenticated user has no Resource role', async () => {
     // Create another resource where the user is NOT a guardian
     const otherResourceId = '222e4567-e89b-12d3-a456-426614174000';
     await repositories.resources.create({
@@ -204,6 +212,94 @@ describe('Resource API', () => {
       headers: { Authorization: `Bearer ${validToken}` },
     });
 
-    assert.strictEqual(listRes.statusCode, 401);
+    assert.strictEqual(listRes.statusCode, 403);
+  });
+
+  it('should deny an explicit Guardian every direct secret field operation', async () => {
+    const guardianId = 'guardian-456';
+    const guardianToken = 'guardian-token-with-secret-scopes';
+
+    await repositories.guardians.add({
+      id: `g-${guardianId}`,
+      resourceId,
+      discordUserId: guardianId,
+      role: 'GUARDIAN',
+    });
+    await repositories.credentials.create({
+      type: 'PAWTHY_TOKEN',
+      subjectId: guardianId,
+      name: 'Guardian negative-path token',
+      digest: computeKeyedDigest(guardianToken, 'PAWTHY_TOKEN'),
+      prefix: guardianToken.slice(0, 8),
+      scopes: [
+        'secret.metadata.read',
+        'secret.value.read',
+        'secret.write',
+        'secret.delete',
+        'totp.link.manage',
+      ].join(','),
+      audience: 'cli',
+      expiresAt: new Date(Date.now() + 3600000),
+      revokedAt: null,
+    });
+    await services.resource.createField(resourceId, 'EXISTING', 'owner-created');
+    const custodyOwnedTotp = await repositories.totp.create({
+      ownerDiscordUserId: 'separate-custody-owner',
+      accountName: 'Custody-owned account',
+      secret: 'JBSWY3DPEHPK3PXP',
+    });
+    await repositories.resources.update(resourceId, { totpAccountId: custodyOwnedTotp.id });
+
+    const requests = [
+      server.inject({
+        method: 'GET',
+        url: `/api/resources/${resourceId}/fields`,
+        headers: { Authorization: `Bearer ${guardianToken}` },
+      }),
+      server.inject({
+        method: 'POST',
+        url: `/api/resources/${resourceId}/fields`,
+        headers: { Authorization: `Bearer ${guardianToken}` },
+        payload: { name: 'CREATED_BY_GUARDIAN', value: 'must-not-write' },
+      }),
+      server.inject({
+        method: 'GET',
+        url: `/api/resources/${resourceId}/fields/EXISTING`,
+        headers: { Authorization: `Bearer ${guardianToken}` },
+      }),
+      server.inject({
+        method: 'DELETE',
+        url: `/api/resources/${resourceId}/fields/EXISTING`,
+        headers: { Authorization: `Bearer ${guardianToken}` },
+      }),
+      server.inject({
+        method: 'POST',
+        url: `/api/resources/${resourceId}/2fa/link`,
+        headers: { Authorization: `Bearer ${guardianToken}` },
+        payload: {
+          totpAccountId: custodyOwnedTotp.id,
+          consentId: '123e4567-e89b-12d3-a456-426614174099',
+        },
+      }),
+      server.inject({
+        method: 'DELETE',
+        url: `/api/resources/${resourceId}/2fa/link`,
+        headers: { Authorization: `Bearer ${guardianToken}` },
+      }),
+    ];
+
+    const responses = await Promise.all(requests);
+    assert.deepStrictEqual(
+      responses.map((response) => response.statusCode),
+      [403, 403, 403, 403, 403, 403]
+    );
+    assert.strictEqual(
+      await repositories.resourceFields.findByResourceAndName(resourceId, 'CREATED_BY_GUARDIAN'),
+      null
+    );
+    assert.ok(
+      await repositories.resourceFields.findByResourceAndName(resourceId, 'EXISTING'),
+      'Guardian delete attempt must not remove the field'
+    );
   });
 });

--- a/apps/purrmission-bot/src/discord/commands/resource.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/resource.test.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { handleResourceAutocomplete, resourceCommand } from './resource.js';
+import { handleResourceAutocomplete, handleResourceCommand, resourceCommand } from './resource.js';
 import type { CommandContext } from './context.js';
-import type { AutocompleteInteraction } from 'discord.js';
+import type { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
+import { createInMemoryRepositories } from '../../domain/repositories.mock.js';
+import { createServices } from '../../domain/services.js';
 
 describe('handleResourceAutocomplete', () => {
   let mockInteraction: AutocompleteInteraction;
@@ -171,5 +173,97 @@ describe('handleResourceAutocomplete', () => {
     const nameOption = registerOption?.options?.find((option: any) => option.name === 'name');
 
     assert.strictEqual(nameOption?.max_length, 100);
+  });
+
+  it('requires an explicit one-time consent ID for /resource 2fa link', () => {
+    const twoFaGroup = (resourceCommand.toJSON() as any).options?.find(
+      (option: any) => option.name === '2fa'
+    );
+    const linkSubcommand = twoFaGroup?.options?.find((option: any) => option.name === 'link');
+    const consentOption = linkSubcommand?.options?.find(
+      (option: any) => option.name === 'consent-id'
+    );
+
+    assert.strictEqual(consentOption?.required, true);
+  });
+
+  it('does not let an explicit Guardian create, reveal, or delete secret fields directly', async () => {
+    const repositories = createInMemoryRepositories();
+    const services = createServices({ repositories });
+    const resourceId = 'resource-guardian-negative';
+    const guardianId = 'explicit-guardian';
+
+    await repositories.resources.create({
+      id: resourceId,
+      name: 'Protected Resource',
+      mode: 'ONE_OF_N',
+      apiKey: 'test-key',
+    });
+    await repositories.guardians.add({
+      id: 'guardian-row',
+      resourceId,
+      discordUserId: guardianId,
+      role: 'GUARDIAN',
+    });
+    await repositories.guardians.add({
+      id: 'owner-row',
+      resourceId,
+      discordUserId: 'resource-owner',
+      role: 'OWNER',
+    });
+    await repositories.resourceFields.create({
+      resourceId,
+      name: 'EXISTING',
+      value: 'owner-created',
+    });
+
+    const commandContext = { repositories, services } as CommandContext;
+    const replies: any[] = [];
+    let directRevealDmCreated = false;
+
+    const interactionFor = (subcommand: 'add' | 'get' | 'remove'): ChatInputCommandInteraction =>
+      ({
+        user: {
+          id: guardianId,
+          createDM: async () => {
+            directRevealDmCreated = true;
+            return { send: async () => undefined };
+          },
+        },
+        options: {
+          getSubcommandGroup: () => 'fields',
+          getSubcommand: () => subcommand,
+          getString: (name: string) => {
+            if (name === 'resource-id') return resourceId;
+            if (name === 'name') return subcommand === 'add' ? 'NEW_FIELD' : 'EXISTING';
+            if (name === 'value') return 'must-not-write';
+            return null;
+          },
+        },
+        client: {
+          users: {
+            fetch: async () => ({
+              createDM: async () => ({ send: async () => undefined }),
+            }),
+          },
+        },
+        reply: async (payload: any) => {
+          replies.push(payload);
+        },
+      }) as unknown as ChatInputCommandInteraction;
+
+    await handleResourceCommand(interactionFor('add'), commandContext);
+    await handleResourceCommand(interactionFor('get'), commandContext);
+    await handleResourceCommand(interactionFor('remove'), commandContext);
+
+    assert.match(replies[0].content, /do not have permission to add fields/i);
+    assert.match(replies[1].content, /access request sent/i);
+    assert.match(replies[2].content, /do not have permission to remove fields/i);
+    assert.strictEqual(directRevealDmCreated, false, 'Guardian must not receive the secret value');
+    assert.strictEqual(
+      await repositories.resourceFields.findByResourceAndName(resourceId, 'NEW_FIELD'),
+      null
+    );
+    assert.ok(await repositories.resourceFields.findByResourceAndName(resourceId, 'EXISTING'));
   });
 });

--- a/apps/purrmission-bot/src/discord/commands/resource.ts
+++ b/apps/purrmission-bot/src/discord/commands/resource.ts
@@ -15,17 +15,20 @@ import type { CommandContext } from './context.js';
 import { logger } from '../../logging/logger.js';
 import { env } from '../../config/env.js';
 import { generateTOTPCode } from '../../domain/totp.js';
-import type { AccessRequestContext, AccessRequestContextWithExtras } from '../../domain/models.js';
+import type {
+  AccessRequestContext,
+  AccessRequestContextWithExtras,
+  Capability,
+} from '../../domain/models.js';
+import { createDiscordPrincipal } from '../../domain/principal.js';
 import {
   createApprovalButtons,
   createAccessRequestEmbed,
 } from '../interactions/approvalButtons.js';
 import { rateLimiter } from '../../infra/rateLimit.js';
 import {
-  checkAccessPolicy,
-  requiresApproval,
   getEffectiveGuardians,
-  isEffectiveGuardian,
+  hasCapability,
   getGuardedResourcesForUser,
   isEffectiveOwner,
 } from '../../domain/policy.js';
@@ -151,6 +154,12 @@ export const resourceCommand = new SlashCommandBuilder()
               .setDescription('2FA account name to link')
               .setRequired(true)
               .setAutocomplete(true)
+          )
+          .addStringOption((option) =>
+            option
+              .setName('consent-id')
+              .setDescription('One-time link consent issued by the 2FA account owner')
+              .setRequired(true)
           )
       )
       .addSubcommand((subcommand) =>
@@ -307,29 +316,18 @@ export async function handleResourceAutocomplete(
   }
 
   if (subcommandGroup === '2fa' && subcommand === 'link' && focusedOption.name === 'account') {
-    // Autocomplete TOTP account names for /resource 2fa link (personal + shared)
+    // Link consent can only be issued by the personal account owner, so expose metadata for the
+    // acting user's accounts only. Global/shared TOTP authority was removed by the custody model.
     const userId = interaction.user.id;
     const { totp } = context.repositories;
-
-    const personalAccounts = await totp.findByOwnerDiscordUserId(userId);
-    const sharedAccounts = await totp.findSharedVisibleTo(userId);
-
-    // Merge and deduplicate accounts
-    const accountMap = new Map<string, (typeof personalAccounts)[0]>();
-    personalAccounts.forEach((acc) => accountMap.set(acc.id, acc));
-    sharedAccounts.forEach((acc) => {
-      if (!accountMap.has(acc.id)) {
-        accountMap.set(acc.id, acc);
-      }
-    });
-    const allAccounts = Array.from(accountMap.values());
+    const accounts = await totp.findMetadataByOwnerDiscordUserId(userId);
 
     const query = focusedOption.value.toLowerCase();
-    const filtered = allAccounts.filter((a) => a.accountName.toLowerCase().includes(query));
+    const filtered = accounts.filter((a) => a.accountName.toLowerCase().includes(query));
 
     await interaction.respond(
       filtered.slice(0, 25).map((a) => ({
-        name: a.shared ? `${a.accountName} (shared)` : a.accountName,
+        name: a.accountName,
         value: a.id,
       }))
     );
@@ -340,14 +338,25 @@ export async function handleResourceAutocomplete(
 }
 
 /**
- * Check if user is owner/guardian of a resource.
+ * Evaluate an exact Resource capability for a Discord interaction.
  */
-async function isOwnerOrGuardian(
+async function hasResourceCapability(
   context: CommandContext,
   resourceId: string,
-  discordUserId: string
+  discordUserId: string,
+  capability: Capability,
+  fieldName?: string
 ): Promise<boolean> {
-  return isEffectiveGuardian(context.repositories, resourceId, discordUserId);
+  const decision = await hasCapability(
+    context.repositories,
+    createDiscordPrincipal(discordUserId),
+    capability,
+    {
+      resourceId,
+      ...(fieldName ? { fieldName } : {}),
+    }
+  );
+  return decision.allowed;
 }
 
 /**
@@ -453,10 +462,9 @@ async function handleFieldsAdd(
     return;
   }
 
-  // Check user is owner/guardian
-  if (!(await isOwnerOrGuardian(context, resourceId, userId))) {
+  if (!(await hasResourceCapability(context, resourceId, userId, 'secret.write', name))) {
     await interaction.reply({
-      content: '❌ You must be an owner or guardian of this resource to add fields.',
+      content: '❌ You do not have permission to add fields to this resource.',
       ephemeral: true,
     });
     return;
@@ -569,10 +577,9 @@ async function handleFieldsList(
     return;
   }
 
-  // Check user is owner/guardian
-  if (!(await isOwnerOrGuardian(context, resourceId, userId))) {
+  if (!(await hasResourceCapability(context, resourceId, userId, 'secret.metadata.read'))) {
     await interaction.reply({
-      content: '❌ You must be an owner or guardian of this resource to list fields.',
+      content: '❌ You do not have permission to list fields on this resource.',
       ephemeral: true,
     });
     return;
@@ -627,30 +634,16 @@ async function handleFieldsGet(
     return;
   }
 
-  // Check access policy
-  const guardians = await getEffectiveGuardians(context.repositories, resourceId);
-  const accessResult = await checkAccessPolicy(resource, guardians, userId, context.repositories);
-
-  if (requiresApproval(accessResult)) {
+  const canReveal = await hasResourceCapability(
+    context,
+    resourceId,
+    userId,
+    'secret.value.read',
+    name
+  );
+  if (!canReveal) {
     // Create approval request for field access
     await createFieldAccessRequest(interaction, context, resource.name, resourceId, name, userId);
-    return;
-  }
-
-  // Access denied (if not requiring approval, and not allowed)
-  if (!accessResult.allowed) {
-    await context.services.audit.log({
-      action: 'FIELD_ACCESSED',
-      resourceId,
-      actorId: userId,
-      status: 'DENIED',
-      context: JSON.stringify({ fieldName: name, reason: accessResult.reason }),
-    });
-
-    await interaction.reply({
-      content: `❌ Access denied: ${accessResult.reason ?? 'You do not have permission.'}`,
-      ephemeral: true,
-    });
     return;
   }
 
@@ -679,11 +672,13 @@ async function handleFieldsGet(
     );
 
     await context.services.audit.log({
-      action: 'FIELD_ACCESSED',
+      eventType: 'SECRET_VALUE_REVEAL',
+      outcomeCode: 'SUCCESS',
+      actorType: 'DISCORD_USER',
       resourceId,
       actorId: userId,
-      status: 'SUCCESS',
-      context: JSON.stringify({ fieldName: name }),
+      authKind: 'DISCORD',
+      payload: { fieldName: name },
     });
 
     logger.info('Field value sent via DM', {
@@ -728,10 +723,9 @@ async function handleFieldsRemove(
     return;
   }
 
-  // Check user is owner/guardian
-  if (!(await isOwnerOrGuardian(context, resourceId, userId))) {
+  if (!(await hasResourceCapability(context, resourceId, userId, 'secret.delete', name))) {
     await interaction.reply({
-      content: '❌ You must be an owner or guardian of this resource to remove fields.',
+      content: '❌ You do not have permission to remove fields from this resource.',
       ephemeral: true,
     });
     return;
@@ -783,6 +777,7 @@ async function handleLink2FA(
 ): Promise<void> {
   const resourceId = interaction.options.getString('resource-id', true);
   const accountId = interaction.options.getString('account', true);
+  const consentId = interaction.options.getString('consent-id', true);
   const userId = interaction.user.id;
 
   const { resources, totp } = context.repositories;
@@ -797,17 +792,8 @@ async function handleLink2FA(
     return;
   }
 
-  // Check user is owner/guardian
-  if (!(await isOwnerOrGuardian(context, resourceId, userId))) {
-    await interaction.reply({
-      content: '❌ You must be an owner or guardian of this resource to link 2FA.',
-      ephemeral: true,
-    });
-    return;
-  }
-
   // Find the TOTP account by ID (from autocomplete)
-  const account = await totp.findById(accountId);
+  const account = await totp.findMetadataById(accountId);
 
   if (!account) {
     await interaction.reply({
@@ -818,7 +804,7 @@ async function handleLink2FA(
   }
 
   // Verify the user has permission to use this account
-  if (account.ownerDiscordUserId !== userId && !account.shared) {
+  if (account.ownerDiscordUserId !== userId) {
     await interaction.reply({
       content: `❌ You do not have permission to use the 2FA account \`${account.accountName}\`.`,
       ephemeral: true,
@@ -826,14 +812,8 @@ async function handleLink2FA(
     return;
   }
 
-  // Check if resource already has a linked 2FA
-  // Note: We'd need to extend ResourceRepository to support linking
-  // For now, we'll use a service-level approach via Prisma directly
-  // TODO: Add proper repository method for this
-
   try {
-    // Use the services to link
-    await context.services.resource.linkTOTPAccount(resourceId, account.id, userId);
+    await context.services.resource.linkTOTPAccount(resourceId, account.id, userId, consentId);
 
     logger.info('Linked 2FA account to resource', {
       resourceId,
@@ -879,15 +859,6 @@ async function handleUnlink2FA(
   if (!resource) {
     await interaction.reply({
       content: '❌ Resource not found.',
-      ephemeral: true,
-    });
-    return;
-  }
-
-  // Check user is owner/guardian
-  if (!(await isOwnerOrGuardian(context, resourceId, userId))) {
-    await interaction.reply({
-      content: '❌ You must be an owner or guardian of this resource to unlink 2FA.',
       ephemeral: true,
     });
     return;
@@ -942,30 +913,10 @@ async function handleGet2FA(
     return;
   }
 
-  // Check access policy
-  const guardians = await getEffectiveGuardians(context.repositories, resourceId);
-  const accessResult = await checkAccessPolicy(resource, guardians, userId, context.repositories);
-
-  if (requiresApproval(accessResult)) {
+  const canReveal = await hasResourceCapability(context, resourceId, userId, 'totp.code.read');
+  if (!canReveal) {
     // Create approval request for 2FA access
     await create2FAAccessRequest(interaction, context, resource.name, resourceId, userId);
-    return;
-  }
-
-  // Access denied
-  if (!accessResult.allowed) {
-    await context.services.audit.log({
-      action: 'TOTP_RETRIEVED',
-      resourceId,
-      actorId: userId,
-      status: 'DENIED',
-      context: JSON.stringify({ reason: accessResult.reason }),
-    });
-
-    await interaction.reply({
-      content: `❌ Access denied: ${accessResult.reason ?? 'You do not have permission.'}`,
-      ephemeral: true,
-    });
     return;
   }
 
@@ -1013,11 +964,13 @@ async function handleGet2FA(
     });
 
     await context.services.audit.log({
-      action: 'TOTP_RETRIEVED',
+      eventType: 'TOTP_CODE_REVEAL',
+      outcomeCode: 'SUCCESS',
+      actorType: 'DISCORD_USER',
       resourceId,
       actorId: userId,
-      status: 'SUCCESS',
-      context: JSON.stringify({ totpAccountId: linkedAccount.id }),
+      authKind: 'DISCORD',
+      payload: { totpAccountId: linkedAccount.id },
     });
 
     await interaction.reply({

--- a/apps/purrmission-bot/src/discord/commands/twoFa.test.ts
+++ b/apps/purrmission-bot/src/discord/commands/twoFa.test.ts
@@ -51,6 +51,7 @@ describe('twoFa command module', () => {
   let mockTotpRepository: {
     create: ReturnType<typeof mock.fn>;
     findByOwnerDiscordUserId: ReturnType<typeof mock.fn>;
+    findMetadataByOwnerDiscordUserId: ReturnType<typeof mock.fn>;
     findByOwnerAndName: ReturnType<typeof mock.fn>;
     update: ReturnType<typeof mock.fn>;
   };
@@ -370,8 +371,8 @@ describe('twoFa command module', () => {
         ownerDiscordUserId: 'user-123',
         accountName: 'Google',
         secret: 'JBSWY3DPEHPK3PXP',
-        shared: false,
         backupKey: 'BACKUP-1234',
+        version: 'totp-v1',
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -400,7 +401,7 @@ describe('twoFa command module', () => {
         ownerDiscordUserId: 'user-123',
         accountName: 'Google',
         secret: 'JBSWY3DPEHPK3PXP',
-        shared: false,
+        version: 'totp-v1',
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -431,8 +432,8 @@ describe('twoFa command module', () => {
         ownerDiscordUserId: 'user-123',
         accountName: 'Google',
         secret: 'JBSWY3DPEHPK3PXP',
-        shared: false,
         backupKey: 'BACKUP-KEY',
+        version: 'totp-v1',
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -487,7 +488,7 @@ describe('twoFa command module', () => {
         ownerDiscordUserId: 'user-123',
         accountName: 'MyAccount',
         secret: 'JBSWY3DPEHPK3PXP',
-        shared: false,
+        version: 'totp-v1',
         createdAt: new Date(),
         updatedAt: new Date(),
       };

--- a/apps/purrmission-bot/src/discord/interactions/approvalButtons.test.ts
+++ b/apps/purrmission-bot/src/discord/interactions/approvalButtons.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { ButtonInteraction, Client } from 'discord.js';
+import type { Services } from '../../domain/services.js';
+import type { Repositories } from '../../domain/repositories.js';
+import { createApprovalEmbed, handleApprovalButton } from './approvalButtons.js';
+
+describe('approval buttons', () => {
+  it('records APPROVE without treating the decision as reveal authority', async () => {
+    let discordFetches = 0;
+    let repositoryReads = 0;
+    const interaction = {
+      customId: 'purrmission:approve:req-1',
+      user: { id: 'guardian-1' },
+      message: { embeds: [createApprovalEmbed('resource', {}, null)] },
+      deferUpdate: async () => {},
+      editReply: async () => {},
+      followUp: async () => {},
+    } as unknown as ButtonInteraction;
+    const services = {
+      ports: {
+        recordApprovalDecision: async () => ({ success: true }),
+        getApprovalRequest: async () => ({
+          id: 'req-1',
+          resourceId: 'resource-1',
+          status: 'APPROVED',
+          context: {
+            type: 'FIELD_ACCESS',
+            requesterId: 'requester-1',
+            description: 'need it',
+            fieldName: 'SECRET',
+          },
+        }),
+      },
+    } as unknown as Services;
+    const repositories = new Proxy(
+      {},
+      {
+        get() {
+          repositoryReads += 1;
+          throw new Error('approval must not read value-bearing repositories');
+        },
+      }
+    ) as Repositories;
+    const discordClient = {
+      users: {
+        fetch: async () => {
+          discordFetches += 1;
+          throw new Error('approval must not DM or reveal to the requester');
+        },
+      },
+    } as unknown as Client;
+
+    await handleApprovalButton(interaction, services, repositories, discordClient);
+
+    assert.equal(repositoryReads, 0);
+    assert.equal(discordFetches, 0);
+  });
+});

--- a/apps/purrmission-bot/src/discord/interactions/approvalButtons.ts
+++ b/apps/purrmission-bot/src/discord/interactions/approvalButtons.ts
@@ -16,7 +16,6 @@ import type { Services } from '../../domain/services.js';
 import type { ApprovalDecision, AccessRequestContext } from '../../domain/models.js';
 import { createDiscordPrincipal } from '../../domain/principal.js';
 import type { Repositories } from '../../domain/repositories.js';
-import { generateTOTPCode } from '../../domain/totp.js';
 import { logger } from '../../logging/logger.js';
 
 /**
@@ -80,7 +79,7 @@ function parseCustomId(customId: string): { action: ApprovalDecision; requestId:
 export async function handleApprovalButton(
   interaction: ButtonInteraction,
   services: Services,
-  repositories: Repositories,
+  _repositories: Repositories,
   discordClient: Client
 ): Promise<void> {
   const parsed = parseCustomId(interaction.customId);
@@ -163,19 +162,9 @@ export async function handleApprovalButton(
       components: [disabledRow],
     });
 
-    // If approved, reveal the data to the requester
-    if (action === 'APPROVE') {
-      const context = request.context;
-      if (isAccessRequestContext(context)) {
-        await revealAccessToRequester(
-          context,
-          request.resourceId,
-          repositories,
-          services,
-          discordClient
-        );
-      }
-    }
+    // Approval records a decision and may mint an immutable grant. It is never reveal authority.
+    // Requester redemption must occur through a separate authenticated, grant-consuming POST use
+    // case (#122/#128); until that exists, the Discord decision path deliberately fails closed.
 
     // If denied, notify the requester via DM
     if (action === 'DENY') {
@@ -201,109 +190,6 @@ export async function handleApprovalButton(
     await interaction.followUp({
       content: '❌ Failed to process your decision. Please try again.',
       ephemeral: true,
-    });
-  }
-}
-
-/**
- * Reveal the requested data to the requester after approval.
- */
-async function revealAccessToRequester(
-  context: AccessRequestContext,
-  resourceId: string,
-  repositories: Repositories,
-  services: Services,
-  discordClient: Client
-): Promise<void> {
-  try {
-    const user = await discordClient.users.fetch(context.requesterId);
-    const dm = await user.createDM();
-    const resource = await repositories.resources.findById(resourceId);
-    const resourceName = resource?.name ?? 'Unknown Resource';
-
-    if (context.type === 'FIELD_ACCESS' && context.fieldName) {
-      // Reveal field value
-      const field = await repositories.resourceFields.findByResourceAndName(
-        resourceId,
-        context.fieldName
-      );
-      if (field) {
-        await dm.send(
-          [
-            '✅ **Access Approved!**',
-            '',
-            `Your request for field **${context.fieldName}** on **${resourceName}** was approved.`,
-            '',
-            `**${field.name}:** \`${field.value}\``,
-            '',
-            '_Keep this value secure._',
-          ].join('\n')
-        );
-        logger.info('Revealed field value to requester', {
-          requesterId: context.requesterId,
-          resourceId,
-          fieldName: context.fieldName,
-        });
-      } else {
-        await dm.send(
-          `✅ Your access request for field **${context.fieldName}** on **${resourceName}** was approved, but the field could not be found. It may have been deleted.`
-        );
-        logger.warn('Approved field access request for a non-existent field', {
-          requesterId: context.requesterId,
-          resourceId,
-          fieldName: context.fieldName,
-        });
-      }
-    } else if (context.type === 'TOTP_ACCESS') {
-      // Reveal TOTP code
-      const linkedAccount = await services.resource.getLinkedTOTPAccount(resourceId);
-      if (linkedAccount) {
-        const code = generateTOTPCode(linkedAccount);
-        await dm.send(
-          [
-            '✅ **Access Approved!**',
-            '',
-            `Your request for 2FA code on **${resourceName}** was approved.`,
-            '',
-            `**${code}**`,
-            '',
-            `_Account: ${linkedAccount.accountName}_`,
-            '_Code is time-based and will expire soon._',
-          ].join('\n')
-        );
-        logger.info('Revealed TOTP code to requester', {
-          requesterId: context.requesterId,
-          resourceId,
-          totpAccountId: linkedAccount.id,
-        });
-      } else {
-        await dm.send(
-          `✅ Your access request for 2FA on **${resourceName}** was approved, but no 2FA account is linked to it. It may have been unlinked.`
-        );
-        logger.warn('Approved 2FA access request for a resource with no linked account', {
-          requesterId: context.requesterId,
-          resourceId,
-        });
-      }
-    } else if (context.type === 'SECRET_ACCESS') {
-      await dm.send(
-        [
-          '✅ **Access Approved!**',
-          '',
-          `Your request for secrets on **${resourceName}** was approved.`,
-          'You can now run your CLI command again to fetch them.',
-        ].join('\n')
-      );
-      logger.info('Notified requester of SECRET_ACCESS approval', {
-        requesterId: context.requesterId,
-        resourceId,
-      });
-    }
-  } catch (error) {
-    logger.error('Failed to reveal access to requester', {
-      context,
-      resourceId,
-      error,
     });
   }
 }

--- a/apps/purrmission-bot/src/domain/approval_v2.test.ts
+++ b/apps/purrmission-bot/src/domain/approval_v2.test.ts
@@ -1,296 +1,150 @@
-import { test, describe, beforeEach } from 'node:test';
-import assert from 'node:assert';
-import { createInMemoryRepositories } from './repositories.mock.js';
-import { createServices } from './services.js';
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
 import { AccessDeniedError } from './auth.js';
 import { createDiscordPrincipal } from './principal.js';
+import { createInMemoryRepositories } from './repositories.mock.js';
+import { createServices } from './services.js';
 
-describe('Approval Request V2, Immutable Grants, and Atomic Consumption', () => {
+describe('Approval decisions and provisional authority fail closed', () => {
   let repos: ReturnType<typeof createInMemoryRepositories>;
   let services: ReturnType<typeof createServices>;
 
   beforeEach(async () => {
     repos = createInMemoryRepositories();
     services = createServices({ repositories: repos });
-
-    // Seed a mock project and resource
-    const project = await repos.projects.createProject({
-      name: 'Test Project',
-      ownerId: 'owner-1',
-    });
-
-    // Seed a mock TOTP account
-    const account = await repos.totp.create({
-      ownerDiscordUserId: 'owner-1',
-      accountName: 'Test Account',
-      secret: 'MOCKSECRET',
-      issuer: 'Test',
-    });
-
     await repos.resources.create({
       id: 'res-1',
-      projectId: project.id,
-      name: 'Test Resource',
-      type: '2FA_SEED',
-      totpAccountId: account.id,
-      version: 'v1',
+      name: 'Protected Resource',
+      mode: 'ONE_OF_N',
+      apiKey: null,
     });
-
-    // Add a guardian to res-1
     await repos.guardians.add({
+      id: 'guardian-row-1',
       resourceId: 'res-1',
       discordUserId: 'guardian-1',
       role: 'GUARDIAN',
     });
   });
 
-  describe('Request Deduplication', () => {
-    test('should return existing request when duplicate pending request is created', async () => {
-      const res1 = await services.approval.createApprovalRequest({
-        resourceId: 'res-1',
-        requesterId: 'user-1',
-        requesterType: 'DISCORD_USER',
-        authKind: 'DISCORD',
-        action: 'secrets.read',
-        targetVersion: 'v1',
-        policyVersion: 'v1',
-      });
-
-      assert.ok(res1.success);
-      assert.ok(res1.request);
-
-      const res2 = await services.approval.createApprovalRequest({
-        resourceId: 'res-1',
-        requesterId: 'user-1',
-        requesterType: 'DISCORD_USER',
-        authKind: 'DISCORD',
-        action: 'secrets.read',
-        targetVersion: 'v1',
-        policyVersion: 'v1',
-      });
-
-      assert.ok(res2.success);
-      assert.strictEqual(res2.request?.id, res1.request?.id);
-    });
+  it('deduplicates exact pending requests', async () => {
+    const input = {
+      resourceId: 'res-1',
+      requesterId: 'user-1',
+      requesterType: 'DISCORD_USER',
+      authKind: 'DISCORD',
+      action: 'secrets.read',
+    };
+    const first = await services.approval.createApprovalRequest(input);
+    const second = await services.approval.createApprovalRequest(input);
+    assert.ok(first.request);
+    assert.equal(second.request?.id, first.request.id);
   });
 
-  describe('Self-Approval Prevention', () => {
-    test('should reject approval from the requester themselves', async () => {
-      const res = await services.approval.createApprovalRequest({
-        resourceId: 'res-1',
-        requesterId: 'guardian-1',
-        requesterType: 'DISCORD_USER',
-        authKind: 'DISCORD',
-        action: 'secrets.read',
-        targetVersion: 'v1',
-        policyVersion: 'v1',
-      });
-
-      assert.ok(res.success);
-      assert.ok(res.request);
-
-      const decision = await services.approval.recordDecision(
-        res.request.id,
-        'APPROVE',
-        createDiscordPrincipal('guardian-1')
-      );
-
-      assert.strictEqual(decision.success, false);
-      assert.strictEqual(decision.error, 'Requesters cannot approve their own requests.');
+  it('prevents self approval', async () => {
+    const result = await services.approval.createApprovalRequest({
+      resourceId: 'res-1',
+      requesterId: 'guardian-1',
+      requesterType: 'DISCORD_USER',
+      authKind: 'DISCORD',
+      action: 'secrets.read',
     });
+    assert.ok(result.request);
+    const decision = await services.approval.recordDecision(
+      result.request.id,
+      'APPROVE',
+      createDiscordPrincipal('guardian-1')
+    );
+    assert.equal(decision.success, false);
+    assert.match(decision.error ?? '', /cannot approve their own/i);
   });
 
-  describe('Immutable Grants & One-Time Atomic Consumption', () => {
-    test('should issue an immutable grant upon approval, consume it once, and block subsequent attempts', async () => {
-      const res = await services.approval.createApprovalRequest({
-        resourceId: 'res-1',
-        requesterId: 'user-1',
-        requesterType: 'DISCORD_USER',
-        authKind: 'DISCORD',
-        action: 'secrets.read',
-        targetVersion: 'v1',
-        policyVersion: 'v1',
-      });
-
-      assert.ok(res.success);
-      assert.ok(res.request);
-
-      // Resolve the request
-      const decision = await services.approval.recordDecision(
-        res.request.id,
-        'APPROVE',
-        createDiscordPrincipal('guardian-1')
-      );
-      assert.ok(decision.success);
-
-      // Verify a grant exists
-      const grant = await repos.approvalGrants.findByRequestId(res.request.id);
-      assert.ok(grant);
-      assert.strictEqual(grant.consumedAt, null);
-
-      const principal = createDiscordPrincipal('user-1');
-
-      // Consume the grant
-      await services.approval.consumeGrant(grant.id, principal, 'secrets.read', 'v1', 'v1');
-
-      // Verify grant is marked consumed in DB
-      const consumedGrant = await repos.approvalGrants.findById(grant.id);
-      assert.ok(consumedGrant?.consumedAt);
-
-      // Attempt to consume again should fail
-      await assert.rejects(
-        services.approval.consumeGrant(grant.id, principal, 'secrets.read', 'v1', 'v1'),
-        (err: unknown) =>
-          err instanceof AccessDeniedError && err.message.includes('already been consumed')
-      );
+  it('records APPROVED as non-authority and mints no grant', async () => {
+    const result = await services.approval.createApprovalRequest({
+      resourceId: 'res-1',
+      requesterId: 'user-1',
+      requesterType: 'DISCORD_USER',
+      authKind: 'DISCORD',
+      action: 'totp.code.read',
     });
-
-    test('should reject consumption if targetVersion or policyVersion has changed', async () => {
-      const res = await services.approval.createApprovalRequest({
-        resourceId: 'res-1',
-        requesterId: 'user-1',
-        requesterType: 'DISCORD_USER',
-        authKind: 'DISCORD',
-        action: 'secrets.read',
-        targetVersion: 'v1',
-        policyVersion: 'v1',
-      });
-
-      assert.ok(res.success);
-      assert.ok(res.request);
-      const decision = await services.approval.recordDecision(
-        res.request.id,
-        'APPROVE',
-        createDiscordPrincipal('guardian-1')
-      );
-      assert.ok(decision.success);
-
-      const grant = await repos.approvalGrants.findByRequestId(res.request.id);
-      assert.ok(grant);
-
-      const principal = createDiscordPrincipal('user-1');
-
-      // Reject consumption with mismatched targetVersion
-      await assert.rejects(
-        services.approval.consumeGrant(grant.id, principal, 'secrets.read', 'v2', 'v1'),
-        (err: unknown) =>
-          err instanceof AccessDeniedError && err.message.includes('Target state version mismatch')
-      );
-
-      // Reject consumption with mismatched policyVersion
-      await assert.rejects(
-        services.approval.consumeGrant(grant.id, principal, 'secrets.read', 'v1', 'v2'),
-        (err: unknown) =>
-          err instanceof AccessDeniedError && err.message.includes('Policy version mismatch')
-      );
-    });
+    assert.ok(result.request);
+    const decision = await services.approval.recordDecision(
+      result.request.id,
+      'APPROVE',
+      createDiscordPrincipal('guardian-1')
+    );
+    assert.equal(decision.success, true);
+    assert.equal(decision.request?.status, 'APPROVED');
+    assert.equal(await repos.approvalGrants.findByRequestId(result.request.id), null);
   });
 
-  describe('Delegated TOTP Reveal (Double-Gating)', () => {
-    test('should require both a valid active ApprovalGrant and TOTPDelegationConsent for delegated access', async () => {
-      const requesterId = 'user-1';
+  it('retains one-time validation for manually persisted future-model grants', async () => {
+    const grant = await repos.approvalGrants.create({
+      requestId: 'future-request',
+      resourceId: 'res-1',
+      requesterId: 'user-1',
+      requesterType: 'DISCORD_USER',
+      authKind: 'DISCORD',
+      action: 'secrets.read',
+      targetKey: null,
+      targetVersion: 'v1',
+      policyVersion: 'v1',
+      constraints: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const principal = createDiscordPrincipal('user-1');
+    await services.approval.consumeGrant(grant.id, principal, 'secrets.read', 'v1', 'v1');
+    await assert.rejects(
+      services.approval.consumeGrant(grant.id, principal, 'secrets.read', 'v1', 'v1'),
+      (error: unknown) =>
+        error instanceof AccessDeniedError && error.message.includes('already been consumed')
+    );
+  });
 
-      // Create and approve request
-      const res = await services.approval.createApprovalRequest({
-        resourceId: 'res-1',
-        requesterId,
-        requesterType: 'DISCORD_USER',
-        authKind: 'DISCORD',
-        action: 'totp.code.read',
-      });
-      assert.ok(res.request);
-
-      const decision = await services.approval.recordDecision(
-        res.request.id,
-        'APPROVE',
-        createDiscordPrincipal('guardian-1')
-      );
-      assert.ok(decision.success);
-
-      // Get latest rotated resource details and create delegation consent
-      const resource = await repos.resources.findById('res-1');
-      assert.ok(resource);
-      assert.ok(resource.totpAccountId);
-      const totpAccountId = resource.totpAccountId;
-      const account = await repos.totp.findById(totpAccountId);
-      assert.ok(account);
-
-      // Create delegation consent directly in repo with rotated linkVersion
-      const consent = await repos.totp.createDelegationConsent({
-        resourceId: 'res-1',
-        totpAccountId,
-        operation: 'totp.code.read',
-        requesterId,
-        authFamily: 'DISCORD',
-        accountVersion: account.version,
-        linkVersion: resource.version,
-        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
-      });
-
-      const principal = createDiscordPrincipal(requesterId);
-
-      // Reveal should succeed
-      const code = await services.resource.revealTOTPCode('res-1', principal);
-      assert.ok(code);
-
-      // Consent and Grant must be consumed now
-      const consumedConsent = await repos.totp.findDelegationConsentById(consent.id);
-      assert.ok(consumedConsent?.usedAt);
-
-      const activeGrant = await repos.approvalGrants.findActiveUnconsumed(
-        'res-1',
-        requesterId,
-        'totp.code.read',
-        null
-      );
-      assert.strictEqual(activeGrant, null);
+  it('denies grant A plus consent B without consuming either provisional record', async () => {
+    const account = await repos.totp.create({
+      ownerDiscordUserId: 'seed-owner',
+      accountName: 'Account B',
+      secret: 'JBSWY3DPEHPK3PXP',
+    });
+    const resource = await repos.resources.update('res-1', {
+      totpAccountId: account.id,
+      version: 'link-v1',
+    });
+    const grantA = await repos.approvalGrants.create({
+      requestId: 'request-a',
+      resourceId: resource.id,
+      requesterId: 'user-1',
+      requesterType: 'DISCORD_USER',
+      authKind: 'DISCORD',
+      action: 'totp.code.read',
+      targetKey: null,
+      targetVersion: resource.version,
+      policyVersion: resource.version,
+      constraints: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const consentB = await repos.totp.createDelegationConsent({
+      resourceId: resource.id,
+      totpAccountId: account.id,
+      operation: 'totp.code.read',
+      requesterId: 'user-1',
+      authFamily: 'DISCORD',
+      accountVersion: account.version,
+      linkVersion: resource.version,
+      expiresAt: new Date(Date.now() + 60_000),
     });
 
-    test('should fail reveal if delegation consent has changed seed version', async () => {
-      const requesterId = 'user-1';
-
-      // Create and approve request
-      const res = await services.approval.createApprovalRequest({
-        resourceId: 'res-1',
-        requesterId,
-        requesterType: 'DISCORD_USER',
-        authKind: 'DISCORD',
-        action: 'totp.code.read',
-      });
-      assert.ok(res.request);
-
-      const decision = await services.approval.recordDecision(
-        res.request.id,
-        'APPROVE',
-        createDiscordPrincipal('guardian-1')
-      );
-      assert.ok(decision.success);
-
-      const resource = await repos.resources.findById('res-1');
-      assert.ok(resource);
-      assert.ok(resource.totpAccountId);
-      const totpAccountId = resource.totpAccountId;
-
-      // Create delegation consent directly in repo with stale seed version
-      await repos.totp.createDelegationConsent({
-        resourceId: 'res-1',
-        totpAccountId,
-        operation: 'totp.code.read',
-        requesterId,
-        authFamily: 'DISCORD',
-        accountVersion: 'seed-stale',
-        linkVersion: resource.version,
-        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
-      });
-
-      const principal = createDiscordPrincipal(requesterId);
-
-      // Reveal should fail closed
-      await assert.rejects(
-        services.resource.revealTOTPCode('res-1', principal),
-        (err: unknown) =>
-          err instanceof AccessDeniedError && err.message.includes('seed version has changed')
-      );
-    });
+    await assert.rejects(
+      services.resource.revealTOTPCode(
+        resource.id,
+        createDiscordPrincipal('user-1'),
+        grantA.id,
+        consentB.id
+      ),
+      (error: unknown) =>
+        error instanceof AccessDeniedError && error.message.includes('request-bound')
+    );
+    assert.equal((await repos.approvalGrants.findById(grantA.id))?.consumedAt, null);
+    assert.equal((await repos.totp.findDelegationConsentById(consentB.id))?.usedAt, null);
   });
 });

--- a/apps/purrmission-bot/src/domain/auth.test.ts
+++ b/apps/purrmission-bot/src/domain/auth.test.ts
@@ -10,6 +10,7 @@ type MockedAuthRepository = {
   findSessionByDeviceCode: Mock<AuthRepository['findSessionByDeviceCode']>;
   findSessionByUserCode: Mock<AuthRepository['findSessionByUserCode']>;
   updateSessionStatus: Mock<AuthRepository['updateSessionStatus']>;
+  transitionSessionStatus: Mock<AuthRepository['transitionSessionStatus']>;
   createApiToken: Mock<AuthRepository['createApiToken']>;
   findApiToken: Mock<AuthRepository['findApiToken']>;
   updateApiTokenLastUsed: Mock<AuthRepository['updateApiTokenLastUsed']>;
@@ -27,6 +28,7 @@ describe('AuthService', () => {
       findSessionByDeviceCode: mock.fn<AuthRepository['findSessionByDeviceCode']>(),
       findSessionByUserCode: mock.fn<AuthRepository['findSessionByUserCode']>(),
       updateSessionStatus: mock.fn<AuthRepository['updateSessionStatus']>(),
+      transitionSessionStatus: mock.fn<AuthRepository['transitionSessionStatus']>(async () => true),
       createApiToken: mock.fn<AuthRepository['createApiToken']>(),
       findApiToken: mock.fn<AuthRepository['findApiToken']>(),
       updateApiTokenLastUsed: mock.fn<AuthRepository['updateApiTokenLastUsed']>(),
@@ -181,8 +183,9 @@ describe('AuthService', () => {
       assert.notStrictEqual(createCall.token, result?.token); // Stored token should be hash, result is plain
 
       // Should mark session as CONSUMED
-      assert.deepStrictEqual(mockRepo.updateSessionStatus.mock.calls[0].arguments, [
+      assert.deepStrictEqual(mockRepo.transitionSessionStatus.mock.calls[0].arguments, [
         'session-1',
+        'APPROVED',
         'CONSUMED',
       ]);
     });

--- a/apps/purrmission-bot/src/domain/credential_hardening.test.ts
+++ b/apps/purrmission-bot/src/domain/credential_hardening.test.ts
@@ -139,7 +139,7 @@ describe('Credential Lifecycle Hardening', () => {
   });
 
   describe('Scoped Service Principals and Double-Gated Scopes', () => {
-    test('should authorize service principal purely by capability scopes', async () => {
+    test('should fail closed for unbound service principal object scopes', async () => {
       const repos = createInMemoryRepositories();
       const authService = new AuthService(repos.auth, repos.credentials);
 
@@ -171,14 +171,14 @@ describe('Credential Lifecycle Hardening', () => {
         slug: 'staging',
       });
 
-      // Double-gate authorization checks
-      // Allowed scope
+      // Capability names are not object bindings. #121 must bind the credential to exact targets
+      // before a service principal may authorize either object.
       const evalView = await hasCapability(repos, principal, 'environment.view', {
         projectId: project.id,
         environmentId: env.id,
       });
-      assert.strictEqual(evalView.allowed, true);
-      assert.strictEqual(evalView.reasonCode, 'SERVICE');
+      assert.strictEqual(evalView.allowed, false);
+      assert.strictEqual(evalView.reasonCode, 'TARGET_SCOPE_MISMATCH');
 
       // Denied scope
       const evalDelete = await hasCapability(repos, principal, 'environment.delete', {

--- a/apps/purrmission-bot/src/domain/models.ts
+++ b/apps/purrmission-bot/src/domain/models.ts
@@ -165,7 +165,10 @@ export interface DecisionResult {
 /**
  * Input for creating a new resource.
  */
-export type CreateResourceInput = Omit<Resource, 'createdAt' | 'version'> & { version?: string };
+export type CreateResourceInput = Omit<Resource, 'id' | 'createdAt' | 'version'> & {
+  id?: string;
+  version?: string;
+};
 
 /**
  * Input for adding a new guardian.

--- a/apps/purrmission-bot/src/domain/models.ts
+++ b/apps/purrmission-bot/src/domain/models.ts
@@ -572,6 +572,8 @@ export interface CapabilityContext {
   environmentId?: string;
   resourceId?: string;
   totpAccountId?: string;
+  /** Distinguishes Resource-owner link authority from custody-owner unlink authority. */
+  totpLinkOperation?: 'LINK' | 'UNLINK';
   requestId?: string;
   fieldName?: string; // specific secret/field
   subjectId?: string;

--- a/apps/purrmission-bot/src/domain/outbox_worker.ts
+++ b/apps/purrmission-bot/src/domain/outbox_worker.ts
@@ -111,11 +111,11 @@ export class OutboxWorker {
     });
 
     // Update message reference inside transaction
-    await this.repos.approvalRequests.update(requestId, {
-      status: request.status,
-      discordMessageId: sentMsg.id,
-      discordChannelId: sentMsg.channelId,
-    });
+    await this.repos.approvalRequests.updateDeliveryReference(
+      requestId,
+      sentMsg.id,
+      sentMsg.channelId
+    );
 
     logger.info('Outbox worker delivered Guardian notification', {
       requestId,

--- a/apps/purrmission-bot/src/domain/policy.test.ts
+++ b/apps/purrmission-bot/src/domain/policy.test.ts
@@ -827,6 +827,22 @@ describe('Principal and exact-object capability policy', () => {
     );
     assert.equal(requestResourceMismatch.allowed, false);
     assert.equal(requestResourceMismatch.reasonCode, 'TARGET_SCOPE_MISMATCH');
+
+    const repositories = capabilityRepositories({
+      request: approvalRequest(REQUESTER_ID),
+    });
+    repositories.projects.getEnvironmentById = async (projectId, environmentId) =>
+      projectId === PROJECT_ID && environmentId === ENVIRONMENT_ID
+        ? { ...environment, resourceId: undefined }
+        : null;
+    const environmentRequestMismatch = await hasCapability(
+      repositories,
+      createDiscordPrincipal(OWNER_ID),
+      'request.decide',
+      { projectId: PROJECT_ID, environmentId: ENVIRONMENT_ID, requestId: 'request-1' }
+    );
+    assert.equal(environmentRequestMismatch.allowed, false);
+    assert.equal(environmentRequestMismatch.reasonCode, 'TARGET_SCOPE_MISMATCH');
   });
 });
 

--- a/apps/purrmission-bot/src/domain/policy.test.ts
+++ b/apps/purrmission-bot/src/domain/policy.test.ts
@@ -33,6 +33,7 @@ const OWNER_ID = 'owner-user';
 const WRITER_ID = 'writer-user';
 const READER_ID = 'reader-user';
 const GUARDIAN_ID = 'guardian-user';
+const CUSTODY_OWNER_ID = 'custody-owner-user';
 const MIXED_ID = 'mixed-user';
 const REQUESTER_ID = 'requester-user';
 
@@ -117,6 +118,12 @@ const totpAccount: TOTPAccount = {
   updatedAt: new Date('2026-01-01T00:00:00Z'),
 };
 
+const custodyOwnedTotpAccount: TOTPAccount = {
+  ...totpAccount,
+  id: 'totp-custody-owned',
+  ownerDiscordUserId: CUSTODY_OWNER_ID,
+};
+
 function approvalRequest(
   requesterId: string,
   overrides: Partial<ApprovalRequest> = {}
@@ -173,6 +180,13 @@ function capabilityRepositories(options?: {
   approvalLookup?: () => void;
 }): CapabilityRepositories {
   return {
+    resources: {
+      async findById(resourceId) {
+        return resourceId === RESOURCE_ID
+          ? { ...resource, totpAccountId: custodyOwnedTotpAccount.id }
+          : null;
+      },
+    },
     guardians: {
       async findByResourceAndUser(resourceId, userId) {
         if (resourceId !== RESOURCE_ID) return null;
@@ -210,7 +224,14 @@ function capabilityRepositories(options?: {
     },
     totp: {
       async findById(totpAccountId) {
-        return totpAccountId === totpAccount.id ? totpAccount : null;
+        if (totpAccountId === totpAccount.id) return totpAccount;
+        if (totpAccountId === custodyOwnedTotpAccount.id) return custodyOwnedTotpAccount;
+        return null;
+      },
+      async findMetadataById(totpAccountId) {
+        if (totpAccountId === totpAccount.id) return totpAccount;
+        if (totpAccountId === custodyOwnedTotpAccount.id) return custodyOwnedTotpAccount;
+        return null;
       },
     },
   };
@@ -528,6 +549,50 @@ describe('Principal and exact-object capability policy', () => {
         assert.equal(result.allowed, false, `${entry.role} should not have ${capability}`);
       }
     }
+  });
+
+  it('allows a TOTP custody owner to unlink only, without granting link or Guardian authority', async () => {
+    const repositories = capabilityRepositories();
+    repositories.totp.findById = async () => {
+      throw new Error('value-bearing TOTP lookup must not run during link authorization');
+    };
+    const unlinkContext: CapabilityContext = {
+      resourceId: RESOURCE_ID,
+      totpAccountId: custodyOwnedTotpAccount.id,
+      totpLinkOperation: 'UNLINK',
+    };
+
+    const custodyUnlink = await hasCapability(
+      repositories,
+      createDiscordPrincipal(CUSTODY_OWNER_ID),
+      'totp.link.manage',
+      unlinkContext
+    );
+    const custodyLink = await hasCapability(
+      repositories,
+      createDiscordPrincipal(CUSTODY_OWNER_ID),
+      'totp.link.manage',
+      { ...unlinkContext, totpLinkOperation: 'LINK' }
+    );
+    const guardianUnlink = await hasCapability(
+      repositories,
+      createDiscordPrincipal(GUARDIAN_ID),
+      'totp.link.manage',
+      unlinkContext
+    );
+    const mismatchedResourceUnlink = await hasCapability(
+      repositories,
+      createDiscordPrincipal(CUSTODY_OWNER_ID),
+      'totp.link.manage',
+      { ...unlinkContext, resourceId: 'different-resource' }
+    );
+
+    assert.equal(custodyUnlink.allowed, true);
+    assert.deepEqual(custodyUnlink.authoritySources, ['TOTP_OWNER']);
+    assert.equal(custodyLink.allowed, false);
+    assert.equal(guardianUnlink.allowed, false);
+    assert.equal(mismatchedResourceUnlink.allowed, false);
+    assert.equal(mismatchedResourceUnlink.reasonCode, 'TARGET_SCOPE_MISMATCH');
   });
 
   it('fails closed when an Environment does not belong to the supplied Project', async () => {

--- a/apps/purrmission-bot/src/domain/policy.test.ts
+++ b/apps/purrmission-bot/src/domain/policy.test.ts
@@ -744,7 +744,7 @@ describe('Principal and exact-object capability policy', () => {
     assert.equal(otherTokens.reasonCode, 'AUTH_SUBJECT_MISMATCH');
   });
 
-  it('double-gates service audit export with a same-credential read scope', async () => {
+  it('fails closed for unbound service object scopes while retaining exact own-subject audit', async () => {
     const service: Principal = {
       type: 'SERVICE',
       id: 'service-credential',
@@ -757,16 +757,16 @@ describe('Principal and exact-object capability policy', () => {
       projectId: PROJECT_ID,
       requiredAudience: 'internal',
     });
-    assert.equal(denied.reasonCode, 'INSUFFICIENT_SCOPES');
+    assert.equal(denied.reasonCode, 'TARGET_SCOPE_MISMATCH');
 
-    const allowed = await hasCapability(
+    const unboundProject = await hasCapability(
       capabilityRepositories(),
       { ...service, scopes: ['audit.export', 'audit.full.read'] },
       'audit.export',
       { projectId: PROJECT_ID, requiredAudience: 'internal' }
     );
-    assert.equal(allowed.allowed, true);
-    assert.deepEqual(allowed.authoritySources, ['SCOPED_CREDENTIAL']);
+    assert.equal(unboundProject.allowed, false);
+    assert.equal(unboundProject.reasonCode, 'TARGET_SCOPE_MISMATCH');
 
     const wrongTargetReadScope = await hasCapability(
       capabilityRepositories(),
@@ -775,7 +775,7 @@ describe('Principal and exact-object capability policy', () => {
       { projectId: PROJECT_ID, requiredAudience: 'internal' }
     );
     assert.equal(wrongTargetReadScope.allowed, false);
-    assert.equal(wrongTargetReadScope.reasonCode, 'INSUFFICIENT_SCOPES');
+    assert.equal(wrongTargetReadScope.reasonCode, 'TARGET_SCOPE_MISMATCH');
 
     const ownTarget = await hasCapability(
       capabilityRepositories(),
@@ -805,6 +805,28 @@ describe('Principal and exact-object capability policy', () => {
 
     assert.equal(result.allowed, false);
     assert.equal(result.reasonCode, 'TARGET_SCOPE_MISMATCH');
+  });
+
+  it('rejects contradictory Project/Resource and approval-request/Resource contexts', async () => {
+    const projectResourceMismatch = await hasCapability(
+      capabilityRepositories(),
+      createDiscordPrincipal(OWNER_ID),
+      'resource.view',
+      { projectId: PROJECT_ID, resourceId: STANDALONE_RESOURCE_ID }
+    );
+    assert.equal(projectResourceMismatch.allowed, false);
+    assert.equal(projectResourceMismatch.reasonCode, 'TARGET_SCOPE_MISMATCH');
+
+    const requestResourceMismatch = await hasCapability(
+      capabilityRepositories({
+        request: approvalRequest(REQUESTER_ID, { resourceId: STANDALONE_RESOURCE_ID }),
+      }),
+      createDiscordPrincipal(OWNER_ID),
+      'request.decide',
+      { projectId: PROJECT_ID, resourceId: RESOURCE_ID, requestId: 'request-1' }
+    );
+    assert.equal(requestResourceMismatch.allowed, false);
+    assert.equal(requestResourceMismatch.reasonCode, 'TARGET_SCOPE_MISMATCH');
   });
 });
 

--- a/apps/purrmission-bot/src/domain/policy.ts
+++ b/apps/purrmission-bot/src/domain/policy.ts
@@ -5,6 +5,7 @@
 import type {
   Resource,
   Guardian,
+  ApprovalRequest,
   Principal,
   Capability,
   CapabilityContext,
@@ -374,6 +375,19 @@ export async function hasCapability(
     return deny('INSUFFICIENT_SCOPES', 'Credential has no capability scopes.');
   }
 
+  // Service credentials currently carry capability names but no immutable target binding. A scope
+  // alone must not authorize an arbitrary caller-supplied object. #121 owns target-bound service
+  // credentials; until then only the service's exact own-subject audit target can proceed.
+  if (
+    principal.type === 'SERVICE' &&
+    (target.type !== 'SUBJECT' || target.id !== authorizationSubjectId(principal))
+  ) {
+    return deny(
+      'TARGET_SCOPE_MISMATCH',
+      'Service credential is not bound to this exact authorization target.'
+    );
+  }
+
   // Resolve roles
   let pOwnerId: string | null = null;
   let pMemberRole: 'WRITER' | 'READER' | null = null;
@@ -381,6 +395,7 @@ export async function hasCapability(
 
   let projectId = context.projectId;
   let resourceId = context.resourceId;
+  let resolvedRequest: ApprovalRequest | null = null;
 
   if (context.environmentId && !projectId) {
     return deny(
@@ -394,9 +409,33 @@ export async function hasCapability(
     if (!env) {
       return deny('TARGET_SCOPE_MISMATCH', 'Environment does not belong to the requested Project.');
     }
+    if (resourceId && env.resourceId !== resourceId) {
+      return deny('TARGET_SCOPE_MISMATCH', 'Environment does not contain the requested Resource.');
+    }
     projectId = env.projectId;
     if (env.resourceId) {
       resourceId = env.resourceId;
+    }
+  }
+
+  if (context.requestId) {
+    resolvedRequest = await repositories.approvalRequests.findById(context.requestId);
+    if (!resolvedRequest) {
+      return deny('TARGET_SCOPE_MISMATCH', 'Approval request target does not exist.');
+    }
+    if (resourceId && resolvedRequest.resourceId !== resourceId) {
+      return deny(
+        'TARGET_SCOPE_MISMATCH',
+        'Approval request does not belong to the requested Resource.'
+      );
+    }
+    resourceId = resolvedRequest.resourceId;
+  }
+
+  if (resourceId && projectId && repositories.projects) {
+    const resourceEnvironment = await repositories.projects.findEnvironmentByResourceId(resourceId);
+    if (!resourceEnvironment || resourceEnvironment.projectId !== projectId) {
+      return deny('TARGET_SCOPE_MISMATCH', 'Resource does not belong to the requested Project.');
     }
   }
 
@@ -436,13 +475,6 @@ export async function hasCapability(
   isProjectOwner = pOwnerId !== null;
   const isProjectLinked = !!projectId;
   const isResourceOwner = isProjectOwner || (!isProjectLinked && explicitGuardianRole === 'OWNER');
-
-  // Non-audit service operations are authorized by their explicit credential scope after exact
-  // target relationships above have been validated. Audit scopes require additional target-shape
-  // checks in their capability cases, and export must re-evaluate a read capability on this target.
-  if (principal.type === 'SERVICE' && !capability.startsWith('audit.')) {
-    return allow('SERVICE', 'Scoped service credential permits this operation.');
-  }
 
   switch (capability) {
     // --- PROJECT CAPABILITIES ---
@@ -625,9 +657,8 @@ export async function hasCapability(
 
     case 'request.view-own':
     case 'request.cancel-own':
-      if (context.requestId && repositories.approvalRequests && userId) {
-        const req = await repositories.approvalRequests.findById(context.requestId);
-        if (req?.requesterId === userId) {
+      if (resolvedRequest && userId) {
+        if (resolvedRequest.requesterId === userId) {
           return allow('READER', 'Requester may view or cancel their own request.', [
             'AUTHENTICATED_SUBJECT',
           ]);
@@ -642,9 +673,11 @@ export async function hasCapability(
       return deny('NO_ROLE', 'No role to view approval queue');
 
     case 'request.decide':
-      if (context.requestId && repositories.approvalRequests && userId) {
-        const req = await repositories.approvalRequests.findById(context.requestId);
-        if (req?.requesterId === userId) {
+      if (!resolvedRequest) {
+        return deny('MISSING_CONTEXT', 'Request decisions require an exact approval request.');
+      }
+      if (userId) {
+        if (resolvedRequest.requesterId === userId) {
           return deny('SELF_APPROVAL_FORBIDDEN', 'A requester cannot decide their own request.');
         }
       }

--- a/apps/purrmission-bot/src/domain/policy.ts
+++ b/apps/purrmission-bot/src/domain/policy.ts
@@ -6,6 +6,7 @@ import type {
   Resource,
   Guardian,
   ApprovalRequest,
+  Environment,
   Principal,
   Capability,
   CapabilityContext,
@@ -396,6 +397,7 @@ export async function hasCapability(
   let projectId = context.projectId;
   let resourceId = context.resourceId;
   let resolvedRequest: ApprovalRequest | null = null;
+  let resolvedEnvironment: Environment | null = null;
 
   if (context.environmentId && !projectId) {
     return deny(
@@ -409,6 +411,7 @@ export async function hasCapability(
     if (!env) {
       return deny('TARGET_SCOPE_MISMATCH', 'Environment does not belong to the requested Project.');
     }
+    resolvedEnvironment = env;
     if (resourceId && env.resourceId !== resourceId) {
       return deny('TARGET_SCOPE_MISMATCH', 'Environment does not contain the requested Resource.');
     }
@@ -430,6 +433,13 @@ export async function hasCapability(
       );
     }
     resourceId = resolvedRequest.resourceId;
+  }
+
+  if (resolvedEnvironment && resourceId && resolvedEnvironment.resourceId !== resourceId) {
+    return deny(
+      'TARGET_SCOPE_MISMATCH',
+      'Resolved Resource does not belong to the requested Environment.'
+    );
   }
 
   if (resourceId && projectId && repositories.projects) {

--- a/apps/purrmission-bot/src/domain/policy.ts
+++ b/apps/purrmission-bot/src/domain/policy.ts
@@ -37,6 +37,7 @@ import type {
 } from './repositories.js';
 
 export interface CapabilityRepositories {
+  resources: Pick<ResourceRepository, 'findById'>;
   guardians: Pick<GuardianRepository, 'findByResourceAndUser'>;
   projects: Pick<
     ProjectRepository,
@@ -44,7 +45,7 @@ export interface CapabilityRepositories {
   >;
   approvalRequests: Pick<ApprovalRequestRepository, 'findById'>;
   approvalGrants: Pick<ApprovalGrantRepository, 'findById'>;
-  totp: Pick<TOTPRepository, 'findById'>;
+  totp: Pick<TOTPRepository, 'findById' | 'findMetadataById'>;
 }
 
 export interface EffectiveGuardianRepositories {
@@ -544,7 +545,7 @@ export async function hasCapability(
 
     case 'totp.recovery.read':
       if (context.totpAccountId && repositories.totp && userId) {
-        const totpAcc = await repositories.totp.findById(context.totpAccountId);
+        const totpAcc = await repositories.totp.findMetadataById(context.totpAccountId);
         if (totpAcc && totpAcc.ownerDiscordUserId === userId) {
           return allow('OWNER', 'Personal TOTP Owner can view recovery key', ['TOTP_OWNER']);
         }
@@ -556,11 +557,31 @@ export async function hasCapability(
 
     case 'totp.link.manage':
       if (isResourceOwner) return allow('OWNER', 'Resource Owner can manage TOTP link');
+      if (
+        context.totpLinkOperation === 'UNLINK' &&
+        context.resourceId &&
+        context.totpAccountId &&
+        repositories.resources &&
+        repositories.totp &&
+        userId
+      ) {
+        const linkedResource = await repositories.resources.findById(context.resourceId);
+        if (linkedResource?.totpAccountId !== context.totpAccountId) {
+          return deny(
+            'TARGET_SCOPE_MISMATCH',
+            'TOTP account is not linked to the requested Resource.'
+          );
+        }
+        const totpAcc = await repositories.totp.findMetadataById(context.totpAccountId);
+        if (totpAcc?.ownerDiscordUserId === userId) {
+          return allow('OWNER', 'TOTP custody owner can unlink their account', ['TOTP_OWNER']);
+        }
+      }
       return deny('NO_ROLE', 'Only Resource Owner can manage TOTP link');
 
     case 'totp.account.manage':
       if (context.totpAccountId && repositories.totp && userId) {
-        const totpAcc = await repositories.totp.findById(context.totpAccountId);
+        const totpAcc = await repositories.totp.findMetadataById(context.totpAccountId);
         if (totpAcc && totpAcc.ownerDiscordUserId === userId) {
           return allow('OWNER', 'Personal TOTP Owner can manage account', ['TOTP_OWNER']);
         }

--- a/apps/purrmission-bot/src/domain/ports_impl.ts
+++ b/apps/purrmission-bot/src/domain/ports_impl.ts
@@ -114,50 +114,15 @@ export class DomainPortsImpl implements DomainPorts {
 
   // Secrets & Reveal Operations
   async getSecrets(
-    principal: Principal,
-    projectId: string,
-    envId: string,
-    grantId?: string
+    _principal: Principal,
+    _projectId: string,
+    _envId: string,
+    _grantId?: string
   ): Promise<Record<string, string>> {
-    const project = await this.getProject(principal, projectId);
-    if (!project) throw new NotFoundError('Project not found');
-
-    const env = await this.projectService.getEnvironmentById(projectId, envId);
-    if (!env || !env.resourceId) throw new NotFoundError('Environment not found');
-
-    // Access check: Owner/Writer can view directly.
-    let authorized = project.ownerId === principal.subjectId;
-    if (!authorized) {
-      const role = await this.projectService.getMemberRole(projectId, principal.subjectId);
-      authorized = role === 'WRITER' || role === 'READER';
-    }
-
-    if (!authorized && grantId) {
-      // Validate and consume the approval grant
-      const consumed = await this.approvalService.consumeGrant(
-        grantId,
-        principal,
-        'secrets.read',
-        env.resourceId
-      );
-      if (consumed) {
-        authorized = true;
-      }
-    }
-
-    if (!authorized) {
-      throw new ForbiddenError('Secrets read access denied');
-    }
-
-    // Load and return secrets
-    const fields = await this.resourceService.deps.repositories.resourceFields.findByResourceId(
-      env.resourceId
-    );
-    const result: Record<string, string> = {};
-    for (const f of fields) {
-      result[f.name] = f.value;
-    }
-    return result;
+    // A GET must be safe and idempotent. Secret-value redemption consumes an exact grant, so it
+    // cannot be implemented by this read port. Keep the legacy boundary fail-closed until the
+    // dedicated authenticated, grant-consuming POST use case is introduced (#122/#128).
+    throw new ForbiddenError('Secret values require the grant-consuming redemption endpoint');
   }
 
   async setSecrets(principal: Principal, dto: BatchSetSecretsDTO): Promise<void> {

--- a/apps/purrmission-bot/src/domain/project.test.ts
+++ b/apps/purrmission-bot/src/domain/project.test.ts
@@ -51,6 +51,7 @@ describe('ProjectService', () => {
       ...input,
       id: 'p-1',
       description: null,
+      policyVersion: 'policy-v1',
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -71,6 +72,7 @@ describe('ProjectService', () => {
         name: 'P1',
         ownerId: userId,
         description: null,
+        policyVersion: 'policy-v1',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
@@ -91,6 +93,7 @@ describe('ProjectService', () => {
       name: 'P1',
       ownerId: 'user-1',
       description: null,
+      policyVersion: 'policy-v1',
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -109,6 +112,7 @@ describe('ProjectService', () => {
       name: 'My Project',
       ownerId: 'user-1',
       description: null,
+      policyVersion: 'policy-v1',
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/apps/purrmission-bot/src/domain/repositories.mock.ts
+++ b/apps/purrmission-bot/src/domain/repositories.mock.ts
@@ -30,7 +30,13 @@ import type {
   CreateApprovalGrantInput,
   CallbackDestination,
   CreateCallbackDestinationInput,
+  TOTPLinkConsent,
+  TOTPDelegationConsent,
+  TOTPLinkEnvelope,
+  OutboxEvent,
+  CreateOutboxEventInput,
 } from './models.js';
+import type { Prisma } from '@prisma/client';
 import {
   ResourceRepository,
   GuardianRepository,
@@ -44,6 +50,7 @@ import {
   CredentialRepository,
   ApprovalGrantRepository,
   CallbackDestinationRepository,
+  OutboxRepository,
 } from './repositories.js';
 import crypto from 'node:crypto';
 
@@ -366,6 +373,20 @@ export class InMemoryTOTPRepository implements TOTPRepository {
     return null;
   }
 
+  async findMetadataById(id: string): Promise<TOTPAccountMetadata | null> {
+    const account = this.accounts.get(id);
+    if (!account) return null;
+    return {
+      id: account.id,
+      ownerDiscordUserId: account.ownerDiscordUserId,
+      accountName: account.accountName,
+      issuer: account.issuer,
+      version: account.version,
+      createdAt: account.createdAt,
+      updatedAt: account.updatedAt,
+    };
+  }
+
   async findMetadataByOwnerDiscordUserId(
     ownerDiscordUserId: string
   ): Promise<TOTPAccountMetadata[]> {
@@ -399,11 +420,13 @@ export class InMemoryTOTPRepository implements TOTPRepository {
     return this.linkConsents.get(id) ?? null;
   }
 
-  async useLinkConsent(id: string): Promise<void> {
+  async useLinkConsent(id: string): Promise<boolean> {
     const found = this.linkConsents.get(id);
-    if (found) {
+    if (found && found.usedAt === null && found.expiresAt > new Date()) {
       found.usedAt = new Date();
+      return true;
     }
+    return false;
   }
 
   async createDelegationConsent(
@@ -443,11 +466,13 @@ export class InMemoryTOTPRepository implements TOTPRepository {
     return null;
   }
 
-  async useDelegationConsent(id: string): Promise<void> {
+  async useDelegationConsent(id: string): Promise<boolean> {
     const found = this.delegationConsents.get(id);
-    if (found) {
+    if (found && found.usedAt === null && found.expiresAt > new Date()) {
       found.usedAt = new Date();
+      return true;
     }
+    return false;
   }
 }
 

--- a/apps/purrmission-bot/src/domain/repositories.mock.ts
+++ b/apps/purrmission-bot/src/domain/repositories.mock.ts
@@ -64,6 +64,7 @@ export class InMemoryResourceRepository implements ResourceRepository {
   async create(input: CreateResourceInput): Promise<Resource> {
     const resource: Resource = {
       ...input,
+      id: input.id ?? crypto.randomUUID(),
       version: input.version || crypto.randomUUID(),
       createdAt: new Date(),
     };
@@ -210,6 +211,18 @@ export class InMemoryApprovalRequestRepository implements ApprovalRequestReposit
         request.resolvedBy = resolvedBy;
         request.resolvedAt = new Date();
       }
+    }
+  }
+
+  async updateDeliveryReference(
+    id: string,
+    discordMessageId: string,
+    discordChannelId: string
+  ): Promise<void> {
+    const request = this.requests.get(id);
+    if (request) {
+      request.discordMessageId = discordMessageId;
+      request.discordChannelId = discordChannelId;
     }
   }
 

--- a/apps/purrmission-bot/src/domain/repositories.ts
+++ b/apps/purrmission-bot/src/domain/repositories.ts
@@ -132,6 +132,14 @@ export interface ApprovalRequestRepository {
     tx?: Prisma.TransactionClient
   ): Promise<void>;
 
+  /** Store the Discord delivery reference after an outbox notification succeeds. */
+  updateDeliveryReference(
+    id: string,
+    discordMessageId: string,
+    discordChannelId: string,
+    tx?: Prisma.TransactionClient
+  ): Promise<void>;
+
   /**
    * Find an approval request by its ID.
    */
@@ -352,7 +360,7 @@ export class PrismaResourceRepository implements ResourceRepository {
     id: string;
     name: string;
     mode: string;
-    apiKey: string;
+    apiKey: string | null;
     totpAccountId: string | null;
     totpDelegationEnvelope: any;
     version: string;
@@ -1001,7 +1009,7 @@ export class PrismaAuditRepository implements AuditRepository {
         grantId: input.grantId ?? null,
         correlationId: input.correlationId ?? null,
         causationId: input.causationId ?? null,
-        payload: input.payload ? (input.payload as Prisma.InputJsonValue) : null,
+        payload: input.payload ? (input.payload as Prisma.InputJsonValue) : Prisma.JsonNull,
       },
     });
     return this.mapPrismaToDomain(created);
@@ -1246,7 +1254,7 @@ export class PrismaApprovalRequestRepository implements ApprovalRequestRepositor
         id: input.id,
         resourceId: input.resourceId,
         status: input.status,
-        context: input.context ? (input.context as Prisma.InputJsonValue) : null,
+        context: input.context ? (input.context as Prisma.InputJsonValue) : Prisma.JsonNull,
         requesterId: input.requesterId,
         requesterType: input.requesterType,
         authKind: input.authKind,
@@ -1280,6 +1288,19 @@ export class PrismaApprovalRequestRepository implements ApprovalRequestRepositor
     await client.approvalRequest.update({
       where: { id },
       data,
+    });
+  }
+
+  async updateDeliveryReference(
+    id: string,
+    discordMessageId: string,
+    discordChannelId: string,
+    tx?: Prisma.TransactionClient
+  ): Promise<void> {
+    const client = tx || this.prisma;
+    await client.approvalRequest.update({
+      where: { id },
+      data: { discordMessageId, discordChannelId },
     });
   }
 

--- a/apps/purrmission-bot/src/domain/repositories.ts
+++ b/apps/purrmission-bot/src/domain/repositories.ts
@@ -48,6 +48,9 @@ import type {
   CreateOutboxEventInput,
   TOTPAccountMetadata,
   ResourceFieldMetadata,
+  TOTPLinkConsent,
+  TOTPDelegationConsent,
+  TOTPLinkEnvelope,
   CallbackDestination,
   CreateCallbackDestinationInput,
 } from './models.js';
@@ -203,6 +206,7 @@ export interface TOTPRepository {
   findById(id: string): Promise<TOTPAccount | null>;
   findByOwnerDiscordUserId(ownerDiscordUserId: string): Promise<TOTPAccount[]>;
   findByOwnerAndName(ownerDiscordUserId: string, accountName: string): Promise<TOTPAccount | null>;
+  findMetadataById(id: string): Promise<TOTPAccountMetadata | null>;
   findMetadataByOwnerDiscordUserId(ownerDiscordUserId: string): Promise<TOTPAccountMetadata[]>;
 
   createLinkConsent(
@@ -210,7 +214,7 @@ export interface TOTPRepository {
     tx?: Prisma.TransactionClient
   ): Promise<TOTPLinkConsent>;
   findLinkConsentById(id: string): Promise<TOTPLinkConsent | null>;
-  useLinkConsent(id: string, tx?: Prisma.TransactionClient): Promise<void>;
+  useLinkConsent(id: string, tx?: Prisma.TransactionClient): Promise<boolean>;
 
   createDelegationConsent(
     input: Omit<TOTPDelegationConsent, 'id' | 'createdAt' | 'usedAt'>,
@@ -222,7 +226,7 @@ export interface TOTPRepository {
     requesterId: string,
     operation: string
   ): Promise<TOTPDelegationConsent | null>;
-  useDelegationConsent(id: string, tx?: Prisma.TransactionClient): Promise<void>;
+  useDelegationConsent(id: string, tx?: Prisma.TransactionClient): Promise<boolean>;
 }
 
 /**
@@ -550,6 +554,21 @@ export class PrismaTOTPRepository implements TOTPRepository {
     return row ? this.mapPrismaToDomain(row) : null;
   }
 
+  async findMetadataById(id: string): Promise<TOTPAccountMetadata | null> {
+    return this.prisma.tOTPAccount.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        ownerDiscordUserId: true,
+        accountName: true,
+        issuer: true,
+        version: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
   async findMetadataByOwnerDiscordUserId(
     ownerDiscordUserId: string
   ): Promise<TOTPAccountMetadata[]> {
@@ -612,12 +631,13 @@ export class PrismaTOTPRepository implements TOTPRepository {
     };
   }
 
-  async useLinkConsent(id: string, tx?: Prisma.TransactionClient): Promise<void> {
+  async useLinkConsent(id: string, tx?: Prisma.TransactionClient): Promise<boolean> {
     const client = tx || this.prisma;
-    await client.tOTPLinkConsent.update({
-      where: { id },
+    const result = await client.tOTPLinkConsent.updateMany({
+      where: { id, usedAt: null, expiresAt: { gt: new Date() } },
       data: { usedAt: new Date() },
     });
+    return result.count === 1;
   }
 
   async createDelegationConsent(
@@ -690,15 +710,30 @@ export class PrismaTOTPRepository implements TOTPRepository {
         createdAt: 'desc',
       },
     });
-    return found ? this.mapDelegationConsent(found) : null;
+    return found
+      ? {
+          id: found.id,
+          resourceId: found.resourceId,
+          totpAccountId: found.totpAccountId,
+          operation: found.operation,
+          requesterId: found.requesterId,
+          authFamily: found.authFamily,
+          accountVersion: found.accountVersion,
+          linkVersion: found.linkVersion,
+          expiresAt: found.expiresAt,
+          usedAt: found.usedAt,
+          createdAt: found.createdAt,
+        }
+      : null;
   }
 
-  async useDelegationConsent(id: string, tx?: Prisma.TransactionClient): Promise<void> {
+  async useDelegationConsent(id: string, tx?: Prisma.TransactionClient): Promise<boolean> {
     const client = tx || this.prisma;
-    await client.tOTPDelegationConsent.update({
-      where: { id },
+    const result = await client.tOTPDelegationConsent.updateMany({
+      where: { id, usedAt: null, expiresAt: { gt: new Date() } },
       data: { usedAt: new Date() },
     });
+    return result.count === 1;
   }
 
   private mapPrismaToDomain(row: {

--- a/apps/purrmission-bot/src/domain/services.test.ts
+++ b/apps/purrmission-bot/src/domain/services.test.ts
@@ -162,12 +162,11 @@ describe('ResourceService', () => {
   });
 
   describe('listGuardians', () => {
-    it('should list guardians if actor is authorized', async () => {
-      // Mock Actor is Guardian
+    it('should list guardians if actor is the Resource Owner', async () => {
       (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
         async (_rid: unknown, uid: unknown) => {
-          if (uid === guardianId)
-            return { id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian;
+          if (uid === ownerId)
+            return { id: 'g1', role: 'OWNER', discordUserId: ownerId } as Guardian;
           return null;
         }
       );
@@ -180,19 +179,21 @@ describe('ResourceService', () => {
         ]
       );
 
-      const result = await resourceService.listGuardians(resourceId, guardianId);
+      const result = await resourceService.listGuardians(resourceId, ownerId);
 
       assert.strictEqual(result.success, true);
       assert.strictEqual(result.guardians?.length, 2);
     });
 
-    it('should fail if actor is unauthorized', async () => {
-      // Mock Actor not found
+    it('should fail if actor is an explicit Guardian rather than the Owner', async () => {
       (mockGuardianRepo.findByResourceAndUser as unknown as MockedFn).mock.mockImplementation(
-        async () => null
+        async (_rid: unknown, uid: unknown) =>
+          uid === guardianId
+            ? ({ id: 'g2', role: 'GUARDIAN', discordUserId: guardianId } as Guardian)
+            : null
       );
 
-      const result = await resourceService.listGuardians(resourceId, otherId);
+      const result = await resourceService.listGuardians(resourceId, guardianId);
 
       assert.strictEqual(result.success, false);
       assert.match(result.error ?? '', /Access denied/);
@@ -200,64 +201,11 @@ describe('ResourceService', () => {
   });
 
   describe('linkTOTPAccount', () => {
-    it('should fail and roll back if audit logging throws an error', async () => {
-      const mockResource = { id: resourceId, totpAccountId: null };
-      const mockTotpAccount = { id: 'totp-1', version: 1 };
-      const mockConsent = {
-        id: 'consent-1',
-        accountId: 'totp-1',
-        resourceId,
-        ownerDiscordUserId: ownerId,
-        delegationPolicy: {},
-        expiresAt: new Date(Date.now() + 60000),
-        usedAt: null,
-      };
-
-      const mockTotpRepo = {
-        findById: mock.fn(async () => mockTotpAccount),
-        findLinkConsentById: mock.fn(async () => mockConsent),
-        useLinkConsent: mock.fn(async () => {}),
-      };
-
-      mockResourceRepo.findById = mock.fn(
-        async () => mockResource
-      ) as unknown as ResourceRepository['findById'];
-      mockResourceRepo.update = mock.fn(
-        async () => mockResource
-      ) as unknown as ResourceRepository['update'];
-
-      mockGuardianRepo.findByResourceAndUser = mock.fn(async (_rid: string, uid: string) => {
-        if (uid === ownerId) {
-          return {
-            id: 'g1',
-            resourceId,
-            role: 'OWNER',
-            discordUserId: ownerId,
-            createdAt: new Date(),
-          } satisfies Guardian;
-        }
-        return null;
-      }) as unknown as GuardianRepository['findByResourceAndUser'];
-
-      const failingAuditService = {
-        log: mock.fn(async () => {
-          throw new Error('Audit service unavailable');
-        }),
-      };
-
-      const deps: ServiceDependencies = {
-        repositories: {
-          ...mockRepositories,
-          totp: mockTotpRepo as unknown as Repositories['totp'],
-        },
-        audit: failingAuditService as unknown as ServiceDependencies['audit'],
-      };
-      const svc = new ResourceService(deps);
-
-      // Should throw due to audit service failure
-      await assert.rejects(async () => {
-        await svc.linkTOTPAccount(resourceId, 'totp-1', ownerId, 'consent-1');
-      }, /Audit service unavailable/);
+    it('fails closed before reading or mutating repositories', async () => {
+      await assert.rejects(
+        resourceService.linkTOTPAccount(resourceId, 'totp-1', ownerId, 'consent-1'),
+        /deferred.*#120/i
+      );
     });
   });
 });
@@ -316,7 +264,7 @@ describe('ApprovalService', () => {
       );
       assert.deepStrictEqual(
         (mockApprovalRepo.findActiveByRequester as unknown as MockedFn).mock.calls[0].arguments,
-        [resourceId, requesterId]
+        [resourceId, requesterId, 'resource.view', null]
       );
     });
   });

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -1014,9 +1014,9 @@ export class ResourceService {
             {
               eventType: 'TOTP_UNLINK',
               outcomeCode: 'SUCCESS',
-              actorType: 'DISCORD_USER',
+              actorType: actorPrincipal.type,
               actorId,
-              authKind: 'DISCORD',
+              authKind: actorPrincipal.authKind,
               resourceId,
               payload: {},
             },

--- a/apps/purrmission-bot/src/domain/services.ts
+++ b/apps/purrmission-bot/src/domain/services.ts
@@ -8,6 +8,7 @@
  */
 
 import crypto from 'node:crypto';
+import type { Prisma } from '@prisma/client';
 import {
   ApprovalRequest,
   Resource,
@@ -17,17 +18,19 @@ import {
   ResourceFieldMetadata,
   TOTPLinkConsent,
   TOTPDelegationConsent,
-  TOTPLinkEnvelope,
   Credential,
   ApprovalGrant,
   Principal,
   ApprovalDecision,
   DecisionResult,
+  Capability,
+  CapabilityContext,
+  EvaluationResult,
 } from './models.js';
 import type { Repositories } from './repositories.js';
 import { logger } from '../logging/logger.js';
 import { AuditService } from './audit.js';
-import { AuthService, AccessDeniedError } from './auth.js';
+import { AuthService, AccessDeniedError, ForbiddenError } from './auth.js';
 import { ProjectService } from './project.js';
 import { ResourceNotFoundError, DuplicateError, ValidationError } from './errors.js';
 import {
@@ -89,7 +92,7 @@ export interface CreateApprovalRequestResult {
  * Application services for the Purrmission system.
  */
 export class ApprovalService {
-  private deps: ServiceDependencies;
+  readonly deps: ServiceDependencies;
 
   constructor(deps: ServiceDependencies) {
     this.deps = deps;
@@ -341,35 +344,8 @@ export class ApprovalService {
           tx
         );
 
-        if (newStatus === 'APPROVED') {
-          if (repositories.approvalGrants) {
-            // Grant expires at the earlier of: 15 minutes from now, or the request's expiry
-            const defaultGrantDurationMs = 15 * 60 * 1000; // 15 minutes
-            const requestExpiresTime = request.expiresAt
-              ? new Date(request.expiresAt).getTime()
-              : Date.now() + defaultGrantDurationMs;
-            const grantExpiresAt = new Date(
-              Math.min(Date.now() + defaultGrantDurationMs, requestExpiresTime)
-            );
-
-            await repositories.approvalGrants.create(
-              {
-                requestId: request.id,
-                resourceId: request.resourceId,
-                requesterId: request.requesterId,
-                requesterType: request.requesterType,
-                authKind: request.authKind,
-                action: request.action,
-                targetKey: request.targetKey,
-                targetVersion: request.targetVersion,
-                policyVersion: request.policyVersion,
-                constraints: request.constraints || null,
-                expiresAt: grantExpiresAt,
-              },
-              tx
-            );
-          }
-        }
+        // APPROVED is decision state, not reveal authority. The conditional transition and
+        // request-bound immutable grant model lands in #122; #117 deliberately mints no grant.
 
         if (this.deps.audit) {
           await this.deps.audit.log(
@@ -458,9 +434,6 @@ export class ApprovalService {
     action: string = 'resource.view',
     targetKey: string | null = null
   ): Promise<ApprovalRequest | null> {
-    if (action === 'resource.view' && targetKey === null) {
-      return this.deps.repositories.approvalRequests.findActiveByRequester(resourceId, requesterId);
-    }
     return this.deps.repositories.approvalRequests.findActiveByRequester(
       resourceId,
       requesterId,
@@ -576,7 +549,7 @@ export class ApprovalService {
  * Service for managing resources.
  */
 export class ResourceService {
-  private deps: ServiceDependencies;
+  readonly deps: ServiceDependencies;
 
   constructor(deps: ServiceDependencies) {
     this.deps = deps;
@@ -603,6 +576,21 @@ export class ResourceService {
    */
   async isGuardian(resourceId: string, userId: string): Promise<boolean> {
     return isEffectiveGuardian(this.deps.repositories, resourceId, userId);
+  }
+
+  /**
+   * Evaluate one exact capability against the authenticated principal and target.
+   *
+   * Legacy adapters use this narrow bridge while their full #128/#129 cutovers remain deferred.
+   * It keeps role interpretation in the domain evaluator instead of recreating broad Guardian
+   * booleans at each transport boundary.
+   */
+  async evaluateCapability(
+    principal: Principal,
+    capability: Capability,
+    context: CapabilityContext
+  ): Promise<EvaluationResult> {
+    return hasCapability(this.deps.repositories, principal, capability, context);
   }
 
   /**
@@ -754,10 +742,16 @@ export class ResourceService {
     resourceId: string,
     actorId: string
   ): Promise<{ success: boolean; guardians?: Guardian[]; error?: string }> {
-    // Verify Access
-    const hasAccess = await this.isGuardian(resourceId, actorId);
-    if (!hasAccess) {
-      return { success: false, error: 'Access denied. You must be a guardian to list guardians.' };
+    const decision = await this.evaluateCapability(
+      createDiscordPrincipal(actorId),
+      'guardian.view',
+      { resourceId }
+    );
+    if (!decision.allowed) {
+      return {
+        success: false,
+        error: 'Access denied. Only the resource owner may list Guardian assignments.',
+      };
     }
 
     const guardians = await getEffectiveGuardians(this.deps.repositories, resourceId);
@@ -943,10 +937,13 @@ export class ResourceService {
   async listApiKeys(resourceId: string, actorId: string): Promise<Credential[]> {
     const { repositories } = this.deps;
 
-    // Verify Access (actor must be resource owner or guardian)
-    const hasAccess = await this.isGuardian(resourceId, actorId);
-    if (!hasAccess) {
-      throw new Error('Access denied. You must be a guardian or owner to list API keys.');
+    const decision = await this.evaluateCapability(
+      createDiscordPrincipal(actorId),
+      'resource.api-key.list',
+      { resourceId }
+    );
+    if (!decision.allowed) {
+      throw new Error('Access denied. Only the resource owner may list API keys.');
     }
 
     const creds = await repositories.credentials.findBySubject(resourceId);
@@ -964,110 +961,24 @@ export class ResourceService {
    * Link a TOTP account to a resource using a one-time consent token.
    */
   async linkTOTPAccount(
-    resourceId: string,
-    totpAccountId: string,
-    actorId: string,
-    consentId: string
+    _resourceId: string,
+    _totpAccountId: string,
+    _principal: Principal | string,
+    _consentId: string
   ): Promise<void> {
-    const { repositories } = this.deps;
-
-    // Verify Resource Authority (actor must be resource owner)
-    const hasOwnerAccess = await isEffectiveOwner(repositories, resourceId, actorId);
-    if (!hasOwnerAccess) {
-      throw new Error('Only the resource owner can link a TOTP account.');
-    }
-
-    // Verify resource exists
-    const resource = await repositories.resources.findById(resourceId);
-    if (!resource) {
-      throw new Error(`Resource not found: ${resourceId}`);
-    }
-
-    // Verify TOTP account exists
-    const totpAccount = await repositories.totp.findById(totpAccountId);
-    if (!totpAccount) {
-      throw new Error(`TOTP account not found: ${totpAccountId}`);
-    }
-
-    // Retrieve and validate consent
-    const consent = await repositories.totp.findLinkConsentById(consentId);
-    if (!consent) {
-      throw new Error(`Link consent not found: ${consentId}`);
-    }
-    if (consent.accountId !== totpAccountId || consent.resourceId !== resourceId) {
-      throw new Error('Link consent parameters mismatch.');
-    }
-    if (consent.expiresAt < new Date()) {
-      throw new Error('Link consent has expired.');
-    }
-    if (consent.usedAt) {
-      throw new Error('Link consent has already been used.');
-    }
-
-    // Check if TOTP account is already linked to another resource
-    if (resource.totpAccountId && resource.totpAccountId !== totpAccountId) {
-      throw new Error('Resource already has a linked 2FA account. Unlink it first.');
-    }
-
-    const delegationEnvelope: TOTPLinkEnvelope = {
-      consentId: consent.id,
-      delegationPolicy: consent.delegationPolicy,
-      accountOwnerDiscordUserId: consent.ownerDiscordUserId,
-      accountVersion: totpAccount.version,
-      linkVersion: crypto.randomUUID(),
-      createdAt: new Date(),
-    };
-
-    // Update the resource with the linked TOTP account ID
-    const prisma = getPrismaClient();
-    try {
-      await prisma.$transaction(async (tx) => {
-        await repositories.totp.useLinkConsent(consentId, tx);
-        await repositories.resources.update(
-          resourceId,
-          {
-            totpAccountId,
-            totpDelegationEnvelope: delegationEnvelope,
-            version: delegationEnvelope.linkVersion,
-          },
-          tx
-        );
-
-        if (this.deps.audit) {
-          await this.deps.audit.log(
-            {
-              eventType: 'TOTP_LINK',
-              outcomeCode: 'SUCCESS',
-              actorType: 'DISCORD_USER',
-              actorId,
-              authKind: 'DISCORD',
-              resourceId,
-              payload: { totpAccountId, consentId },
-            },
-            tx
-          );
-        }
-      });
-    } catch (err) {
-      logger.error('Failed to link TOTP account atomically', {
-        resourceId,
-        totpAccountId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      throw err; // Fail closed
-    }
-
-    logger.info('Linked TOTP account to resource', {
-      resourceId,
-      totpAccountId,
-    });
+    throw new ForbiddenError(
+      'TOTP linking is deferred until authenticated, seed-version-bound custody consent lands in #120.'
+    );
   }
 
   /**
    * Unlink TOTP account from a resource.
    */
-  async unlinkTOTPAccount(resourceId: string, actorId: string): Promise<void> {
+  async unlinkTOTPAccount(resourceId: string, principal: Principal | string): Promise<void> {
     const { repositories } = this.deps;
+    const actorPrincipal =
+      typeof principal === 'string' ? createDiscordPrincipal(principal) : principal;
+    const actorId = actorPrincipal.subjectId;
 
     // Verify resource exists
     const resource = await repositories.resources.findById(resourceId);
@@ -1079,20 +990,13 @@ export class ResourceService {
       throw new Error('Resource is not linked to any TOTP account.');
     }
 
-    // Verify Actor is Resource Owner or TOTP Account Custody Owner
-    const isResourceOwner = await isEffectiveOwner(repositories, resourceId, actorId);
-    let isTotpOwner = false;
-    if (resource.totpAccountId) {
-      const totpAcc = await repositories.totp.findById(resource.totpAccountId);
-      if (totpAcc && totpAcc.ownerDiscordUserId === actorId) {
-        isTotpOwner = true;
-      }
-    }
-
-    if (!isResourceOwner && !isTotpOwner) {
-      throw new Error(
-        'Access denied. Only the resource owner or the TOTP account owner can unlink.'
-      );
+    const unlinkDecision = await this.evaluateCapability(actorPrincipal, 'totp.link.manage', {
+      resourceId,
+      totpAccountId: resource.totpAccountId,
+      totpLinkOperation: 'UNLINK',
+    });
+    if (!unlinkDecision.allowed) {
+      throw new ForbiddenError(unlinkDecision.safeExplanation);
     }
 
     // Update the resource to remove the linked TOTP account
@@ -1151,76 +1055,29 @@ export class ResourceService {
    * Create a link consent for a TOTP account.
    */
   async createTOTPLinkConsent(
-    accountId: string,
-    resourceId: string,
-    ownerDiscordUserId: string,
-    delegationPolicy: Record<string, unknown>
+    _accountId: string,
+    _resourceId: string,
+    _ownerDiscordUserId: string,
+    _delegationPolicy: Record<string, unknown>
   ): Promise<TOTPLinkConsent> {
-    const { repositories } = this.deps;
-    const acc = await repositories.totp.findById(accountId);
-    if (!acc || acc.ownerDiscordUserId !== ownerDiscordUserId) {
-      throw new Error('Only the TOTP account owner can create link consent.');
-    }
-    const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes expiry
-    return repositories.totp.createLinkConsent({
-      accountId,
-      resourceId,
-      ownerDiscordUserId,
-      delegationPolicy,
-      expiresAt,
-    });
+    throw new ForbiddenError(
+      'TOTP link consent is deferred until authenticated, seed-version-bound custody consent lands in #120.'
+    );
   }
 
   /**
    * Create a delegation consent token.
    */
   async createTOTPDelegationConsent(
-    resourceId: string,
-    totpAccountId: string,
-    requesterId: string,
-    operation: string,
-    authFamily: string
+    _resourceId: string,
+    _totpAccountId: string,
+    _requesterId: string,
+    _operation: string,
+    _authFamily: string
   ): Promise<TOTPDelegationConsent> {
-    const { repositories } = this.deps;
-
-    const resource = await repositories.resources.findById(resourceId);
-    if (!resource || resource.totpAccountId !== totpAccountId) {
-      throw new Error('Invalid resource or linked TOTP account.');
-    }
-
-    const envelope = resource.totpDelegationEnvelope;
-    if (!envelope) {
-      throw new Error('No delegation policy found on this link.');
-    }
-
-    const totpAccount = await repositories.totp.findById(totpAccountId);
-    if (!totpAccount || totpAccount.version !== envelope.accountVersion) {
-      throw new Error('Stale link delegation envelope. Seed has rotated.');
-    }
-
-    const policy = envelope.delegationPolicy;
-    if (policy.allowedOperations && Array.isArray(policy.allowedOperations)) {
-      if (!policy.allowedOperations.includes(operation)) {
-        throw new Error(`Operation ${operation} is not permitted by the delegation policy.`);
-      }
-    }
-    if (policy.allowedRequesters && Array.isArray(policy.allowedRequesters)) {
-      if (!policy.allowedRequesters.includes(requesterId)) {
-        throw new Error(`Requester ${requesterId} is not permitted by the delegation policy.`);
-      }
-    }
-
-    const expiresAt = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes short-lived
-    return repositories.totp.createDelegationConsent({
-      resourceId,
-      totpAccountId,
-      operation,
-      requesterId,
-      authFamily,
-      accountVersion: totpAccount.version,
-      linkVersion: envelope.linkVersion,
-      expiresAt,
-    });
+    throw new ForbiddenError(
+      'TOTP delegation consent is deferred until request-bound authenticated custody consent lands in #120/#122.'
+    );
   }
 
   /**
@@ -1250,88 +1107,24 @@ export class ResourceService {
       throw new Error('No 2FA account linked to this resource.');
     }
 
-    const account = await repositories.totp.findById(resource.totpAccountId);
-    if (!account) {
+    const accountMetadata = await repositories.totp.findMetadataById(resource.totpAccountId);
+    if (!accountMetadata) {
       throw new Error('TOTP account not found.');
     }
 
     if (!authorized) {
-      // Delegated access! Must consume ApprovalGrant AND TOTPDelegationConsent atomically.
-      const requesterId = userPrincipal.subjectId;
+      void grantId;
+      void consentId;
+      throw new AccessDeniedError(
+        'Delegated TOTP reveal is deferred until request-bound consent and grant authority lands in #120/#122.'
+      );
+    }
 
-      let resolvedGrantId = grantId;
-      if (!resolvedGrantId) {
-        const activeGrant = await repositories.approvalGrants.findActiveUnconsumed(
-          resourceId,
-          requesterId,
-          'totp.code.read',
-          null
-        );
-        if (!activeGrant) {
-          throw new AccessDeniedError('Access denied. No valid approval grant found.');
-        }
-        resolvedGrantId = activeGrant.id;
-      }
-
-      let resolvedConsentId = consentId;
-      if (!resolvedConsentId) {
-        const activeConsent = await repositories.totp.findActiveDelegationConsent(
-          resourceId,
-          requesterId,
-          'totp.code.read'
-        );
-        if (!activeConsent) {
-          throw new AccessDeniedError(
-            'Access denied. A current unconsumed delegation consent from the seed owner is required.'
-          );
-        }
-        resolvedConsentId = activeConsent.id;
-      }
-
-      try {
-        await this.runTransaction(async (tx) => {
-          // Retrieve and re-verify consent
-          const consent = await repositories.totp.findDelegationConsentById(resolvedConsentId!);
-          if (!consent || consent.usedAt || consent.expiresAt < new Date()) {
-            throw new AccessDeniedError('Invalid or expired delegation consent.');
-          }
-
-          // Revalidate target versions
-          if (consent.accountVersion !== account.version) {
-            throw new AccessDeniedError(
-              'TOTP account seed version has changed. Consent has been invalidated.'
-            );
-          }
-
-          if (consent.linkVersion !== resource.version) {
-            throw new AccessDeniedError(
-              'Resource link state version has changed. Consent has been invalidated.'
-            );
-          }
-
-          // Mark consent as used
-          await repositories.totp.useDelegationConsent(consent.id, tx);
-
-          // Mark grant as consumed
-          if (this.deps.approval) {
-            await this.deps.approval.consumeGrant(
-              resolvedGrantId!,
-              userPrincipal,
-              'totp.code.read',
-              resource.version,
-              resource.version,
-              tx
-            );
-          }
-        });
-      } catch (err) {
-        logger.error('Failed to consume delegated TOTP code grant and consent atomically', {
-          resourceId,
-          requesterId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        throw err; // Fail closed
-      }
+    // Load value-bearing custody data only after authorization and, for delegated access, after
+    // both exact one-time authorities have been consumed atomically.
+    const account = await repositories.totp.findById(resource.totpAccountId);
+    if (!account || account.version !== accountMetadata.version) {
+      throw new AccessDeniedError('TOTP account changed during authorization.');
     }
 
     const code = generateTOTPCode(account);

--- a/apps/purrmission-bot/src/domain/totp.test.ts
+++ b/apps/purrmission-bot/src/domain/totp.test.ts
@@ -7,7 +7,6 @@ describe('Bypassing spaces in TOTP secrets', () => {
     ownerDiscordUserId: 'user-123',
     accountName: 'Test Account',
     issuer: undefined,
-    shared: false,
   };
 
   test('should accept a valid Base32 secret without spaces', () => {
@@ -16,8 +15,7 @@ describe('Bypassing spaces in TOTP secrets', () => {
       accountBase.ownerDiscordUserId,
       accountBase.accountName,
       validSecret,
-      accountBase.issuer,
-      accountBase.shared
+      accountBase.issuer
     );
     assert.strictEqual(account.secret, validSecret);
   });
@@ -29,8 +27,7 @@ describe('Bypassing spaces in TOTP secrets', () => {
       accountBase.ownerDiscordUserId,
       accountBase.accountName,
       secretWithSpaces,
-      accountBase.issuer,
-      accountBase.shared
+      accountBase.issuer
     );
     assert.strictEqual(account.secret, expectedSecret);
   });
@@ -42,8 +39,7 @@ describe('Bypassing spaces in TOTP secrets', () => {
       accountBase.ownerDiscordUserId,
       accountBase.accountName,
       secretWithSpaces,
-      accountBase.issuer,
-      accountBase.shared
+      accountBase.issuer
     );
     assert.strictEqual(account.secret, expectedSecret);
   });
@@ -55,8 +51,7 @@ describe('Bypassing spaces in TOTP secrets', () => {
         accountBase.ownerDiscordUserId,
         accountBase.accountName,
         invalidSecret,
-        accountBase.issuer,
-        accountBase.shared
+        accountBase.issuer
       );
     }, /Invalid TOTP secret format \(Base32 expected\)/);
   });
@@ -68,8 +63,7 @@ describe('Bypassing spaces in TOTP secrets', () => {
       accountBase.ownerDiscordUserId,
       accountBase.accountName,
       secretWithMixedWhitespace,
-      accountBase.issuer,
-      accountBase.shared
+      accountBase.issuer
     );
     assert.strictEqual(account.secret, expectedSecret);
   });

--- a/apps/purrmission-bot/src/domain/totp_custody.test.ts
+++ b/apps/purrmission-bot/src/domain/totp_custody.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import { AccessDeniedError } from './auth.js';
+import { AuditService } from './audit.js';
+import type { Principal } from './models.js';
 import { createDiscordPrincipal } from './principal.js';
 import { ProjectService } from './project.js';
 import { createInMemoryRepositories } from './repositories.mock.js';
@@ -168,5 +170,34 @@ describe('TOTP custody boundaries', () => {
     await repos.resources.update(resourceId, { totpAccountId: account.id, version: 'link-v1' });
     await resourceService.unlinkTOTPAccount(resourceId, ownerId);
     assert.equal((await repos.resources.findById(resourceId))?.totpAccountId, undefined);
+  });
+
+  it('attributes unlink to the authenticated principal kind', async () => {
+    const ownerId = 'resource-owner';
+    const resourceId = await createOwnedResource(ownerId);
+    const account = await repos.totp.create({
+      ownerDiscordUserId: ownerId,
+      accountName: 'Existing linked seed',
+      secret: 'JBSWY3DPEHPK3PXP',
+    });
+    await repos.resources.update(resourceId, { totpAccountId: account.id, version: 'link-v1' });
+
+    const deps: ServiceDependencies = { repositories: repos };
+    deps.audit = new AuditService(deps);
+    const auditedResourceService = new ResourceService(deps);
+    const pawthyPrincipal: Principal = {
+      type: 'PAWTHY_TOKEN',
+      id: 'pawthy-token-1',
+      subjectId: ownerId,
+      actorDiscordId: ownerId,
+      authKind: 'PAWTHY',
+      scopes: ['totp.link.manage'],
+    };
+
+    await auditedResourceService.unlinkTOTPAccount(resourceId, pawthyPrincipal);
+    const [event] = await repos.audit.findByResourceId(resourceId);
+    assert.equal(event.actorType, 'PAWTHY_TOKEN');
+    assert.equal(event.authKind, 'PAWTHY');
+    assert.equal(event.actorId, ownerId);
   });
 });

--- a/apps/purrmission-bot/src/domain/totp_custody.test.ts
+++ b/apps/purrmission-bot/src/domain/totp_custody.test.ts
@@ -1,331 +1,172 @@
-import { describe, it, beforeEach } from 'node:test';
-import assert from 'node:assert';
-import { createInMemoryRepositories } from './repositories.mock.js';
-import { ResourceService, ApprovalService } from './services.js';
-import { ProjectService } from './project.js';
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { AccessDeniedError } from './auth.js';
 import { createDiscordPrincipal } from './principal.js';
+import { ProjectService } from './project.js';
+import { createInMemoryRepositories } from './repositories.mock.js';
+import { ApprovalService, ResourceService, type ServiceDependencies } from './services.js';
 
-describe('TOTP Custody, Consents, and Reveals', () => {
+describe('TOTP custody boundaries', () => {
   let repos: ReturnType<typeof createInMemoryRepositories>;
   let resourceService: ResourceService;
   let projectService: ProjectService;
 
   beforeEach(() => {
     repos = createInMemoryRepositories();
-    const deps: any = { repositories: repos };
-    const approval = new ApprovalService(deps);
-    deps.approval = approval;
+    const deps: ServiceDependencies = { repositories: repos };
+    deps.approval = new ApprovalService(deps);
     resourceService = new ResourceService(deps);
     projectService = new ProjectService(repos.projects, resourceService);
   });
 
-  describe('Global Shared switch removal', () => {
-    it('should only resolve personal accounts for the acting user', async () => {
-      const ownerId = 'user-owner';
-      const otherId = 'user-other';
-
-      const acc = await repos.totp.create({
-        ownerDiscordUserId: ownerId,
-        accountName: 'Personal Bank',
-        secret: 'BASE32SECRET3232323232323232',
-        issuer: 'Bank',
-      });
-
-      // Owner can find it
-      const found = await repos.totp.findByOwnerAndName(ownerId, 'Personal Bank');
-      assert.ok(found);
-      assert.strictEqual(found.id, acc.id);
-
-      // Other user cannot find it
-      const notFound = await repos.totp.findByOwnerAndName(otherId, 'Personal Bank');
-      assert.strictEqual(notFound, null);
+  async function createOwnedResource(ownerId: string): Promise<string> {
+    const project = await projectService.createProject({ name: 'Project', ownerId });
+    const environment = await projectService.createEnvironment({
+      projectId: project.id,
+      name: 'Production',
+      slug: 'prod',
     });
+    assert.ok(environment.resourceId);
+    return environment.resourceId;
+  }
+
+  it('keeps personal account lookup and recovery custody owner-scoped', async () => {
+    const account = await repos.totp.create({
+      ownerDiscordUserId: 'seed-owner',
+      accountName: 'Personal Bank',
+      secret: 'JBSWY3DPEHPK3PXP',
+      backupKey: 'RECOVERY',
+    });
+    assert.equal(
+      (await repos.totp.findByOwnerAndName('seed-owner', account.accountName))?.id,
+      account.id
+    );
+    assert.equal(await repos.totp.findByOwnerAndName('stranger', account.accountName), null);
+    assert.equal(await resourceService.revealTOTPRecoveryKey(account.id, 'seed-owner'), 'RECOVERY');
+    await assert.rejects(
+      resourceService.revealTOTPRecoveryKey(account.id, 'stranger'),
+      /Only the personal owner/
+    );
   });
 
-  describe('Consent-Bound Link Creation', () => {
-    it('should link TOTP only with valid link consent and resource ownership', async () => {
-      const ownerId = 'owner-john';
-      const strangerId = 'stranger-evil';
-
-      const project = await projectService.createProject({
-        name: 'Project Alpha',
-        ownerId,
-      });
-
-      const env = await projectService.createEnvironment({
-        name: 'Production',
-        slug: 'prod',
-        projectId: project.id,
-      });
-      assert.ok(env.resourceId);
-      const resourceId = env.resourceId;
-
-      // Create TOTP account for owner-john
-      const totpAcc = await repos.totp.create({
-        ownerDiscordUserId: ownerId,
-        accountName: 'My Auth',
-        secret: 'BASE32SECRET3232323232323232',
-      });
-
-      // 1. Attempt link without consent -> should fail
-      await assert.rejects(async () => {
-        await resourceService.linkTOTPAccount(resourceId, totpAcc.id, ownerId, 'invalid-consent');
-      }, /Link consent not found/);
-
-      // 2. Create consent but attempt link by stranger -> should fail
-      const consent = await resourceService.createTOTPLinkConsent(totpAcc.id, resourceId, ownerId, {
-        allowedOperations: ['totp.code.read'],
-      });
-
-      await assert.rejects(async () => {
-        await resourceService.linkTOTPAccount(resourceId, totpAcc.id, strangerId, consent.id);
-      }, /Only the resource owner can link/);
-
-      // 3. Link with valid consent and resource owner -> should succeed
-      await resourceService.linkTOTPAccount(resourceId, totpAcc.id, ownerId, consent.id);
-
-      // Verify delegation envelope is written on resource
-      const resource = await repos.resources.findById(resourceId);
-      assert.ok(resource);
-      assert.strictEqual(resource.totpAccountId, totpAcc.id);
-      assert.ok(resource.totpDelegationEnvelope);
-      assert.strictEqual(resource.totpDelegationEnvelope.consentId, consent.id);
-      assert.strictEqual(resource.totpDelegationEnvelope.accountOwnerDiscordUserId, ownerId);
-
-      // 4. Try to reuse the consent -> should fail (one-time consumption)
-      const consentAfterUse = await repos.totp.findLinkConsentById(consent.id);
-      assert.ok(consentAfterUse?.usedAt);
-
-      await assert.rejects(async () => {
-        await resourceService.linkTOTPAccount(resourceId, totpAcc.id, ownerId, consent.id);
-      }, /Link consent has already been used/);
+  it('fails closed for link-consent creation and linking until seed-version custody binding lands', async () => {
+    const resourceId = await createOwnedResource('resource-owner');
+    const account = await repos.totp.create({
+      ownerDiscordUserId: 'seed-owner',
+      accountName: 'Seed',
+      secret: 'JBSWY3DPEHPK3PXP',
     });
+    const oldConsent = await repos.totp.createLinkConsent({
+      accountId: account.id,
+      resourceId,
+      ownerDiscordUserId: 'seed-owner',
+      delegationPolicy: {},
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await repos.totp.update({ ...account, secret: 'KRSXG5DSNFXGOIDB' });
 
-    it('should allow either the resource owner or the TOTP owner to unlink', async () => {
-      const ownerId = 'owner-john';
-      const totpOwnerId = 'totp-alice';
-      const strangerId = 'stranger';
-
-      const project = await projectService.createProject({
-        name: 'Project Beta',
-        ownerId,
-      });
-
-      const env = await projectService.createEnvironment({
-        name: 'Prod',
-        slug: 'prod',
-        projectId: project.id,
-      });
-      const resourceId = env.resourceId!;
-
-      const totpAcc = await repos.totp.create({
-        ownerDiscordUserId: totpOwnerId,
-        accountName: 'Alice Auth',
-        secret: 'BASE32SECRET3232323232323232',
-      });
-
-      const consent = await resourceService.createTOTPLinkConsent(
-        totpAcc.id,
+    await assert.rejects(
+      resourceService.createTOTPLinkConsent(account.id, resourceId, 'seed-owner', {}),
+      /#120/
+    );
+    await assert.rejects(
+      resourceService.linkTOTPAccount(
         resourceId,
-        totpOwnerId,
-        {}
-      );
-      await resourceService.linkTOTPAccount(resourceId, totpAcc.id, ownerId, consent.id);
-
-      // Stranger cannot unlink
-      await assert.rejects(async () => {
-        await resourceService.unlinkTOTPAccount(resourceId, strangerId);
-      }, /Only the resource owner or the TOTP account owner can unlink/);
-
-      // TOTP owner can unlink
-      await resourceService.unlinkTOTPAccount(resourceId, totpOwnerId);
-
-      const resAfterUnlink = await repos.resources.findById(resourceId);
-      assert.strictEqual(resAfterUnlink?.totpAccountId, undefined);
-      assert.strictEqual(resAfterUnlink?.totpDelegationEnvelope, undefined);
-    });
+        account.id,
+        createDiscordPrincipal('resource-owner'),
+        oldConsent.id
+      ),
+      /#120/
+    );
+    assert.equal((await repos.totp.findLinkConsentById(oldConsent.id))?.usedAt, null);
+    assert.equal((await repos.resources.findById(resourceId))?.totpAccountId, undefined);
   });
 
-  describe('Code and Recovery Reveals', () => {
-    it('should restrict recovery key reveal exclusively to the account owner', async () => {
-      const ownerId = 'owner-john';
-      const strangerId = 'stranger';
-
-      const totpAcc = await repos.totp.create({
-        ownerDiscordUserId: ownerId,
-        accountName: 'Johns Auth',
-        secret: 'BASE32SECRET3232323232323232',
-        backupKey: 'BACKUP_RECOVERY_KEY',
-      });
-
-      // Owner can reveal
-      const key = await resourceService.revealTOTPRecoveryKey(totpAcc.id, ownerId);
-      assert.strictEqual(key, 'BACKUP_RECOVERY_KEY');
-
-      // Stranger gets denied
-      await assert.rejects(async () => {
-        await resourceService.revealTOTPRecoveryKey(totpAcc.id, strangerId);
-      }, /Only the personal owner of the TOTP account can view the recovery key/);
-    });
-
-    it('should allow code reveal only for authorized roles or active approved requests', async () => {
-      const ownerId = 'owner-john';
-      const requesterId = 'user-requester';
-      const strangerId = 'stranger';
-
-      const project = await projectService.createProject({
-        name: 'Project Delta',
-        ownerId,
-      });
-
-      const env = await projectService.createEnvironment({
-        name: 'Prod',
-        slug: 'prod',
-        projectId: project.id,
-      });
-      const resourceId = env.resourceId!;
-
-      const totpAcc = await repos.totp.create({
-        ownerDiscordUserId: ownerId,
-        accountName: 'Johns Auth',
-        secret: 'BASE32SECRET3232323232323232',
-      });
-
-      const consent = await resourceService.createTOTPLinkConsent(totpAcc.id, resourceId, ownerId, {
-        allowedOperations: ['totp.code.read'],
-      });
-      await resourceService.linkTOTPAccount(resourceId, totpAcc.id, ownerId, consent.id);
-
-      // Owner can reveal code directly
-      const code = await resourceService.revealTOTPCode(resourceId, ownerId);
-      assert.match(code, /^\d{6}$/);
-
-      // Stranger gets denied
-      await assert.rejects(async () => {
-        await resourceService.revealTOTPCode(resourceId, strangerId);
-      }, /Access denied/);
-
-      // Create delegation consent directly in repo
-      const currentResource = await repos.resources.findById(resourceId);
-      assert.ok(currentResource);
-      await repos.totp.createDelegationConsent({
-        resourceId,
-        totpAccountId: totpAcc.id,
-        operation: 'totp.code.read',
-        requesterId,
-        authFamily: 'DISCORD',
-        accountVersion: totpAcc.version,
-        linkVersion: currentResource.version,
-        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
-      });
-
-      // Create approved request for requester (which generates ApprovalGrant)
-      const reqRes = await resourceService.deps.approval.createApprovalRequest({
-        resourceId,
-        requesterId,
-        requesterType: 'DISCORD_USER',
-        authKind: 'DISCORD',
-        action: 'totp.code.read',
-      });
-      assert.ok(reqRes.success && reqRes.request);
-
-      const decision = await resourceService.deps.approval.recordDecision(
-        reqRes.request.id,
-        'APPROVE',
-        createDiscordPrincipal(ownerId)
-      );
-      assert.ok(decision.success);
-
-      // Requester with active approval and consent can reveal code
-      const reqCode = await resourceService.revealTOTPCode(resourceId, {
-        type: 'DISCORD_USER',
-        id: requesterId,
-        subjectId: requesterId,
-        authKind: 'DISCORD',
-        actorDiscordId: requesterId,
-      });
-      assert.match(reqCode, /^\d{6}$/);
-    });
-  });
-
-  describe('Delegation Consent and Rotations', () => {
-    it('should validate delegation consent policies and check versions', async () => {
-      const ownerId = 'owner-john';
-      const requesterId = 'user-requester';
-
-      const project = await projectService.createProject({
-        name: 'Project Epsilon',
-        ownerId,
-      });
-
-      const env = await projectService.createEnvironment({
-        name: 'Prod',
-        slug: 'prod',
-        projectId: project.id,
-      });
-      const resourceId = env.resourceId!;
-
-      const totpAcc = await repos.totp.create({
-        ownerDiscordUserId: ownerId,
-        accountName: 'Johns Auth',
-        secret: 'BASE32SECRET3232323232323232',
-      });
-
-      // Link with strict policy (only allows 'totp.code.read' and requesterId)
-      const consent = await resourceService.createTOTPLinkConsent(totpAcc.id, resourceId, ownerId, {
-        allowedOperations: ['totp.code.read'],
-        allowedRequesters: [requesterId],
-      });
-      await resourceService.linkTOTPAccount(resourceId, totpAcc.id, ownerId, consent.id);
-
-      // 1. Request consent for allowed operation and requester -> succeeds
-      const delConsent = await resourceService.createTOTPDelegationConsent(
-        resourceId,
-        totpAcc.id,
-        requesterId,
+  it('denies unauthenticated delegation-consent creation', async () => {
+    await assert.rejects(
+      resourceService.createTOTPDelegationConsent(
+        'resource-id',
+        'account-id',
+        'forged-requester',
         'totp.code.read',
-        'web-session'
-      );
-      assert.ok(delConsent);
-      assert.strictEqual(delConsent.requesterId, requesterId);
+        'forged-auth-family'
+      ),
+      /authenticated custody/
+    );
+  });
 
-      // 2. Request consent for disallowed operation -> fails
-      await assert.rejects(async () => {
-        await resourceService.createTOTPDelegationConsent(
-          resourceId,
-          totpAcc.id,
-          requesterId,
-          'totp.recovery.read',
-          'web-session'
-        );
-      }, /not permitted by the delegation policy/);
-
-      // 3. Request consent for disallowed requester -> fails
-      await assert.rejects(async () => {
-        await resourceService.createTOTPDelegationConsent(
-          resourceId,
-          totpAcc.id,
-          'stranger-requester',
-          'totp.code.read',
-          'web-session'
-        );
-      }, /not permitted by the delegation policy/);
-
-      // 4. Seed rotation (TOTP update) -> invalidates stale delegation consent creation
-      const updatedAccount = await repos.totp.update({
-        ...totpAcc,
-        secret: 'BASE32NEWSECRET32323232323232',
-      });
-
-      await assert.rejects(async () => {
-        await resourceService.createTOTPDelegationConsent(
-          resourceId,
-          updatedAccount.id,
-          requesterId,
-          'totp.code.read',
-          'web-session'
-        );
-      }, /Stale link delegation envelope/);
+  it('allows a direct Resource owner to reveal an already-linked TOTP code', async () => {
+    const ownerId = 'resource-owner';
+    const resourceId = await createOwnedResource(ownerId);
+    const account = await repos.totp.create({
+      ownerDiscordUserId: ownerId,
+      accountName: 'Existing linked seed',
+      secret: 'JBSWY3DPEHPK3PXP',
     });
+    await repos.resources.update(resourceId, { totpAccountId: account.id, version: 'link-v1' });
+
+    assert.match(await resourceService.revealTOTPCode(resourceId, ownerId), /^\d{6}$/);
+  });
+
+  it('rejects delegated reveal unconditionally even when generic grant and consent records exist', async () => {
+    const resourceId = await createOwnedResource('resource-owner');
+    const account = await repos.totp.create({
+      ownerDiscordUserId: 'seed-owner',
+      accountName: 'Existing linked seed',
+      secret: 'JBSWY3DPEHPK3PXP',
+    });
+    const resource = await repos.resources.update(resourceId, {
+      totpAccountId: account.id,
+      version: 'link-v1',
+    });
+    const grant = await repos.approvalGrants.create({
+      requestId: 'unrelated-request-a',
+      resourceId,
+      requesterId: 'requester',
+      requesterType: 'DISCORD_USER',
+      authKind: 'DISCORD',
+      action: 'totp.code.read',
+      targetKey: null,
+      targetVersion: resource.version,
+      policyVersion: resource.version,
+      constraints: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const consent = await repos.totp.createDelegationConsent({
+      resourceId,
+      totpAccountId: account.id,
+      operation: 'totp.code.read',
+      requesterId: 'requester',
+      authFamily: 'DISCORD',
+      accountVersion: account.version,
+      linkVersion: resource.version,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await assert.rejects(
+      resourceService.revealTOTPCode(
+        resourceId,
+        createDiscordPrincipal('requester'),
+        grant.id,
+        consent.id
+      ),
+      (error: unknown) =>
+        error instanceof AccessDeniedError && error.message.includes('request-bound')
+    );
+    assert.equal((await repos.approvalGrants.findById(grant.id))?.consumedAt, null);
+    assert.equal((await repos.totp.findDelegationConsentById(consent.id))?.usedAt, null);
+  });
+
+  it('allows an owner to unlink an already-linked account', async () => {
+    const ownerId = 'resource-owner';
+    const resourceId = await createOwnedResource(ownerId);
+    const account = await repos.totp.create({
+      ownerDiscordUserId: ownerId,
+      accountName: 'Existing linked seed',
+      secret: 'JBSWY3DPEHPK3PXP',
+    });
+    await repos.resources.update(resourceId, { totpAccountId: account.id, version: 'link-v1' });
+    await resourceService.unlinkTOTPAccount(resourceId, ownerId);
+    assert.equal((await repos.resources.findById(resourceId))?.totpAccountId, undefined);
   });
 });

--- a/apps/purrmission-bot/src/http/server.ts
+++ b/apps/purrmission-bot/src/http/server.ts
@@ -16,7 +16,7 @@ import {
   SlowDownError,
 } from '../domain/auth.js';
 import { ResourceNotFoundError } from '../domain/errors.js';
-import type { Principal } from '../domain/models.js';
+import type { Capability, Principal } from '../domain/models.js';
 import { createDiscordPrincipal } from '../domain/principal.js';
 import type { Services } from '../domain/services.js';
 import { logger } from '../logging/logger.js';
@@ -395,12 +395,21 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     req.principal = principal;
   }
 
-  // Authorization Hook: Verify Guardian/Owner Access
-  const verifyIsGuardian = async (req: FastifyRequest<{ Params: { id: string } }>) => {
-    const { id } = req.params;
-    if (!(await services.resource.isGuardian(id, req.user.id))) {
-      throw new AccessDeniedError('Access denied');
+  const requireResourceCapability = async (
+    req: FastifyRequest,
+    capability: Capability,
+    resourceId: string,
+    fieldName?: string
+  ): Promise<Principal> => {
+    const principal = extractPrincipal(req, req.user.id);
+    const decision = await services.resource.evaluateCapability(principal, capability, {
+      resourceId,
+      ...(fieldName ? { fieldName } : {}),
+    });
+    if (!decision.allowed) {
+      throw new ForbiddenError(decision.safeExplanation);
     }
+    return principal;
   };
 
   // Configure Zod Validator
@@ -559,101 +568,14 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     {
       preHandler: [authenticate],
     },
-    async (req, rep) => {
-      const { projectId, envId } = req.params as { projectId: string; envId: string };
-      const { grantId, keys } = (req.query || {}) as { grantId?: string; keys?: string };
-      const userId = req.user.id;
-
-      const project = await services.project.getProject(projectId);
-      if (!project) throw new ResourceNotFoundError('Project not found');
-
-      const environment = await services.project.getEnvironmentById(projectId, envId);
-      if (!environment) throw new ResourceNotFoundError('Environment not found');
-      if (!environment.resourceId)
-        throw new ResourceNotFoundError('Environment has no linked resource');
-
-      const resourceId = environment.resourceId;
-
-      const principal = extractPrincipal(req, userId);
-
-      try {
-        // Resolve active grant first if not explicitly passed
-        let resolvedGrantId = grantId;
-        if (!resolvedGrantId) {
-          const activeGrant = await services.approval.findActiveUnconsumedGrant(
-            resourceId,
-            userId,
-            'secrets.read',
-            keys || null
-          );
-          if (activeGrant) {
-            resolvedGrantId = activeGrant.id;
-          }
-        }
-
-        let secrets = await services.ports.getSecrets(principal, projectId, envId, resolvedGrantId);
-
-        if (keys) {
-          const filterKeys = new Set(
-            keys
-              .split(',')
-              .map((k) => k.trim())
-              .filter(Boolean)
-          );
-          secrets = Object.fromEntries(Object.entries(secrets).filter(([k]) => filterKeys.has(k)));
-        }
-
-        return { secrets };
-      } catch (err) {
-        if (err instanceof ForbiddenError) {
-          // Check for active approval or create one
-          const approval = await services.approval.findActiveApproval(
-            resourceId,
-            userId,
-            'secrets.read',
-            keys || null
-          );
-
-          if (approval) {
-            if (approval.status === 'PENDING') {
-              rep.status(202);
-              return {
-                status: 'pending',
-                message: 'Secret access is pending approval in Discord',
-                requestId: approval.id,
-              };
-            }
-            if (approval.status === 'APPROVED') {
-              throw new AccessDeniedError(
-                'Access denied: Active approval is approved but grant is missing or consumed.'
-              );
-            }
-            throw new AccessDeniedError('Access denied: Secrets access was denied');
-          }
-
-          // Create a new approval request
-          const result = await services.ports.createApprovalRequest(
-            principal,
-            resourceId,
-            'secrets.read',
-            keys || null
-          );
-          if (!result.success || !result.request) {
-            throw new Error(
-              `Failed to create approval request: ${result.error || 'Unknown error'}`
-            );
-          }
-          const newApproval = result.request;
-
-          rep.status(202);
-          return {
-            status: 'pending',
-            message: 'Secret access is pending approval in Discord',
-            requestId: newApproval.id,
-          };
-        }
-        throw err;
-      }
+    async (_req, rep) => {
+      // Secret redemption is a state-changing, one-time grant consumption and therefore must not
+      // happen on GET. This legacy route intentionally performs no policy lookup, approval
+      // creation, grant consumption, or value-bearing repository read.
+      return rep.status(405).header('allow', 'PUT').send({
+        error: 'method_not_allowed',
+        message: 'Secret values require the grant-consuming redemption endpoint',
+      });
     }
   );
 
@@ -703,13 +625,14 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
   server.get<{ Params: z.infer<typeof ResourceParamsSchema> }>(
     '/api/resources/:id/fields',
     {
-      preHandler: [authenticate, verifyIsGuardian],
+      preHandler: [authenticate],
       schema: {
         params: ResourceParamsSchema,
       },
     },
     async (req) => {
       const { id } = req.params;
+      await requireResourceCapability(req, 'secret.metadata.read', id);
       const fields = await services.resource.listFieldsMetadata(id);
       return fields.map((f) => f.name);
     }
@@ -721,7 +644,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
   }>(
     '/api/resources/:id/fields',
     {
-      preHandler: [authenticate, verifyIsGuardian],
+      preHandler: [authenticate],
       schema: {
         params: ResourceParamsSchema,
         body: CreateResourceFieldSchema,
@@ -730,6 +653,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     async (req, rep) => {
       const { id } = req.params;
       const { name, value } = req.body;
+      await requireResourceCapability(req, 'secret.write', id, name);
 
       const field = await services.resource.createField(id, name, value);
       return rep.status(201).send(field);
@@ -739,13 +663,14 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
   server.get<{ Params: z.infer<typeof FieldParamsSchema> }>(
     '/api/resources/:id/fields/:name',
     {
-      preHandler: [authenticate, verifyIsGuardian],
+      preHandler: [authenticate],
       schema: {
         params: FieldParamsSchema,
       },
     },
     async (req) => {
       const { id, name } = req.params;
+      await requireResourceCapability(req, 'secret.value.read', id, name);
 
       const field = await services.resource.getField(id, name);
       if (!field) {
@@ -759,13 +684,14 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
   server.delete<{ Params: z.infer<typeof FieldParamsSchema> }>(
     '/api/resources/:id/fields/:name',
     {
-      preHandler: [authenticate, verifyIsGuardian],
+      preHandler: [authenticate],
       schema: {
         params: FieldParamsSchema,
       },
     },
     async (req, rep) => {
       const { id, name } = req.params;
+      await requireResourceCapability(req, 'secret.delete', id, name);
 
       await services.resource.deleteField(id, name);
       return rep.status(204).send();
@@ -779,7 +705,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
   server.post<{ Params: z.infer<typeof ResourceParamsSchema> }>(
     '/api/resources/:id/2fa/code',
     {
-      preHandler: [authenticate, verifyIsGuardian],
+      preHandler: [authenticate],
       schema: {
         params: ResourceParamsSchema,
       },
@@ -787,8 +713,9 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     async (req, rep) => {
       const { id } = req.params;
       const userId = req.user.id;
+      const principal = extractPrincipal(req, userId);
 
-      const code = await services.resource.revealTOTPCode(id, userId);
+      const code = await services.resource.revealTOTPCode(id, principal);
       rep.header('Cache-Control', 'no-store');
       return { code };
     }
@@ -800,7 +727,7 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
   }>(
     '/api/resources/:id/2fa/link',
     {
-      preHandler: [authenticate, verifyIsGuardian],
+      preHandler: [authenticate],
       schema: {
         params: ResourceParamsSchema,
         body: LinkTotpSchema,
@@ -809,9 +736,9 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
     async (req, rep) => {
       const { id } = req.params;
       const { totpAccountId, consentId } = req.body;
-      const userId = req.user.id; // Actor ID
+      const principal = extractPrincipal(req, req.user.id);
 
-      await services.resource.linkTOTPAccount(id, totpAccountId, userId, consentId);
+      await services.resource.linkTOTPAccount(id, totpAccountId, principal, consentId);
       return rep.status(200).send({ success: true });
     }
   );
@@ -819,16 +746,16 @@ export function createHttpServer(deps: HttpServerDeps): FastifyInstance {
   server.delete<{ Params: z.infer<typeof ResourceParamsSchema> }>(
     '/api/resources/:id/2fa/link',
     {
-      preHandler: [authenticate, verifyIsGuardian],
+      preHandler: [authenticate],
       schema: {
         params: ResourceParamsSchema,
       },
     },
     async (req, rep) => {
       const { id } = req.params;
-      const userId = req.user.id;
+      const principal = extractPrincipal(req, req.user.id);
 
-      await services.resource.unlinkTOTPAccount(id, userId);
+      await services.resource.unlinkTOTPAccount(id, principal);
       return rep.status(204).send();
     }
   );

--- a/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
+++ b/apps/purrmission-bot/src/test/credential_sync_logic.test.ts
@@ -34,6 +34,7 @@ import {
   ProjectMemberRole,
   OutboxEvent,
   CreateOutboxEventInput,
+  CreateAuditLogInput,
 } from '../domain/models.js';
 import { randomUUID } from 'crypto';
 
@@ -49,6 +50,7 @@ class MemProjectRepo implements ProjectRepository {
       id: randomUUID(),
       ...input,
       description: input.description || null,
+      policyVersion: randomUUID(),
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -118,10 +120,11 @@ class MemResourceRepo implements ResourceRepository {
 
   async create(input: CreateResourceInput, _tx?: any): Promise<Resource> {
     const r: Resource = {
-      id: input.id,
+      id: input.id ?? randomUUID(),
       name: input.name,
       mode: input.mode,
       apiKey: input.apiKey,
+      version: input.version ?? randomUUID(),
       createdAt: new Date(),
     };
     this.resources.push(r);
@@ -205,6 +208,28 @@ class MemFieldRepo implements ResourceFieldRepository {
   async findById(id: string): Promise<ResourceField | null> {
     return this.fields.find((f) => f.id === id) || null;
   }
+  async findMetadataByResourceId(resourceId: string) {
+    return this.fields
+      .filter((field) => field.resourceId === resourceId)
+      .map(({ id, resourceId: fieldResourceId, name, createdAt, updatedAt }) => ({
+        id,
+        resourceId: fieldResourceId,
+        name,
+        createdAt,
+        updatedAt,
+      }));
+  }
+  async findMetadataByResourceAndName(resourceId: string, name: string) {
+    const field = this.fields.find((item) => item.resourceId === resourceId && item.name === name);
+    if (!field) return null;
+    return {
+      id: field.id,
+      resourceId: field.resourceId,
+      name: field.name,
+      createdAt: field.createdAt,
+      updatedAt: field.updatedAt,
+    };
+  }
 }
 
 class MemApprovalRepo implements ApprovalRequestRepository {
@@ -238,6 +263,17 @@ class MemApprovalRepo implements ApprovalRequestRepository {
       r.resolvedAt = new Date();
     }
   }
+  async updateDeliveryReference(
+    id: string,
+    discordMessageId: string,
+    discordChannelId: string
+  ): Promise<void> {
+    const request = this.requests.find((item) => item.id === id);
+    if (request) {
+      request.discordMessageId = discordMessageId;
+      request.discordChannelId = discordChannelId;
+    }
+  }
   async findActiveByRequester(
     resourceId: string,
     requesterId: string
@@ -251,8 +287,27 @@ class MemApprovalRepo implements ApprovalRequestRepository {
           r.resourceId === resourceId &&
           ['PENDING', 'APPROVED'].includes(r.status) &&
           (!r.expiresAt || r.expiresAt > now) &&
-          r.context['requesterId'] === requesterId
+          r.context?.['requesterId'] === requesterId
       ) || null
+    );
+  }
+  async findPending(
+    resourceId: string,
+    requesterId: string,
+    action: string,
+    targetKey: string | null
+  ): Promise<ApprovalRequest | null> {
+    const now = new Date();
+    return (
+      this.requests.find(
+        (request) =>
+          request.resourceId === resourceId &&
+          request.requesterId === requesterId &&
+          request.action === action &&
+          request.targetKey === targetKey &&
+          request.status === 'PENDING' &&
+          request.expiresAt > now
+      ) ?? null
     );
   }
   async findByResourceId(resourceId: string): Promise<ApprovalRequest[]> {
@@ -363,6 +418,9 @@ describe('Credential Sync Logic Smoke Test', () => {
     totp: totpRepo,
     audit: auditRepo,
     outbox: outboxRepo,
+    credentials: {} as Repositories['credentials'],
+    approvalGrants: {} as Repositories['approvalGrants'],
+    callbackDestinations: {} as Repositories['callbackDestinations'],
   };
 
   beforeEach(() => {

--- a/apps/purrmission-bot/src/test/system_api.test.ts
+++ b/apps/purrmission-bot/src/test/system_api.test.ts
@@ -290,144 +290,38 @@ describe('System API E2E Tests', () => {
       assert.strictEqual(data.error, 'unauthorized');
     });
 
-    it('should return 200 with secrets when requester is the project owner', async () => {
+    it('fails closed without reading values, resolving roles, or mutating approval state', async () => {
       mockValidateToken.fn = async () => pawthyPrincipal('user-owner');
-      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
-      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
-      mockListFields.fn = async () => [
-        { name: 'DB_PASS', value: 'my-pass' },
-        { name: 'API_SECRET', value: 'my-secret' },
-      ];
-
-      const response = await server.inject({
-        method: 'GET',
-        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
-        headers: {
-          Authorization: 'Bearer valid-token',
-        },
-      });
-      assert.strictEqual(response.statusCode, 200);
-      const data = JSON.parse(response.payload);
-      assert.deepStrictEqual(data.secrets, {
-        DB_PASS: 'my-pass',
-        API_SECRET: 'my-secret',
-      });
-    });
-
-    it('should return 202 pending when approval is required and is currently pending', async () => {
-      mockValidateToken.fn = async () => pawthyPrincipal('user-requester');
-      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
-      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
-      mockGetMemberRole.fn = async () => null; // not a project member
-      mockIsGuardian.fn = async () => false; // not a guardian
-      mockFindActiveApproval.fn = async () => ({
-        id: 'req-1',
-        status: 'PENDING',
-      });
-
-      const response = await server.inject({
-        method: 'GET',
-        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
-        headers: {
-          Authorization: 'Bearer valid-token',
-        },
-      });
-      assert.strictEqual(response.statusCode, 202);
-      const data = JSON.parse(response.payload);
-      assert.strictEqual(data.status, 'pending');
-      assert.strictEqual(data.requestId, 'req-1');
-    });
-
-    it('should return 200 with secrets only when an exact grant exists', async () => {
-      mockValidateToken.fn = async () => pawthyPrincipal('user-requester');
-      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
-      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
-      mockGetMemberRole.fn = async () => null;
-      mockIsGuardian.fn = async () => false;
-      mockFindActiveApproval.fn = async () => ({
-        id: 'req-1',
-        status: 'APPROVED',
-      });
-      mockFindActiveGrant.fn = async () => ({
-        id: 'grant-1',
-        requestId: 'req-1',
-        resourceId: 'res-1',
-        requesterId: 'user-requester',
-      });
-      mockListFields.fn = async () => [{ name: 'SECRET_KEY', value: 'approved-value' }];
-
-      const response = await server.inject({
-        method: 'GET',
-        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
-        headers: {
-          Authorization: 'Bearer valid-token',
-        },
-      });
-      assert.strictEqual(response.statusCode, 200);
-      const data = JSON.parse(response.payload);
-      assert.deepStrictEqual(data.secrets, {
-        SECRET_KEY: 'approved-value',
-      });
-    });
-
-    it('should automatically trigger a new approval request and return 202 when no active request exists', async () => {
-      mockValidateToken.fn = async () => pawthyPrincipal('user-requester');
-      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
-      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
-      mockGetMemberRole.fn = async () => null;
-      mockIsGuardian.fn = async () => false;
-      mockFindActiveApproval.fn = async () => null; // none exists yet
-
-      let createdRequest = false;
-      mockCreateApprovalRequest.fn = async (input: unknown) => {
-        createdRequest = true;
-        assert.strictEqual((input as { resourceId: string }).resourceId, 'res-1');
-        return {
-          success: true,
-          request: {
-            id: 'req-new',
-            status: 'PENDING',
-          },
-          resource: { id: 'res-1', name: 'MyProject:Production' },
-          guardians: [{ discordUserId: 'g-1', role: 'OWNER' }],
-        };
+      let boundaryCalls = 0;
+      mockGetProject.fn = async () => {
+        boundaryCalls += 1;
+        throw new Error('GET must not resolve project-role authority');
+      };
+      mockListFields.fn = async () => {
+        boundaryCalls += 1;
+        throw new Error('GET must not decrypt secret values');
+      };
+      mockCreateApprovalRequest.fn = async () => {
+        boundaryCalls += 1;
+        throw new Error('GET must not create approval state');
+      };
+      mockFindActiveGrant.fn = async () => {
+        boundaryCalls += 1;
+        throw new Error('GET must not consume or resolve grants');
       };
 
       const response = await server.inject({
         method: 'GET',
-        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
+        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets?grantId=grant-1&keys=DB_PASS',
         headers: {
           Authorization: 'Bearer valid-token',
         },
       });
-      assert.strictEqual(response.statusCode, 202);
+      assert.strictEqual(response.statusCode, 405);
       const data = JSON.parse(response.payload);
-      assert.strictEqual(data.status, 'pending');
-      assert.strictEqual(data.requestId, 'req-new');
-      assert.strictEqual(createdRequest, true);
-    });
-
-    it('should return 401 when access is explicitly denied', async () => {
-      mockValidateToken.fn = async () => pawthyPrincipal('user-requester');
-      mockGetProject.fn = async () => ({ ownerId: 'user-owner', name: 'MyProject' });
-      mockGetEnvironmentById.fn = async () => ({ name: 'Production', resourceId: 'res-1' });
-      mockGetMemberRole.fn = async () => null;
-      mockIsGuardian.fn = async () => false;
-      mockFindActiveApproval.fn = async () => ({
-        id: 'req-1',
-        status: 'DENIED',
-      });
-
-      const response = await server.inject({
-        method: 'GET',
-        url: '/api/projects/b0f19c99-d41c-43be-82a8-9d7a96df3222/environments/e0f19c99-d41c-43be-82a8-9d7a96df3222/secrets',
-        headers: {
-          Authorization: 'Bearer valid-token',
-        },
-      });
-      assert.strictEqual(response.statusCode, 401);
-      const data = JSON.parse(response.payload);
-      assert.strictEqual(data.error, 'unauthorized');
+      assert.strictEqual(data.error, 'method_not_allowed');
+      assert.strictEqual(response.headers.allow, 'PUT');
+      assert.strictEqual(boundaryCalls, 0);
     });
   });
 

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -13,8 +13,8 @@
 
 - [ ] **Database & Migrations**:
   - [ ] **Artifact Check**: Ensure `prisma/` directory (containing `schema.prisma`) is included in the deployment artifact.
-    - _Current Status_: **MISSING** in `deploy.yml`. Application execution might work, but migrations will fail.
-  - [ ] **Migration Check**: Run `npx prisma migrate deploy` on the server after deployment.
+    - _Current Status_: `deploy.yml` includes Prisma plus the supported migration wrapper and its Guardian reconciliation dependency.
+  - [ ] **Migration Check**: Run `pnpm prisma:deploy` on the server after deployment. This supported wrapper performs the required RBAC reconciliation before invoking Prisma.
   - [ ] **Persistence Check**: Verify SQLite database file is not overwritten/deleted during deployment cleanup.
 
 - [ ] **Dependencies**:
@@ -28,7 +28,7 @@
 3.  **Post-Deployment Server Checks**:
     - SSH into server.
     - Navigate to deployment directory.
-    - Run Migrations: `npx prisma migrate deploy` (Requires fixing artifact export first).
+    - Run Migrations: `pnpm prisma:deploy`.
     - Check PM2 status: `pm2 status`.
     - View Logs: `pm2 logs Purrmission`.
 
@@ -36,4 +36,7 @@
 
 - **"Schema not found"**: The `prisma` directory was not uploaded. Copy it manually or update `deploy.yml`.
 - **"Database is locked"**: Common with SQLite if multiple processes access it. Restart PM2.
-- **Missing Dependencies**: If `npx` or `prisma` not found, ensure they are in `dependencies` or `pnpm install` installs dev deps (default for Yarn Berry).
+- **Missing Dependencies**: If `pnpm` or Prisma is not found, ensure project dependencies were installed with `pnpm install`.
+
+> [!WARNING]
+> Direct Prisma migration CLI invocation is unsupported because it bypasses the required Guardian/owner reconciliation preflight. Operators must use `pnpm prisma:deploy`.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "discord:deploy-commands": "turbo run discord:deploy-commands",
     "prod:purrmission": "node apps/purrmission-bot/dist/index.js",
     "prisma:generate": "prisma generate",
-    "prisma:deploy": "prisma migrate deploy",
+    "prisma:deploy": "tsx scripts/deploy-migrations.ts",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:studio": "prisma studio",
     "prisma:format": "prisma format",

--- a/scripts/deploy-migrations.ts
+++ b/scripts/deploy-migrations.ts
@@ -1,0 +1,86 @@
+import 'dotenv/config';
+
+import { PrismaClient } from '@prisma/client';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { runGuardianReconciliation } from './reconcile-guardians-owners.js';
+
+const RECONCILIATION_TABLES = ['Environment', 'Guardian', 'Project', 'Resource'] as const;
+
+export type MigrationDatabaseState = 'FRESH' | 'INITIALIZED';
+
+export function classifyMigrationDatabaseTables(
+  tableNames: readonly string[]
+): MigrationDatabaseState {
+  const applicationTables = tableNames.filter(
+    (name) => name !== '_prisma_migrations' && !name.startsWith('sqlite_')
+  );
+  if (applicationTables.length === 0 && !tableNames.includes('_prisma_migrations')) {
+    return 'FRESH';
+  }
+
+  const missing = RECONCILIATION_TABLES.filter((name) => !tableNames.includes(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `Migration preflight found an initialized database missing required table(s): ${missing.join(', ')}. Refusing to bypass Guardian reconciliation.`
+    );
+  }
+  return 'INITIALIZED';
+}
+
+export async function runMigrationPreflight(prisma: PrismaClient): Promise<MigrationDatabaseState> {
+  const tables = await prisma.$queryRawUnsafe<Array<{ name: string }>>(
+    `SELECT "name" FROM "sqlite_master" WHERE "type" = 'table'`
+  );
+  const state = classifyMigrationDatabaseTables(tables.map(({ name }) => name));
+
+  if (state === 'FRESH') {
+    console.log('✅ Fresh empty database detected; Guardian reconciliation is not required.');
+    return state;
+  }
+
+  console.log('🔒 Running Guardian/owner reconciliation before published migrations...');
+  await runGuardianReconciliation(prisma, true);
+  return state;
+}
+
+export async function deployMigrations(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required for migration deployment.');
+  }
+
+  const prisma = new PrismaClient();
+  try {
+    await runMigrationPreflight(prisma);
+  } finally {
+    await prisma.$disconnect();
+  }
+
+  const result = spawnSync('pnpm', ['exec', 'prisma', 'migrate', 'deploy'], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`prisma migrate deploy exited with status ${result.status ?? 'unknown'}.`);
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    await deployMigrations();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  void main();
+}

--- a/scripts/deploy-migrations.ts
+++ b/scripts/deploy-migrations.ts
@@ -8,6 +8,8 @@ import { pathToFileURL } from 'node:url';
 import { runGuardianReconciliation } from './reconcile-guardians-owners.js';
 
 const RECONCILIATION_TABLES = ['Environment', 'Guardian', 'Project', 'Resource'] as const;
+const HARDENING_MIGRATION = '20260724110200_rbac_dashboard_hardening_remediations';
+const LEGACY_STAGE_TABLES = ['AuditLog', 'Project', 'Resource', 'TOTPAccount'] as const;
 
 export type MigrationDatabaseState = 'FRESH' | 'INITIALIZED';
 
@@ -46,14 +48,177 @@ export async function runMigrationPreflight(prisma: PrismaClient): Promise<Migra
   return state;
 }
 
+async function tableExists(prisma: PrismaClient, tableName: string): Promise<boolean> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+    `SELECT COUNT(*) AS "count" FROM "sqlite_master" WHERE "type" = 'table' AND "name" = ?`,
+    tableName
+  );
+  return Number(rows[0]?.count ?? 0) === 1;
+}
+
+async function rowCount(
+  prisma: Pick<Prisma.TransactionClient, '$queryRawUnsafe'>,
+  tableName: string
+): Promise<number> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+    `SELECT COUNT(*) AS "count" FROM "${tableName}"`
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
+async function hardeningMigrationApplied(prisma: PrismaClient): Promise<boolean> {
+  if (!(await tableExists(prisma, '_prisma_migrations'))) return false;
+  const rows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+    `SELECT COUNT(*) AS "count" FROM "_prisma_migrations"
+     WHERE "migration_name" = ? AND "finished_at" IS NOT NULL AND "rolled_back_at" IS NULL`,
+    HARDENING_MIGRATION
+  );
+  return Number(rows[0]?.count ?? 0) === 1;
+}
+
+/**
+ * Preserve rows around the published hardening migration without changing its checksum.
+ *
+ * The published SQLite table rebuild omitted values for newly-required columns. Empty tables are
+ * safe, but populated legacy tables fail during deployment. These repository-owned stage tables
+ * make the wrapper resumable: a failed deploy leaves the only copy in a plainly named table, and a
+ * later invocation resumes instead of overwriting it.
+ */
+export async function stageLegacyHardeningRows(prisma: PrismaClient): Promise<boolean> {
+  const stageAlreadyExists = await tableExists(prisma, '_purrmission_stage_Project');
+  if (await hardeningMigrationApplied(prisma)) return stageAlreadyExists;
+
+  const unmappableAuditRows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+    `SELECT COUNT(*) AS "count" FROM "AuditLog"
+     WHERE "resolverId" IS NOT NULL OR "context" IS NOT NULL`
+  );
+  if (Number(unmappableAuditRows[0]?.count ?? 0) > 0) {
+    throw new Error(
+      'Legacy AuditLog rows contain resolver/context data that cannot be safely mapped by the compatibility preflight. Refusing a lossy upgrade; complete the #118 audit migration path first.'
+    );
+  }
+
+  for (const table of LEGACY_STAGE_TABLES) {
+    await prisma.$executeRawUnsafe(
+      `CREATE TABLE IF NOT EXISTS "_purrmission_stage_${table}" AS SELECT * FROM "${table}" WHERE 0`
+    );
+  }
+
+  for (const table of LEGACY_STAGE_TABLES) {
+    const sourceCount = await rowCount(prisma, table);
+    const stageCount = await rowCount(prisma, `_purrmission_stage_${table}`);
+    if (sourceCount > 0 && stageCount > 0) {
+      throw new Error(
+        `Migration staging found rows in both ${table} and _purrmission_stage_${table}; refusing to overwrite recoverable data.`
+      );
+    }
+  }
+
+  await prisma.$executeRawUnsafe('PRAGMA foreign_keys=OFF');
+  try {
+    await prisma.$transaction(async (tx) => {
+      for (const table of LEGACY_STAGE_TABLES) {
+        const sourceCount = await rowCount(tx, table);
+        const stageCount = await rowCount(tx, `_purrmission_stage_${table}`);
+        if (sourceCount > 0 && stageCount === 0) {
+          await tx.$executeRawUnsafe(
+            `INSERT INTO "_purrmission_stage_${table}" SELECT * FROM "${table}"`
+          );
+          await tx.$executeRawUnsafe(`DELETE FROM "${table}"`);
+        }
+      }
+    });
+  } finally {
+    await prisma.$executeRawUnsafe('PRAGMA foreign_keys=ON');
+  }
+  return true;
+}
+
+export async function restoreLegacyHardeningRows(prisma: PrismaClient): Promise<void> {
+  if (!(await tableExists(prisma, '_purrmission_stage_Project'))) return;
+  if (!(await hardeningMigrationApplied(prisma))) {
+    throw new Error('Refusing to restore staged rows before the hardening migration is applied.');
+  }
+
+  const expected = new Map<string, number>();
+  for (const table of LEGACY_STAGE_TABLES) {
+    expected.set(table, await rowCount(prisma, `_purrmission_stage_${table}`));
+    if ((await rowCount(prisma, table)) > 0 && (expected.get(table) ?? 0) > 0) {
+      throw new Error(`Refusing to merge staged ${table} rows into a non-empty destination.`);
+    }
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(
+      `INSERT INTO "TOTPAccount"
+         ("id", "ownerDiscordUserId", "accountName", "secret", "issuer", "backupKey", "version", "createdAt", "updatedAt")
+       SELECT "id", "ownerDiscordUserId", "accountName", "secret", "issuer", "backupKey",
+              'legacy-totp-' || "id", "createdAt", "updatedAt"
+       FROM "_purrmission_stage_TOTPAccount"`
+    );
+    await tx.$executeRawUnsafe(
+      `INSERT INTO "Resource"
+         ("id", "name", "mode", "apiKey", "createdAt", "totpAccountId", "version")
+       SELECT "id", "name", "mode", "apiKey", "createdAt", "totpAccountId",
+              'legacy-resource-' || "id"
+       FROM "_purrmission_stage_Resource"`
+    );
+    await tx.$executeRawUnsafe(
+      `INSERT INTO "Project"
+         ("id", "name", "description", "ownerId", "policyVersion", "createdAt", "updatedAt")
+       SELECT "id", "name", "description", "ownerId", 'legacy-policy-' || "id",
+              "createdAt", "updatedAt"
+       FROM "_purrmission_stage_Project"`
+    );
+    await tx.$executeRawUnsafe(
+      `INSERT INTO "AuditLog"
+         ("id", "schemaVersion", "eventType", "outcomeCode", "actorType", "actorId",
+          "resourceId", "payload", "createdAt")
+       SELECT "id", 1, "action", "status",
+              CASE WHEN "actorId" IS NULL THEN 'SYSTEM' ELSE 'DISCORD_USER' END,
+              "actorId", "resourceId", NULL, "createdAt"
+       FROM "_purrmission_stage_AuditLog"`
+    );
+  });
+
+  for (const table of LEGACY_STAGE_TABLES) {
+    const actual = await rowCount(prisma, table);
+    if (actual !== expected.get(table)) {
+      throw new Error(
+        `Restored ${table} row count ${actual} did not match staged count ${expected.get(table)}.`
+      );
+    }
+  }
+  const foreignKeyViolations = await prisma.$queryRawUnsafe<Array<Record<string, unknown>>>(
+    'PRAGMA foreign_key_check'
+  );
+  if (foreignKeyViolations.length > 0) {
+    throw new Error(
+      `Restored database has ${foreignKeyViolations.length} foreign-key violation(s); staged recovery tables were retained.`
+    );
+  }
+  for (const table of LEGACY_STAGE_TABLES) {
+    await prisma.$executeRawUnsafe(`DROP TABLE "_purrmission_stage_${table}"`);
+  }
+}
+
 export async function deployMigrations(): Promise<void> {
   if (!process.env.DATABASE_URL) {
     throw new Error('DATABASE_URL is required for migration deployment.');
   }
 
   const prisma = new PrismaClient();
+  let stagedHardeningRows = false;
   try {
-    await runMigrationPreflight(prisma);
+    const resumesStagedDeploy = await tableExists(prisma, '_purrmission_stage_Project');
+    if (resumesStagedDeploy) {
+      console.log('🔒 Recoverable hardening stage detected; resuming migration deployment.');
+      stagedHardeningRows = await stageLegacyHardeningRows(prisma);
+    } else {
+      const databaseState = await runMigrationPreflight(prisma);
+      stagedHardeningRows =
+        databaseState === 'INITIALIZED' ? await stageLegacyHardeningRows(prisma) : false;
+    }
   } finally {
     await prisma.$disconnect();
   }
@@ -68,6 +233,15 @@ export async function deployMigrations(): Promise<void> {
   }
   if (result.status !== 0) {
     throw new Error(`prisma migrate deploy exited with status ${result.status ?? 'unknown'}.`);
+  }
+
+  if (stagedHardeningRows) {
+    const restoreClient = new PrismaClient();
+    try {
+      await restoreLegacyHardeningRows(restoreClient);
+    } finally {
+      await restoreClient.$disconnect();
+    }
   }
 }
 

--- a/scripts/deploy-migrations.ts
+++ b/scripts/deploy-migrations.ts
@@ -10,6 +10,7 @@ import { runGuardianReconciliation } from './reconcile-guardians-owners.js';
 const RECONCILIATION_TABLES = ['Environment', 'Guardian', 'Project', 'Resource'] as const;
 const HARDENING_MIGRATION = '20260724110200_rbac_dashboard_hardening_remediations';
 const LEGACY_STAGE_TABLES = ['AuditLog', 'Project', 'Resource', 'TOTPAccount'] as const;
+const LEGACY_STAGE_TABLE_NAMES = LEGACY_STAGE_TABLES.map((table) => `_purrmission_stage_${table}`);
 
 export type MigrationDatabaseState = 'FRESH' | 'INITIALIZED';
 
@@ -76,6 +77,22 @@ async function hardeningMigrationApplied(prisma: PrismaClient): Promise<boolean>
   return Number(rows[0]?.count ?? 0) === 1;
 }
 
+async function presentLegacyStageTables(prisma: PrismaClient): Promise<string[]> {
+  const present: string[] = [];
+  for (const tableName of LEGACY_STAGE_TABLE_NAMES) {
+    if (await tableExists(prisma, tableName)) present.push(tableName);
+  }
+  return present;
+}
+
+function assertCompleteLegacyStage(present: readonly string[]): void {
+  if (present.length === 0 || present.length === LEGACY_STAGE_TABLE_NAMES.length) return;
+  const missing = LEGACY_STAGE_TABLE_NAMES.filter((tableName) => !present.includes(tableName));
+  throw new Error(
+    `Incomplete hardening recovery stage detected. Present: ${present.join(', ')}; missing: ${missing.join(', ')}. Refusing to ignore recoverable credential data.`
+  );
+}
+
 /**
  * Preserve rows around the published hardening migration without changing its checksum.
  *
@@ -85,7 +102,9 @@ async function hardeningMigrationApplied(prisma: PrismaClient): Promise<boolean>
  * later invocation resumes instead of overwriting it.
  */
 export async function stageLegacyHardeningRows(prisma: PrismaClient): Promise<boolean> {
-  const stageAlreadyExists = await tableExists(prisma, '_purrmission_stage_Project');
+  const presentStageTables = await presentLegacyStageTables(prisma);
+  assertCompleteLegacyStage(presentStageTables);
+  const stageAlreadyExists = presentStageTables.length > 0;
   if (await hardeningMigrationApplied(prisma)) return stageAlreadyExists;
 
   const unmappableAuditRows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
@@ -98,28 +117,24 @@ export async function stageLegacyHardeningRows(prisma: PrismaClient): Promise<bo
     );
   }
 
-  for (const table of LEGACY_STAGE_TABLES) {
-    await prisma.$executeRawUnsafe(
-      `CREATE TABLE IF NOT EXISTS "_purrmission_stage_${table}" AS SELECT * FROM "${table}" WHERE 0`
-    );
-  }
-
-  for (const table of LEGACY_STAGE_TABLES) {
-    const sourceCount = await rowCount(prisma, table);
-    const stageCount = await rowCount(prisma, `_purrmission_stage_${table}`);
-    if (sourceCount > 0 && stageCount > 0) {
-      throw new Error(
-        `Migration staging found rows in both ${table} and _purrmission_stage_${table}; refusing to overwrite recoverable data.`
-      );
-    }
-  }
-
   await prisma.$executeRawUnsafe('PRAGMA foreign_keys=OFF');
   try {
     await prisma.$transaction(async (tx) => {
+      if (!stageAlreadyExists) {
+        for (const table of LEGACY_STAGE_TABLES) {
+          await tx.$executeRawUnsafe(
+            `CREATE TABLE "_purrmission_stage_${table}" AS SELECT * FROM "${table}" WHERE 0`
+          );
+        }
+      }
       for (const table of LEGACY_STAGE_TABLES) {
         const sourceCount = await rowCount(tx, table);
         const stageCount = await rowCount(tx, `_purrmission_stage_${table}`);
+        if (sourceCount > 0 && stageCount > 0) {
+          throw new Error(
+            `Migration staging found rows in both ${table} and _purrmission_stage_${table}; refusing to overwrite recoverable data.`
+          );
+        }
         if (sourceCount > 0 && stageCount === 0) {
           await tx.$executeRawUnsafe(
             `INSERT INTO "_purrmission_stage_${table}" SELECT * FROM "${table}"`
@@ -135,20 +150,22 @@ export async function stageLegacyHardeningRows(prisma: PrismaClient): Promise<bo
 }
 
 export async function restoreLegacyHardeningRows(prisma: PrismaClient): Promise<void> {
-  if (!(await tableExists(prisma, '_purrmission_stage_Project'))) return;
+  const presentStageTables = await presentLegacyStageTables(prisma);
+  assertCompleteLegacyStage(presentStageTables);
+  if (presentStageTables.length === 0) return;
   if (!(await hardeningMigrationApplied(prisma))) {
     throw new Error('Refusing to restore staged rows before the hardening migration is applied.');
   }
 
-  const expected = new Map<string, number>();
-  for (const table of LEGACY_STAGE_TABLES) {
-    expected.set(table, await rowCount(prisma, `_purrmission_stage_${table}`));
-    if ((await rowCount(prisma, table)) > 0 && (expected.get(table) ?? 0) > 0) {
-      throw new Error(`Refusing to merge staged ${table} rows into a non-empty destination.`);
-    }
-  }
-
   await prisma.$transaction(async (tx) => {
+    const expected = new Map<string, number>();
+    for (const table of LEGACY_STAGE_TABLES) {
+      expected.set(table, await rowCount(tx, `_purrmission_stage_${table}`));
+      if ((await rowCount(tx, table)) > 0 && (expected.get(table) ?? 0) > 0) {
+        throw new Error(`Refusing to merge staged ${table} rows into a non-empty destination.`);
+      }
+    }
+
     await tx.$executeRawUnsafe(
       `INSERT INTO "TOTPAccount"
          ("id", "ownerDiscordUserId", "accountName", "secret", "issuer", "backupKey", "version", "createdAt", "updatedAt")
@@ -179,27 +196,29 @@ export async function restoreLegacyHardeningRows(prisma: PrismaClient): Promise<
               "actorId", "resourceId", NULL, "createdAt"
        FROM "_purrmission_stage_AuditLog"`
     );
-  });
 
-  for (const table of LEGACY_STAGE_TABLES) {
-    const actual = await rowCount(prisma, table);
-    if (actual !== expected.get(table)) {
+    for (const table of LEGACY_STAGE_TABLES) {
+      const actual = await rowCount(tx, table);
+      if (actual !== expected.get(table)) {
+        throw new Error(
+          `Restored ${table} row count ${actual} did not match staged count ${expected.get(table)}.`
+        );
+      }
+    }
+    const foreignKeyViolations = await tx.$queryRawUnsafe<Array<Record<string, unknown>>>(
+      'PRAGMA foreign_key_check'
+    );
+    if (foreignKeyViolations.length > 0) {
       throw new Error(
-        `Restored ${table} row count ${actual} did not match staged count ${expected.get(table)}.`
+        `Restored database has ${foreignKeyViolations.length} foreign-key violation(s); staged recovery tables were retained.`
       );
     }
-  }
-  const foreignKeyViolations = await prisma.$queryRawUnsafe<Array<Record<string, unknown>>>(
-    'PRAGMA foreign_key_check'
-  );
-  if (foreignKeyViolations.length > 0) {
-    throw new Error(
-      `Restored database has ${foreignKeyViolations.length} foreign-key violation(s); staged recovery tables were retained.`
-    );
-  }
-  for (const table of LEGACY_STAGE_TABLES) {
-    await prisma.$executeRawUnsafe(`DROP TABLE "_purrmission_stage_${table}"`);
-  }
+    // Keep value restoration and removal of every seed-bearing recovery table in one SQLite
+    // transaction. An interruption therefore leaves either the complete stage or no stage.
+    for (const table of LEGACY_STAGE_TABLES) {
+      await tx.$executeRawUnsafe(`DROP TABLE "_purrmission_stage_${table}"`);
+    }
+  });
 }
 
 export async function deployMigrations(): Promise<void> {
@@ -210,8 +229,9 @@ export async function deployMigrations(): Promise<void> {
   const prisma = new PrismaClient();
   let stagedHardeningRows = false;
   try {
-    const resumesStagedDeploy = await tableExists(prisma, '_purrmission_stage_Project');
-    if (resumesStagedDeploy) {
+    const presentStageTables = await presentLegacyStageTables(prisma);
+    assertCompleteLegacyStage(presentStageTables);
+    if (presentStageTables.length > 0) {
       console.log('🔒 Recoverable hardening stage detected; resuming migration deployment.');
       stagedHardeningRows = await stageLegacyHardeningRows(prisma);
     } else {

--- a/scripts/ops.test.ts
+++ b/scripts/ops.test.ts
@@ -8,7 +8,11 @@ import { createHash } from 'node:crypto';
 import { PrismaClient } from '@prisma/client';
 import { env } from '../apps/purrmission-bot/src/config/env.js';
 import { backupDatabase } from './backup-db.js';
-import { classifyMigrationDatabaseTables, runMigrationPreflight } from './deploy-migrations.js';
+import {
+  classifyMigrationDatabaseTables,
+  runMigrationPreflight,
+  stageLegacyHardeningRows,
+} from './deploy-migrations.js';
 import { selectCanonicalGuardianRow } from './reconcile-guardians-owners.js';
 
 describe('Operations Scripts', () => {
@@ -425,6 +429,80 @@ describe('Operations Scripts', () => {
         'legacy-policy-project-1',
         'legacy-resource-resource-1',
       ]);
+    });
+
+    it('resumes safely after interruption leaves the complete pre-migration stage', async () => {
+      const databasePath = createTemporaryDatabase('staged-resume');
+      applyMigrationsBeforeGuardianInvariant(databasePath, true);
+      applySql(
+        databasePath,
+        `INSERT INTO "Resource" ("id", "name", "mode", "apiKey")
+           VALUES ('resource-resume', 'Protected', 'ONE_OF_N', 'key');
+         INSERT INTO "Project" ("id", "name", "ownerId", "updatedAt")
+           VALUES ('project-resume', 'Project', 'owner', '2026-07-01T00:00:00Z');
+         INSERT INTO "Environment" ("id", "name", "slug", "projectId", "updatedAt", "resourceId")
+           VALUES ('environment-resume', 'Production', 'prod', 'project-resume', '2026-07-01T00:00:00Z', 'resource-resume');`
+      );
+
+      const prisma = new PrismaClient({
+        datasources: { db: { url: `file:${databasePath}` } },
+      });
+      try {
+        assert.equal(await stageLegacyHardeningRows(prisma), true);
+      } finally {
+        await prisma.$disconnect();
+      }
+      assert.equal(
+        execFileSync('sqlite3', ['-noheader', databasePath, `SELECT COUNT(*) FROM "Resource";`], {
+          encoding: 'utf8',
+        }).trim(),
+        '0'
+      );
+
+      const result = runSupportedDeploy(databasePath);
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+      assert.equal(
+        execFileSync(
+          'sqlite3',
+          [
+            '-noheader',
+            databasePath,
+            `SELECT "version" FROM "Resource" WHERE "id" = 'resource-resume';`,
+          ],
+          { encoding: 'utf8' }
+        ).trim(),
+        'legacy-resource-resource-resume'
+      );
+    });
+
+    it('fails closed when any seed-bearing recovery stage table is residual by itself', () => {
+      const databasePath = createTemporaryDatabase('partial-stage');
+      assert.equal(runSupportedDeploy(databasePath).status, 0);
+      applySql(
+        databasePath,
+        `CREATE TABLE "_purrmission_stage_TOTPAccount" AS
+           SELECT * FROM "TOTPAccount" WHERE 0;
+         INSERT INTO "_purrmission_stage_TOTPAccount"
+           ("id", "ownerDiscordUserId", "accountName", "secret", "version", "createdAt", "updatedAt")
+         VALUES
+           ('residual-totp', 'owner', 'Residual', 'SENSITIVE-SEED', 'v1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);`
+      );
+
+      const result = runSupportedDeploy(databasePath);
+      assert.equal(result.status, 1);
+      assert.match(`${result.stdout}\n${result.stderr}`, /Incomplete hardening recovery stage/);
+      assert.equal(
+        execFileSync(
+          'sqlite3',
+          [
+            '-noheader',
+            databasePath,
+            `SELECT "secret" FROM "_purrmission_stage_TOTPAccount" WHERE "id" = 'residual-totp';`,
+          ],
+          { encoding: 'utf8' }
+        ).trim(),
+        'SENSITIVE-SEED'
+      );
     });
 
     it('deploys every migration on a fresh empty database through the supported wrapper', () => {

--- a/scripts/ops.test.ts
+++ b/scripts/ops.test.ts
@@ -2,12 +2,19 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { PrismaClient } from '@prisma/client';
 import { env } from '../apps/purrmission-bot/src/config/env.js';
 import { backupDatabase } from './backup-db.js';
+import { classifyMigrationDatabaseTables, runMigrationPreflight } from './deploy-migrations.js';
+import { selectCanonicalGuardianRow } from './reconcile-guardians-owners.js';
 
 describe('Operations Scripts', () => {
   let dummyDbCreated = false;
   let resolvedDbPath = '';
+  const temporaryDirectories: string[] = [];
 
   before(() => {
     // Find where the script thinks the DB is
@@ -41,6 +48,9 @@ describe('Operations Scripts', () => {
         // ignore
       }
     }
+    for (const directory of temporaryDirectories) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
   });
   describe('backup-db', () => {
     it('should create a backup file for a valid SQLite DB', async () => {
@@ -69,6 +79,311 @@ describe('Operations Scripts', () => {
     it('should be importable without side effects', async () => {
       const module = await import('./rotate-keys.js');
       assert.ok(module);
+    });
+  });
+
+  describe('supported migration command', () => {
+    it('does not document a raw Prisma deployment bypass in operational files', () => {
+      const operationalFiles = [
+        'README.md',
+        'DEPLOY.md',
+        'AGENTS.md',
+        'docs/deployment-checklist.md',
+        'apps/purrmission-bot/README.md',
+        'scripts/quick-start.sh',
+        '.github/workflows/deploy.yml',
+        'package.json',
+      ];
+      const rawDeployCommand = /\b(?:npx|pnpm\s+exec)\s+prisma\s+migrate\s+deploy\b/;
+
+      for (const file of operationalFiles) {
+        assert.doesNotMatch(
+          fs.readFileSync(path.join(process.cwd(), file), 'utf8'),
+          rawDeployCommand,
+          `${file} must direct operators through pnpm prisma:deploy`
+        );
+      }
+      assert.doesNotMatch(
+        fs.readFileSync(path.join(process.cwd(), 'scripts/quick-start.sh'), 'utf8'),
+        /prisma:deploy\s*\|\|/,
+        'quick-start must propagate migration deployment failures'
+      );
+
+      const deployWorkflow = fs.readFileSync(
+        path.join(process.cwd(), '.github/workflows/deploy.yml'),
+        'utf8'
+      );
+      assert.match(deployWorkflow, /pnpm prisma:deploy/);
+      assert.match(deployWorkflow, /scripts\/deploy-migrations\.ts/);
+      assert.match(deployWorkflow, /scripts\/reconcile-guardians-owners\.ts/);
+    });
+  });
+
+  describe('guardian-owner reconciliation', () => {
+    const at = (day: number) => new Date(`2026-07-${String(day).padStart(2, '0')}T00:00:00Z`);
+
+    it('preserves Writer plus explicit Guardian when a stale OWNER mirror is duplicated', () => {
+      const rows = [
+        {
+          id: 'stale-owner-mirror',
+          resourceId: 'resource-1',
+          discordUserId: 'writer-and-guardian',
+          role: 'OWNER' as const,
+          createdAt: at(20),
+        },
+        {
+          id: 'explicit-guardian',
+          resourceId: 'resource-1',
+          discordUserId: 'writer-and-guardian',
+          role: 'GUARDIAN' as const,
+          createdAt: at(21),
+        },
+      ];
+
+      const kept = selectCanonicalGuardianRow(rows, 'canonical-project-owner');
+      assert.equal(kept.id, 'explicit-guardian');
+      assert.equal(kept.role, 'GUARDIAN');
+    });
+
+    it('retains OWNER for the canonical Project Owner and standalone Resource Owner', () => {
+      const rows = [
+        {
+          id: 'guardian',
+          resourceId: 'resource-1',
+          discordUserId: 'canonical-project-owner',
+          role: 'GUARDIAN' as const,
+          createdAt: at(20),
+        },
+        {
+          id: 'owner',
+          resourceId: 'resource-1',
+          discordUserId: 'canonical-project-owner',
+          role: 'OWNER' as const,
+          createdAt: at(21),
+        },
+      ];
+
+      assert.equal(selectCanonicalGuardianRow(rows, 'canonical-project-owner').role, 'OWNER');
+      assert.equal(selectCanonicalGuardianRow(rows).role, 'OWNER');
+    });
+
+    it('does not promote an ambiguous stale OWNER-only row to Guardian authority', () => {
+      const staleOwnerOnly = [
+        {
+          id: 'ambiguous-stale-owner',
+          resourceId: 'resource-1',
+          discordUserId: 'former-owner',
+          role: 'OWNER' as const,
+          createdAt: at(20),
+        },
+      ];
+
+      const kept = selectCanonicalGuardianRow(staleOwnerOnly, 'canonical-project-owner');
+      assert.equal(kept.role, 'OWNER');
+      assert.notEqual(kept.role, 'GUARDIAN');
+    });
+  });
+
+  describe('safe migration deployment', () => {
+    const createTemporaryDatabase = (name: string): string => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), `purrmission-${name}-`));
+      temporaryDirectories.push(directory);
+      return path.join(directory, 'test.db');
+    };
+
+    const applySql = (databasePath: string, sql: string): void => {
+      execFileSync('sqlite3', ['-bail', databasePath], { input: sql });
+    };
+
+    const applyMigrationsBeforeGuardianInvariant = (
+      databasePath: string,
+      recordMigrationHistory = false
+    ): void => {
+      const sourceMigrationsRoot = path.join(process.cwd(), 'prisma', 'migrations');
+      if (recordMigrationHistory) {
+        applySql(
+          databasePath,
+          `CREATE TABLE "_prisma_migrations" (
+             "id" TEXT PRIMARY KEY NOT NULL,
+             "checksum" TEXT NOT NULL,
+             "finished_at" DATETIME,
+             "migration_name" TEXT NOT NULL,
+             "logs" TEXT,
+             "rolled_back_at" DATETIME,
+             "started_at" DATETIME NOT NULL DEFAULT current_timestamp,
+             "applied_steps_count" INTEGER UNSIGNED NOT NULL DEFAULT 0
+           );`
+        );
+      }
+      const migrations = fs
+        .readdirSync(sourceMigrationsRoot)
+        .filter((name) => name < '20260724110100_guardian_assignment_invariant')
+        .sort();
+      for (const migration of migrations) {
+        const sql = fs.readFileSync(
+          path.join(sourceMigrationsRoot, migration, 'migration.sql'),
+          'utf8'
+        );
+        applySql(databasePath, sql);
+        if (recordMigrationHistory) {
+          const checksum = createHash('sha256').update(sql).digest('hex');
+          applySql(
+            databasePath,
+            `INSERT INTO "_prisma_migrations"
+               ("id", "checksum", "finished_at", "migration_name", "started_at", "applied_steps_count")
+             VALUES
+               ('fixture-${migration}', '${checksum}', CURRENT_TIMESTAMP, '${migration}', CURRENT_TIMESTAMP, 1);`
+          );
+        }
+      }
+    };
+
+    const runSupportedDeploy = (databasePath: string) =>
+      spawnSync('pnpm', ['prisma:deploy'], {
+        cwd: process.cwd(),
+        env: { ...process.env, DATABASE_URL: `file:${databasePath}` },
+        encoding: 'utf8',
+      });
+
+    it('classifies a fresh database and fails closed on initialized partial schemas', () => {
+      assert.equal(classifyMigrationDatabaseTables([]), 'FRESH');
+      assert.throws(
+        () => classifyMigrationDatabaseTables(['_prisma_migrations', 'Guardian']),
+        /missing required table\(s\)/
+      );
+    });
+
+    it('returns nonzero for an initialized database missing reconciliation tables', () => {
+      const databasePath = createTemporaryDatabase('corrupt-deploy');
+      applySql(databasePath, 'CREATE TABLE "Guardian" ("id" TEXT PRIMARY KEY);');
+
+      const result = runSupportedDeploy(databasePath);
+      assert.equal(result.status, 1);
+      assert.match(`${result.stdout}\n${result.stderr}`, /missing required table\(s\)/);
+    });
+
+    it('reconciles populated data before applying the published Guardian invariant', async () => {
+      const databasePath = createTemporaryDatabase('guardian-upgrade');
+      applyMigrationsBeforeGuardianInvariant(databasePath);
+      applySql(
+        databasePath,
+        `PRAGMA foreign_keys=ON;
+         INSERT INTO "Resource" ("id", "name", "mode", "apiKey")
+           VALUES ('resource-1', 'Protected', 'ONE_OF_N', 'key');
+         INSERT INTO "Project" ("id", "name", "ownerId", "updatedAt")
+           VALUES ('project-1', 'Project', 'canonical-owner', '2026-07-01T00:00:00Z');
+         INSERT INTO "ProjectMember" ("id", "projectId", "userId", "role", "addedBy", "updatedAt")
+           VALUES ('member-1', 'project-1', 'writer-guardian', 'WRITER', 'canonical-owner', '2026-07-01T00:00:00Z');
+         INSERT INTO "Environment" ("id", "name", "slug", "projectId", "updatedAt", "resourceId")
+           VALUES ('environment-1', 'Production', 'prod', 'project-1', '2026-07-01T00:00:00Z', 'resource-1');
+         INSERT INTO "Guardian" ("id", "resourceId", "discordUserId", "role", "createdAt")
+           VALUES ('stale-owner', 'resource-1', 'writer-guardian', 'OWNER', '2026-07-01T00:00:00Z');
+         INSERT INTO "Guardian" ("id", "resourceId", "discordUserId", "role", "createdAt")
+           VALUES ('explicit-guardian', 'resource-1', 'writer-guardian', 'GUARDIAN', '2026-07-02T00:00:00Z');
+         INSERT INTO "Guardian" ("id", "resourceId", "discordUserId", "role", "createdAt")
+           VALUES ('ambiguous-owner-only', 'resource-1', 'former-owner', 'OWNER', '2026-07-03T00:00:00Z');`
+      );
+
+      const prisma = new PrismaClient({
+        datasources: { db: { url: `file:${databasePath}` } },
+      });
+      try {
+        assert.equal(await runMigrationPreflight(prisma), 'INITIALIZED');
+      } finally {
+        await prisma.$disconnect();
+      }
+
+      applySql(
+        databasePath,
+        fs.readFileSync(
+          path.join(
+            process.cwd(),
+            'prisma/migrations/20260724110100_guardian_assignment_invariant/migration.sql'
+          ),
+          'utf8'
+        )
+      );
+
+      const rows = execFileSync(
+        'sqlite3',
+        [
+          '-noheader',
+          databasePath,
+          `SELECT "discordUserId" || ':' || "role" FROM "Guardian" ORDER BY "discordUserId";`,
+        ],
+        { encoding: 'utf8' }
+      )
+        .trim()
+        .split('\n');
+      assert.deepEqual(rows, ['former-owner:OWNER', 'writer-guardian:GUARDIAN']);
+    });
+
+    it('reports the #118 populated AuditLog migration blocker after a real-history preflight', () => {
+      const databasePath = createTemporaryDatabase('audit-history-blocker');
+      applyMigrationsBeforeGuardianInvariant(databasePath, true);
+      applySql(
+        databasePath,
+        `INSERT INTO "AuditLog" ("id", "action", "status")
+         VALUES ('legacy-audit', 'FIELD_ACCESSED', 'SUCCESS');`
+      );
+
+      const result = runSupportedDeploy(databasePath);
+      const output = `${result.stdout}\n${result.stderr}`;
+      assert.equal(result.status, 1);
+      assert.match(output, /Migration name: 20260724110200_rbac_dashboard_hardening_remediations/);
+      assert.match(output, /NOT NULL constraint failed: new_AuditLog\.eventType/);
+    });
+
+    it('preserves Guardian data before reporting the #119 populated version blocker', () => {
+      const databasePath = createTemporaryDatabase('version-history-blocker');
+      applyMigrationsBeforeGuardianInvariant(databasePath, true);
+      applySql(
+        databasePath,
+        `INSERT INTO "Resource" ("id", "name", "mode", "apiKey")
+           VALUES ('resource-1', 'Protected', 'ONE_OF_N', 'key');
+         INSERT INTO "Project" ("id", "name", "ownerId", "updatedAt")
+           VALUES ('project-1', 'Project', 'canonical-owner', '2026-07-01T00:00:00Z');
+         INSERT INTO "Environment" ("id", "name", "slug", "projectId", "updatedAt", "resourceId")
+           VALUES ('environment-1', 'Production', 'prod', 'project-1', '2026-07-01T00:00:00Z', 'resource-1');
+         INSERT INTO "Guardian" ("id", "resourceId", "discordUserId", "role", "createdAt")
+           VALUES ('stale-owner', 'resource-1', 'writer-guardian', 'OWNER', '2026-07-01T00:00:00Z');
+         INSERT INTO "Guardian" ("id", "resourceId", "discordUserId", "role", "createdAt")
+           VALUES ('explicit-guardian', 'resource-1', 'writer-guardian', 'GUARDIAN', '2026-07-02T00:00:00Z');`
+      );
+
+      const result = runSupportedDeploy(databasePath);
+      const output = `${result.stdout}\n${result.stderr}`;
+      assert.equal(result.status, 1);
+      assert.match(output, /Migration name: 20260724110200_rbac_dashboard_hardening_remediations/);
+      assert.match(output, /NOT NULL constraint failed: new_Project\.policyVersion/);
+
+      const guardianRows = execFileSync(
+        'sqlite3',
+        [
+          '-noheader',
+          databasePath,
+          `SELECT "discordUserId" || ':' || "role" FROM "Guardian" ORDER BY "discordUserId";`,
+        ],
+        { encoding: 'utf8' }
+      ).trim();
+      assert.equal(guardianRows, 'writer-guardian:GUARDIAN');
+    });
+
+    it('deploys every migration on a fresh empty database through the supported wrapper', () => {
+      const databasePath = createTemporaryDatabase('fresh-deploy');
+      applySql(databasePath, 'VACUUM;');
+
+      const result = runSupportedDeploy(databasePath);
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+      const appliedCount = Number(
+        execFileSync(
+          'sqlite3',
+          ['-noheader', databasePath, 'SELECT COUNT(*) FROM "_prisma_migrations";'],
+          { encoding: 'utf8' }
+        ).trim()
+      );
+      assert.equal(appliedCount, 16);
     });
   });
 });

--- a/scripts/ops.test.ts
+++ b/scripts/ops.test.ts
@@ -318,7 +318,7 @@ describe('Operations Scripts', () => {
       assert.deepEqual(rows, ['former-owner:OWNER', 'writer-guardian:GUARDIAN']);
     });
 
-    it('reports the #118 populated AuditLog migration blocker after a real-history preflight', () => {
+    it('preserves populated legacy AuditLog rows through the published hardening migration', () => {
       const databasePath = createTemporaryDatabase('audit-history-blocker');
       applyMigrationsBeforeGuardianInvariant(databasePath, true);
       applySql(
@@ -328,13 +328,58 @@ describe('Operations Scripts', () => {
       );
 
       const result = runSupportedDeploy(databasePath);
-      const output = `${result.stdout}\n${result.stderr}`;
-      assert.equal(result.status, 1);
-      assert.match(output, /Migration name: 20260724110200_rbac_dashboard_hardening_remediations/);
-      assert.match(output, /NOT NULL constraint failed: new_AuditLog\.eventType/);
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+      const auditRow = execFileSync(
+        'sqlite3',
+        [
+          '-noheader',
+          databasePath,
+          `SELECT "eventType" || ':' || "outcomeCode" || ':' || "actorType"
+           FROM "AuditLog" WHERE "id" = 'legacy-audit';`,
+        ],
+        { encoding: 'utf8' }
+      ).trim();
+      assert.equal(auditRow, 'FIELD_ACCESSED:SUCCESS:SYSTEM');
+      assert.equal(
+        execFileSync(
+          'sqlite3',
+          [
+            '-noheader',
+            databasePath,
+            `SELECT COUNT(*) FROM "sqlite_master"
+             WHERE "type" = 'table' AND "name" LIKE '_purrmission_stage_%';`,
+          ],
+          { encoding: 'utf8' }
+        ).trim(),
+        '0'
+      );
     });
 
-    it('preserves Guardian data before reporting the #119 populated version blocker', () => {
+    it('fails closed instead of silently dropping unmappable legacy audit context', () => {
+      const databasePath = createTemporaryDatabase('audit-context-blocker');
+      applyMigrationsBeforeGuardianInvariant(databasePath, true);
+      applySql(
+        databasePath,
+        `INSERT INTO "AuditLog" ("id", "action", "status", "context")
+         VALUES ('legacy-audit-context', 'FIELD_ACCESSED', 'SUCCESS', '{"unknown":"value"}');`
+      );
+
+      const result = runSupportedDeploy(databasePath);
+      assert.equal(result.status, 1);
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        /cannot be safely mapped by the compatibility preflight/
+      );
+      assert.equal(
+        execFileSync('sqlite3', ['-noheader', databasePath, `SELECT COUNT(*) FROM "AuditLog";`], {
+          encoding: 'utf8',
+        }).trim(),
+        '1'
+      );
+    });
+
+    it('preserves Guardian data and supplies stable compatibility versions on populated deploy', () => {
       const databasePath = createTemporaryDatabase('version-history-blocker');
       applyMigrationsBeforeGuardianInvariant(databasePath, true);
       applySql(
@@ -352,10 +397,7 @@ describe('Operations Scripts', () => {
       );
 
       const result = runSupportedDeploy(databasePath);
-      const output = `${result.stdout}\n${result.stderr}`;
-      assert.equal(result.status, 1);
-      assert.match(output, /Migration name: 20260724110200_rbac_dashboard_hardening_remediations/);
-      assert.match(output, /NOT NULL constraint failed: new_Project\.policyVersion/);
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 
       const guardianRows = execFileSync(
         'sqlite3',
@@ -367,6 +409,22 @@ describe('Operations Scripts', () => {
         { encoding: 'utf8' }
       ).trim();
       assert.equal(guardianRows, 'writer-guardian:GUARDIAN');
+      const compatibilityVersions = execFileSync(
+        'sqlite3',
+        [
+          '-noheader',
+          databasePath,
+          `SELECT "policyVersion" FROM "Project" WHERE "id" = 'project-1';
+           SELECT "version" FROM "Resource" WHERE "id" = 'resource-1';`,
+        ],
+        { encoding: 'utf8' }
+      )
+        .trim()
+        .split('\n');
+      assert.deepEqual(compatibilityVersions, [
+        'legacy-policy-project-1',
+        'legacy-resource-resource-1',
+      ]);
     });
 
     it('deploys every migration on a fresh empty database through the supported wrapper', () => {

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -42,7 +42,10 @@ echo -e "${YELLOW}Setting up database...${NC}"
 pnpm prisma:generate
 # Check if we can run migrate (needs DB url)
 if grep -q -E '^DATABASE_URL=.+' .env; then
-    pnpm prisma:deploy || echo -e "${YELLOW}Migration deploy failed. Skipping.${NC}"
+    if ! pnpm prisma:deploy; then
+        echo -e "${RED}Migration deploy failed. Setup cannot continue safely.${NC}"
+        exit 1
+    fi
 else 
     echo -e "${YELLOW}No DATABASE_URL in .env. Skipping migration.${NC}"
 fi

--- a/scripts/reconcile-guardians-owners.ts
+++ b/scripts/reconcile-guardians-owners.ts
@@ -1,22 +1,80 @@
 import { PrismaClient } from '@prisma/client';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const prisma = new PrismaClient();
+export interface GuardianReconciliationRow {
+  id: string;
+  resourceId: string;
+  discordUserId: string;
+  role: 'OWNER' | 'GUARDIAN';
+  createdAt: Date;
+}
 
-async function runReconciliation() {
-  const args = process.argv.slice(2);
-  const isExecute = args.includes('--execute');
+interface EnvironmentOwnerRow {
+  resourceId: string;
+  ownerId: string;
+}
+
+export interface GuardianReconciliationDatabase {
+  $queryRawUnsafe<T>(query: string, ...values: unknown[]): Promise<T>;
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+}
+
+export interface GuardianReconciliationSummary {
+  duplicatesDeleted: number;
+  ownerRowsRetainedForReview: string[];
+}
+
+/**
+ * Select the one assignment that preserves the canonical authority model.
+ *
+ * For project-linked resources, a noncanonical OWNER row is a stale mirror and must never win
+ * over an explicit GUARDIAN row. For the canonical Project Owner (and standalone Resources), an
+ * OWNER row remains authoritative. Timestamp/ID ordering makes same-role reconciliation stable.
+ */
+export function selectCanonicalGuardianRow<T extends GuardianReconciliationRow>(
+  group: readonly T[],
+  canonicalProjectOwnerId?: string
+): T {
+  if (group.length === 0) {
+    throw new Error('Cannot reconcile an empty Guardian assignment group.');
+  }
+
+  const subjectId = group[0].discordUserId;
+  const preferGuardian =
+    canonicalProjectOwnerId !== undefined && subjectId !== canonicalProjectOwnerId;
+
+  return [...group].sort((a, b) => {
+    if (a.role !== b.role) {
+      if (preferGuardian) return a.role === 'GUARDIAN' ? -1 : 1;
+      return a.role === 'OWNER' ? -1 : 1;
+    }
+    const createdAtOrder = a.createdAt.getTime() - b.createdAt.getTime();
+    return createdAtOrder !== 0 ? createdAtOrder : a.id.localeCompare(b.id);
+  })[0];
+}
+
+export async function runGuardianReconciliation(
+  prisma: GuardianReconciliationDatabase,
+  isExecute: boolean
+): Promise<GuardianReconciliationSummary> {
   const isDryRun = !isExecute;
 
   console.log(`🚀 Starting Database Reconciliation (Mode: ${isDryRun ? 'DRY-RUN' : 'EXECUTE'})`);
   console.log('================================================================');
 
   // 1. Fetch data
-  const environments = await prisma.environment.findMany({
-    where: { resourceId: { not: null } },
-    include: { project: true },
-  });
-
-  const guardians = await prisma.guardian.findMany();
+  // Select only columns that exist before and after the published hardening migrations. Using the
+  // generated model shape here would request newer columns from a pre-migration database.
+  const environments = await prisma.$queryRawUnsafe<EnvironmentOwnerRow[]>(
+    `SELECT "Environment"."resourceId", "Project"."ownerId"
+       FROM "Environment"
+       INNER JOIN "Project" ON "Project"."id" = "Environment"."projectId"
+      WHERE "Environment"."resourceId" IS NOT NULL`
+  );
+  const guardians = await prisma.$queryRawUnsafe<GuardianReconciliationRow[]>(
+    `SELECT "id", "resourceId", "discordUserId", "role", "createdAt" FROM "Guardian"`
+  );
 
   console.log(`Found ${environments.length} environment-linked resources.`);
   console.log(`Found ${guardians.length} total explicit guardian rows.`);
@@ -27,7 +85,7 @@ async function runReconciliation() {
   const resourceToProjectOwnerMap = new Map<string, string>(); // resourceId -> project.ownerId
   for (const env of environments) {
     if (env.resourceId) {
-      resourceToProjectOwnerMap.set(env.resourceId, env.project.ownerId);
+      resourceToProjectOwnerMap.set(env.resourceId, env.ownerId);
     }
   }
 
@@ -54,20 +112,22 @@ async function runReconciliation() {
     }
 
     console.log(`⚠️ Found duplicate assignments for key "${key}" (count: ${group.length})`);
-    // Choose primary row to keep:
-    // Prefer OWNER role first. If roles match, keep the oldest (smallest createdAt or id)
-    const sorted = [...group].sort((a, b) => {
-      if (a.role === 'OWNER' && b.role !== 'OWNER') return -1;
-      if (a.role !== 'OWNER' && b.role === 'OWNER') return 1;
-      const createdAtOrder = a.createdAt.getTime() - b.createdAt.getTime();
-      return createdAtOrder !== 0 ? createdAtOrder : a.id.localeCompare(b.id);
-    });
-
-    const primary = sorted[0];
+    const canonicalProjectOwnerId = resourceToProjectOwnerMap.get(group[0].resourceId);
+    const primary = selectCanonicalGuardianRow(group, canonicalProjectOwnerId);
+    const sorted = [primary, ...group.filter((row) => row.id !== primary.id)];
     keptGuardians.push(primary);
     console.log(
       `   Keeping row ID: ${primary.id} (role: ${primary.role}, created: ${primary.createdAt.toISOString()})`
     );
+    if (
+      canonicalProjectOwnerId &&
+      primary.discordUserId !== canonicalProjectOwnerId &&
+      primary.role === 'GUARDIAN'
+    ) {
+      console.log(
+        `   Preserving explicit GUARDIAN; OWNER rows for this subject are noncanonical Project-owner mirrors.`
+      );
+    }
 
     for (let i = 1; i < sorted.length; i++) {
       duplicatesToDelete.push(sorted[i].id);
@@ -112,7 +172,7 @@ async function runReconciliation() {
 
   if (duplicatesToDelete.length === 0) {
     console.log('✅ No duplicate Guardian assignments require reconciliation.');
-    return;
+    return { duplicatesDeleted: 0, ownerRowsRetainedForReview: ownerRowsToReview };
   }
 
   if (isDryRun) {
@@ -120,15 +180,44 @@ async function runReconciliation() {
     console.log('   To apply these changes, run the script with: --execute');
   } else {
     console.log('\n💾 Executing database writes...');
-    const result = await prisma.guardian.deleteMany({
-      where: {
-        id: { in: duplicatesToDelete },
-      },
-    });
-    console.log(`✅ Successfully deleted ${result.count} guardian rows from database.`);
+    const placeholders = duplicatesToDelete.map(() => '?').join(', ');
+    const deletedCount = await prisma.$executeRawUnsafe(
+      `DELETE FROM "Guardian" WHERE "id" IN (${placeholders})`,
+      ...duplicatesToDelete
+    );
+    if (deletedCount !== duplicatesToDelete.length) {
+      throw new Error(
+        `Guardian reconciliation deleted ${deletedCount} rows; expected ${duplicatesToDelete.length}.`
+      );
+    }
+    console.log(`✅ Successfully deleted ${deletedCount} guardian rows from database.`);
+    return {
+      duplicatesDeleted: deletedCount,
+      ownerRowsRetainedForReview: ownerRowsToReview,
+    };
+  }
+
+  return { duplicatesDeleted: 0, ownerRowsRetainedForReview: ownerRowsToReview };
+}
+
+async function main(): Promise<void> {
+  const prisma = new PrismaClient();
+  try {
+    await runGuardianReconciliation(prisma, process.argv.slice(2).includes('--execute'));
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    try {
+      await prisma.$disconnect();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    }
   }
 }
 
-runReconciliation()
-  .catch(console.error)
-  .finally(() => prisma.$disconnect());
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  void main();
+}


### PR DESCRIPTION
## Status

**Ready for formal human security review. Do not merge without approval.**

This is the approved narrow corrective lane for reopened #117. It fail-closes authority merged ahead of #120/#121/#122/#130 and repairs shared verification infrastructure, without transferring or completing those nodes.

## What this correction does

- replaces live Guardian secret/TOTP mutation and reveal authority with exact capability checks
- makes APPROVED a decision state only: approval buttons do not reveal/DM and decisions mint no provisional grant
- fails closed the legacy GET secret-reveal path and provisional grant-backed bulk reveal
- temporarily disables incomplete TOTP link/delegation consent creation and delegated non-owner reveal
- preserves direct Resource Owner TOTP reveal and authorized unlink
- uses metadata-only TOTP custody reads before authorization
- fails closed unbound SERVICE object capabilities until #121 supplies target-bound credentials
- rejects contradictory Project/Environment/Resource/ApprovalRequest target ancestry
- safely reconciles explicit Guardian rows against stale noncanonical OWNER mirrors
- makes Pawthy HTTP 202 fail closed immediately until #130 owns bounded POST/polling cutover
- restores strict repository/fixture/build parity
- stages, reconciles, restores, and verifies populated legacy AuditLog/Project/Resource/TOTP rows through the supported deploy wrapper without editing published migrations

## Temporary availability tradeoff

Until the owning successor nodes deliver their final contracts:

- approval decisions mint no grant
- TOTP linking and delegation-consent creation return Forbidden
- delegated/non-owner TOTP reveal returns Forbidden
- unbound service credentials receive no object authority
- Pawthy does not poll a 202 response
- direct Resource Owner reveal and authorized unlink remain available

## Verification at `4f97868d315905ae4217153a1d680411a0952d1f`

- `pnpm prisma:generate`: pass
- `pnpm lint`: pass, 0 errors / 39 existing warnings
- `pnpm test`: pass — bot 196/196, Pawthy 184/184, ops 15/15
- `pnpm build`: pass
- focused authorization/release-gate tests: 33/33 pass
- Prettier and `git diff --check`: pass
- fresh and populated supported-wrapper migration rehearsals: pass
- published migration checksums: unchanged

Unmappable non-null legacy audit resolver/context data deliberately fails closed before mutation and leaves recovery data intact; #118 owns its final safe mapping.

## Remaining merge gate

- formal human security approval is required
- this issue remains open until clean-`master` post-merge verification

Refs #116
Refs #117
Refs #118
Refs #119
Refs #120
Refs #121
Refs #122
Refs #130